### PR TITLE
fix: Improve backup UI labels and scope validation

### DIFF
--- a/frontend/src/features/backup/BackupPage.tsx
+++ b/frontend/src/features/backup/BackupPage.tsx
@@ -47,7 +47,7 @@ export function BackupPage() {
 
   const handleCreate = async (backup: BackupCreate) => {
     try {
-      const endpoint = buildEndpoint("backup/create", { project_path: activeProject?.path });
+      const endpoint = buildEndpoint("backup/create");
       await apiClient<Backup>(endpoint, {
         method: "POST",
         body: JSON.stringify(backup),

--- a/frontend/src/features/backup/BackupWizard.tsx
+++ b/frontend/src/features/backup/BackupWizard.tsx
@@ -70,8 +70,8 @@ export function BackupWizard({
       case 0:
         return name.trim().length > 0;
       case 1:
-        // Project scope requires a project path
-        if (scope === "project" && !currentProjectPath) {
+        // Full and project scopes require a project path
+        if ((scope === "full" || scope === "project") && !currentProjectPath) {
           return false;
         }
         return true;
@@ -185,7 +185,7 @@ export function BackupWizard({
               onValueChange={(v) => setScope(v as BackupScope)}
             >
               {BACKUP_SCOPES.map((s) => {
-                const isDisabled = s.value === "project" && !currentProjectPath;
+                const isDisabled = (s.value === "full" || s.value === "project") && !currentProjectPath;
                 return (
                   <div
                     key={s.value}

--- a/frontend/src/features/projects/ProjectSwitcher.tsx
+++ b/frontend/src/features/projects/ProjectSwitcher.tsx
@@ -44,7 +44,7 @@ export function ProjectSwitcher() {
         onChange={(e) => handleChange(e.target.value)}
         className="w-full px-2 py-1 text-sm border rounded-md bg-background"
       >
-        <option value="">Global (User Scope)</option>
+        <option value="">User (All Projects)</option>
         {projects.map((project) => (
           <option key={project.id} value={project.id}>
             {project.name}

--- a/frontend/src/types/backup.ts
+++ b/frontend/src/types/backup.ts
@@ -72,17 +72,17 @@ export function formatDate(dateString: string): string {
 export const BACKUP_SCOPES = [
   {
     value: "full" as BackupScope,
-    label: "Full Backup",
-    description: "All user and project configurations",
+    label: "Complete",
+    description: "User and project configurations",
   },
   {
     value: "user" as BackupScope,
-    label: "User Only",
-    description: "User-level settings, commands, agents, and plugins",
+    label: "User",
+    description: "Settings in ~/.claude/",
   },
   {
     value: "project" as BackupScope,
-    label: "Project Only",
-    description: "Current project's .claude directory and config files",
+    label: "Project",
+    description: "Settings in .claude/",
   },
 ];


### PR DESCRIPTION
## Summary
- Fix backup wizard to require project path for "full" scope (since full backups include project configs)
- Simplify backup scope labels: "Complete", "User", "Project"
- Clarify descriptions to reference actual directories (`~/.claude/`, `.claude/`)
- Rename "Global (User Scope)" to "User (All Projects)" in project switcher for clarity
- Remove unnecessary `project_path` param from create endpoint call

## Test plan
- [ ] Create a backup with "Complete" scope - verify it requires an active project
- [ ] Create a backup with "User" scope - verify it works without a project
- [ ] Verify project switcher shows "User (All Projects)" when no project selected