### PR TITLE
docs: Add acknowledgments for adapted code

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,12 @@ The usage tracking feature parses JSONL files from `~/.claude/projects/` to prov
 - **Billing blocks**: 5-hour billing period tracking with active block detection
 - **Burn rate**: Real-time cost projections for active sessions
 
+## Acknowledgments
+
+The session transcript viewer feature was inspired by and includes code adapted from [claude-code-transcripts](https://github.com/simonw/claude-code-transcripts) by [Simon Willison](https://simonwillison.net/). Simon's project pioneered the approach for parsing and displaying Claude Code session JSONL files.
+
+The usage tracking feature ports algorithms from [ccusage](https://github.com/ryoppippi/ccusage) by [ryoppippi](https://github.com/ryoppippi), including the 5-hour session block identification, tiered pricing calculations, and burn rate projections.
+
 ## License
 
 MIT License

--- a/backend/app/services/pricing_service.py
+++ b/backend/app/services/pricing_service.py
@@ -1,6 +1,8 @@
 """Service for model pricing and cost calculation.
 
-Ports pricing logic from ccusage/LiteLLM for calculating token costs.
+Pricing logic adapted from ccusage by ryoppippi
+https://github.com/ryoppippi/ccusage
+Licensed under MIT
 """
 from typing import Optional
 

--- a/backend/app/services/session_service.py
+++ b/backend/app/services/session_service.py
@@ -1,4 +1,9 @@
-"""Service for managing Claude Code session transcripts."""
+"""Service for managing Claude Code session transcripts.
+
+Session parsing logic adapted from claude-code-transcripts by Simon Willison
+https://github.com/simonw/claude-code-transcripts
+Licensed under Apache 2.0
+"""
 import json
 import hashlib
 from pathlib import Path

--- a/backend/app/services/usage_service.py
+++ b/backend/app/services/usage_service.py
@@ -1,7 +1,8 @@
 """Service for usage data loading and aggregation.
 
-Ports usage tracking functionality from ccusage for analyzing Claude Code
-token usage and costs.
+Usage tracking algorithms adapted from ccusage by ryoppippi
+https://github.com/ryoppippi/ccusage
+Licensed under MIT
 """
 import hashlib
 import json


### PR DESCRIPTION
## Summary

This PR adds proper attribution for code that was adapted from external open source projects:

### claude-code-transcripts by Simon Willison
- **Repository**: https://github.com/simonw/claude-code-transcripts
- **License**: Apache 2.0
- **Adapted code**: Session transcript parsing logic in `session_service.py`
  - `extract_text_from_content` function
  - Summary extraction algorithm (two-pass: summary type first, then first user message)
  - JSONL parsing approach

### ccusage by ryoppippi
- **Repository**: https://github.com/ryoppippi/ccusage
- **License**: MIT
- **Adapted code**: Usage tracking algorithms in `usage_service.py` and `pricing_service.py`
  - 5-hour session block identification with gap detection
  - Tiered pricing calculations (200k token threshold)
  - Burn rate and usage projection calculations
  - `floorToHour` timestamp flooring

## Changes

- Added "Acknowledgments" section to README.md crediting both projects
- Added attribution comments with repository URLs to:
  - `backend/app/services/session_service.py`
  - `backend/app/services/usage_service.py`
  - `backend/app/services/pricing_service.py`

## Test plan

- [x] README renders correctly with new Acknowledgments section
- [x] Attribution comments don't affect code functionality (documentation only)