### PR TITLE
fix: Fix usage tracking project filtering and add frontend caching

### DIFF
--- a/backend/app/services/usage_service.py
+++ b/backend/app/services/usage_service.py
@@ -31,7 +31,7 @@ from app.models.schemas import (
     UsageSummaryResponse,
 )
 from app.services.pricing_service import PricingService
-from app.utils.path_utils import get_claude_projects_dir, get_project_display_name
+from app.utils.path_utils import get_claude_projects_dir, get_project_display_name, convert_path_to_folder_name
 
 
 @dataclass
@@ -161,8 +161,9 @@ class UsageService:
             return files
 
         if project_path:
-            # Scan specific project folder
-            project_folder = self.projects_dir / project_path
+            # Convert absolute path to Claude's hyphenated folder format
+            folder_name = convert_path_to_folder_name(project_path)
+            project_folder = self.projects_dir / folder_name
             if project_folder.exists():
                 files.extend(project_folder.glob("*.jsonl"))
         else:

--- a/backend/app/utils/path_utils.py
+++ b/backend/app/utils/path_utils.py
@@ -184,3 +184,11 @@ def get_project_display_name(folder_name: str) -> str:
         # Return the last part as the display name
         return parts[-1]
     return folder_name
+
+
+def convert_path_to_folder_name(absolute_path: str) -> str:
+    """Convert absolute path to Claude's hyphenated folder format.
+
+    Example: '/home/juan/projects/foo' -> '-home-juan-projects-foo'
+    """
+    return absolute_path.rstrip('/').replace('/', '-')

--- a/frontend/src/lib/usageCache.ts
+++ b/frontend/src/lib/usageCache.ts
@@ -1,0 +1,72 @@
+// Cache configuration
+const CACHE_KEY_PREFIX = 'usage_cache_'
+const CACHE_VERSION = 'v1'
+const CACHE_TTL_MS = 2 * 60 * 1000 // 2 minutes
+
+interface CacheEntry<T> {
+  data: T
+  timestamp: number
+  version: string
+}
+
+export function getCacheKey(projectPath: string | null): string {
+  return `${CACHE_KEY_PREFIX}${projectPath ?? 'all'}`
+}
+
+export function getFromCache<T>(projectPath: string | null): T | null {
+  const key = getCacheKey(projectPath)
+  const raw = localStorage.getItem(key)
+  if (!raw) return null
+
+  try {
+    const entry: CacheEntry<T> = JSON.parse(raw)
+    if (entry.version !== CACHE_VERSION) return null
+    return entry.data
+  } catch {
+    return null
+  }
+}
+
+export function isCacheStale(projectPath: string | null): boolean {
+  const key = getCacheKey(projectPath)
+  const raw = localStorage.getItem(key)
+  if (!raw) return true
+
+  try {
+    const entry = JSON.parse(raw)
+    return Date.now() - entry.timestamp > CACHE_TTL_MS
+  } catch {
+    return true
+  }
+}
+
+export function saveToCache<T>(projectPath: string | null, data: T): void {
+  const key = getCacheKey(projectPath)
+  const entry: CacheEntry<T> = {
+    data,
+    timestamp: Date.now(),
+    version: CACHE_VERSION
+  }
+  try {
+    localStorage.setItem(key, JSON.stringify(entry))
+  } catch {
+    // localStorage might be full - clear old caches and retry
+    invalidateCache()
+    try {
+      localStorage.setItem(key, JSON.stringify(entry))
+    } catch {
+      // If still fails, ignore silently
+    }
+  }
+}
+
+export function invalidateCache(projectPath?: string | null): void {
+  if (projectPath === undefined) {
+    // Clear all usage caches
+    Object.keys(localStorage)
+      .filter(k => k.startsWith(CACHE_KEY_PREFIX))
+      .forEach(k => localStorage.removeItem(k))
+  } else {
+    localStorage.removeItem(getCacheKey(projectPath))
+  }
+}


### PR DESCRIPTION
## Summary

- **Fix project filtering**: Resolved path format mismatch where frontend sends absolute paths but Claude stores data in hyphenated folder names
- **Add frontend caching**: Implemented localStorage-based stale-while-revalidate caching to reduce API calls and improve UX

## Changes

### Backend (Issue 1: Project Filtering)
- Added `convert_path_to_folder_name()` utility in `path_utils.py`
- Updated `usage_service.py` to convert absolute paths to Claude's hyphenated folder format before file discovery

### Frontend (Issue 2: Caching)
- Created `usageCache.ts` with localStorage cache utilities (2-minute TTL)
- Updated `UsagePage.tsx` with stale-while-revalidate pattern:
  - Instant load from cache (no loading spinner if cached)
  - Background refresh when cache is stale
  - Manual refresh invalidates cache

## Test plan

- [ ] Select a specific project from dropdown on Usage page - should show filtered data (not empty)
- [ ] Load Usage page, navigate away, return - data should appear instantly
- [ ] Click Refresh button - should force fetch fresh data
- [ ] Switch between "All Projects" and specific projects - cached data loads instantly