### PR TITLE
Fix directory name references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ A self-hosted web application for visualizing and managing Claude Code configura
 1. Clone the repository:
 ```bash
 git clone <repository-url>
-cd claude-control-registry
+cd claude-deck
 ```
 
 2. Run the install script:
@@ -143,7 +143,7 @@ Visit http://localhost:8000/docs for interactive API documentation.
 ## Project Structure
 
 ```
-claude-control-registry/
+claude-deck/
 ├── backend/
 │   ├── app/
 │   │   ├── api/v1/          # API endpoints


### PR DESCRIPTION
## Summary
- Update directory references from `claude-control-registry` to `claude-deck` in README.md
- Fixes installation instructions and project structure documentation to use the correct project name

## Test plan
- [x] Verified the changes are cosmetic documentation fixes
- [x] No code changes