### PR TITLE
feat: Presence Dashboard — Real-Time Multi-Session Monitoring

### DIFF
--- a/backend/app/api/v1/hooks.py
+++ b/backend/app/api/v1/hooks.py
@@ -63,10 +63,10 @@ async def create_hook(
         Created hook
     """
     # Validate hook type
-    if hook.type not in ["command", "prompt"]:
+    if hook.type not in ["command", "prompt", "agent", "http"]:
         raise HTTPException(
             status_code=400,
-            detail="Hook type must be 'command' or 'prompt'"
+            detail="Hook type must be 'command', 'prompt', 'agent', or 'http'"
         )
 
     # Validate scope
@@ -88,6 +88,18 @@ async def create_hook(
             status_code=400,
             detail="Prompt is required for prompt-type hooks"
         )
+
+    if hook.type == "http":
+        if not hook.url:
+            raise HTTPException(
+                status_code=400,
+                detail="URL is required for http-type hooks"
+            )
+        if hook.command or hook.prompt:
+            raise HTTPException(
+                status_code=400,
+                detail="HTTP hooks should not have command or prompt fields"
+            )
 
     try:
         service = HookService()
@@ -127,10 +139,10 @@ async def update_hook(
         )
 
     # Validate hook type if provided
-    if hook_update.type and hook_update.type not in ["command", "prompt"]:
+    if hook_update.type and hook_update.type not in ["command", "prompt", "agent", "http"]:
         raise HTTPException(
             status_code=400,
-            detail="Hook type must be 'command' or 'prompt'"
+            detail="Hook type must be 'command', 'prompt', 'agent', or 'http'"
         )
 
     try:

--- a/backend/app/api/v1/presence.py
+++ b/backend/app/api/v1/presence.py
@@ -1,0 +1,127 @@
+"""API endpoints for Presence Dashboard — webhook receiver, REST, and WebSocket."""
+import json
+
+from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.models.schemas import (
+    PresenceConfigSnippet,
+    PresenceEventIn,
+    PresenceSessionListResponse,
+    PresenceSessionResponse,
+    PresenceSessionUpdate,
+)
+from app.services.presence_service import PresenceService, manager
+
+router = APIRouter()
+service = PresenceService()
+
+
+@router.post("/events")
+async def receive_event(
+    payload: PresenceEventIn,
+    db: AsyncSession = Depends(get_db),
+):
+    """Webhook receiver for Claude Code HTTP hooks. Always returns {} with 200."""
+    updated_session = await service.process_event(payload.model_dump(), db)
+
+    # Broadcast to WebSocket clients
+    msg = json.dumps({"type": "session_update", "session": updated_session.model_dump()})
+    await manager.broadcast(msg)
+
+    return {}
+
+
+@router.get("/sessions", response_model=PresenceSessionListResponse)
+async def list_sessions(db: AsyncSession = Depends(get_db)):
+    """Return all presence sessions."""
+    sessions = await service.get_all_sessions(db)
+    active = sum(1 for s in sessions if s.status == "active")
+    error = sum(1 for s in sessions if s.status == "error")
+    return PresenceSessionListResponse(
+        sessions=sessions, total=len(sessions), active=active, error=error
+    )
+
+
+@router.patch("/sessions/{session_id}", response_model=PresenceSessionResponse)
+async def update_session_label(
+    session_id: str,
+    update: PresenceSessionUpdate,
+    db: AsyncSession = Depends(get_db),
+):
+    """Update a session's label."""
+    result = await service.update_label(session_id, update.label, db)
+    if not result:
+        from fastapi import HTTPException
+        raise HTTPException(status_code=404, detail="Session not found")
+    return result
+
+
+@router.delete("/sessions/{session_id}", status_code=204)
+async def remove_session(
+    session_id: str,
+    db: AsyncSession = Depends(get_db),
+):
+    """Remove a session from the dashboard."""
+    removed = await service.remove_session(session_id, db)
+    if not removed:
+        from fastapi import HTTPException
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    # Broadcast removal
+    msg = json.dumps({"type": "session_remove", "session_id": session_id})
+    await manager.broadcast(msg)
+    return None
+
+
+@router.delete("/sessions", status_code=204)
+async def clear_all_sessions(db: AsyncSession = Depends(get_db)):
+    """Clear all sessions from the dashboard."""
+    await service.clear_all_sessions(db)
+
+    msg = json.dumps({"type": "sessions_cleared"})
+    await manager.broadcast(msg)
+    return None
+
+
+@router.get("/config-snippet", response_model=PresenceConfigSnippet)
+async def get_config_snippet():
+    """Generate the settings.json snippet for hooking up Claude Code."""
+    url = "http://localhost:8000/api/v1/presence/events"
+    events = ["Notification", "PostToolUse", "Stop", "SessionStart", "SessionEnd"]
+    snippet = {
+        "hooks": {
+            event: [{"hooks": [{"type": "http", "url": url}]}]
+            for event in events
+        }
+    }
+    instructions = (
+        "Add this to your ~/.claude/settings.json (or merge into existing hooks). "
+        "Then restart any running Claude Code sessions for the hooks to take effect."
+    )
+    return PresenceConfigSnippet(snippet=snippet, instructions=instructions)
+
+
+@router.websocket("/ws")
+async def presence_websocket(
+    ws: WebSocket,
+    db: AsyncSession = Depends(get_db),
+):
+    """WebSocket for live presence updates. On connect, sends all current sessions."""
+    await manager.connect(ws)
+    try:
+        # Send initial state
+        sessions = await service.get_all_sessions(db)
+        for s in sessions:
+            await ws.send_text(
+                json.dumps({"type": "session_update", "session": s.model_dump()})
+            )
+
+        # Keep connection alive — wait for disconnection
+        while True:
+            await ws.receive_text()
+    except WebSocketDisconnect:
+        pass
+    finally:
+        manager.disconnect(ws)

--- a/backend/app/api/v1/presence.py
+++ b/backend/app/api/v1/presence.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
+from app.models.constants import SessionStatus
 from app.models.schemas import (
     PresenceConfigSnippet,
     PresenceEventIn,
@@ -37,8 +38,8 @@ async def receive_event(
 async def list_sessions(db: AsyncSession = Depends(get_db)):
     """Return all presence sessions."""
     sessions = await service.get_all_sessions(db)
-    active = sum(1 for s in sessions if s.status == "active")
-    error = sum(1 for s in sessions if s.status == "error")
+    active = sum(1 for s in sessions if s.status == SessionStatus.ACTIVE)
+    error = sum(1 for s in sessions if s.status == SessionStatus.ERROR)
     return PresenceSessionListResponse(
         sessions=sessions, total=len(sessions), active=active, error=error
     )
@@ -89,7 +90,11 @@ async def clear_all_sessions(db: AsyncSession = Depends(get_db)):
 async def get_config_snippet():
     """Generate the settings.json snippet for hooking up Claude Code."""
     url = "http://localhost:8000/api/v1/presence/events"
-    events = ["Notification", "PostToolUse", "Stop", "SessionStart", "SessionEnd"]
+    events = [
+        "Notification", "PreToolUse", "PostToolUse", "Stop",
+        "SessionStart", "SessionEnd", "UserPromptSubmit",
+        "SubagentStart", "SubagentStop",
+    ]
     snippet = {
         "hooks": {
             event: [{"hooks": [{"type": "http", "url": url}]}]

--- a/backend/app/api/v1/presence.py
+++ b/backend/app/api/v1/presence.py
@@ -25,7 +25,8 @@ async def receive_event(
     db: AsyncSession = Depends(get_db),
 ):
     """Webhook receiver for Claude Code HTTP hooks. Always returns {} with 200."""
-    updated_session = await service.process_event(payload.model_dump(), db)
+    dumped = payload.model_dump()
+    updated_session = await service.process_event(dumped, db)
 
     # Broadcast to WebSocket clients
     msg = json.dumps({"type": "session_update", "session": updated_session.model_dump()})

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -17,6 +17,7 @@ from .usage import router as usage_router
 from .memory import router as memory_router
 from .context import router as context_router
 from .plans import router as plans_router
+from .presence import router as presence_router
 from .cc_bridge.router import router as cc_bridge_router
 
 router = APIRouter()
@@ -51,4 +52,5 @@ router.include_router(usage_router, tags=["Usage"])
 router.include_router(memory_router, tags=["Memory"])
 router.include_router(context_router, tags=["Context"])
 router.include_router(plans_router, tags=["Plans"])
+router.include_router(presence_router, prefix="/presence", tags=["Presence"])
 router.include_router(cc_bridge_router, prefix="/cc-bridge", tags=["CC Bridge"])

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -19,6 +19,7 @@ from .context import router as context_router
 from .plans import router as plans_router
 from .presence import router as presence_router
 from .cc_bridge.router import router as cc_bridge_router
+from .status import router as status_router
 
 router = APIRouter()
 
@@ -54,3 +55,4 @@ router.include_router(context_router, tags=["Context"])
 router.include_router(plans_router, tags=["Plans"])
 router.include_router(presence_router, prefix="/presence", tags=["Presence"])
 router.include_router(cc_bridge_router, prefix="/cc-bridge", tags=["CC Bridge"])
+router.include_router(status_router, tags=["Status"])

--- a/backend/app/api/v1/status.py
+++ b/backend/app/api/v1/status.py
@@ -1,0 +1,73 @@
+"""System status endpoint for header indicators."""
+import asyncio
+import re
+import shutil
+import time
+from typing import Optional
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.models.schemas import SystemStatusResponse
+from app.services.presence_service import PresenceService
+
+router = APIRouter()
+
+# Cache CC version for 5 minutes
+_version_cache: tuple[Optional[str], float] = (None, 0.0)
+_version_lock = asyncio.Lock()
+_CACHE_TTL = 300  # seconds
+
+
+async def _get_claude_code_version() -> Optional[str]:
+    global _version_cache
+    cached_version, cached_at = _version_cache
+    if time.time() - cached_at < _CACHE_TTL:
+        return cached_version
+
+    async with _version_lock:
+        # Re-check after acquiring lock (another request may have refreshed)
+        cached_version, cached_at = _version_cache
+        if time.time() - cached_at < _CACHE_TTL:
+            return cached_version
+
+        claude_bin = await asyncio.to_thread(shutil.which, "claude")
+        if not claude_bin:
+            _version_cache = (None, time.time())
+            return None
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                claude_bin, "--version",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
+            match = re.search(r"(\d+\.\d+\.\d+)", stdout.decode())
+            version = match.group(1) if match else None
+        except (OSError, asyncio.TimeoutError):
+            version = None
+
+        _version_cache = (version, time.time())
+        return version
+
+
+async def _get_active_count(db: AsyncSession) -> int:
+    service = PresenceService()
+    sessions = await service.get_all_sessions(db)
+    return sum(1 for s in sessions if s.status == "active")
+
+
+@router.get("/status", response_model=SystemStatusResponse)
+async def get_system_status(db: AsyncSession = Depends(get_db)):
+    """Return system status for header indicators."""
+    version, active_count = await asyncio.gather(
+        _get_claude_code_version(),
+        _get_active_count(db),
+    )
+
+    return SystemStatusResponse(
+        claude_code_version=version,
+        active_sessions=active_count,
+    )

--- a/backend/app/api/v1/status.py
+++ b/backend/app/api/v1/status.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
+from app.models.constants import SessionStatus
 from app.models.schemas import SystemStatusResponse
 from app.services.presence_service import PresenceService
 
@@ -56,7 +57,7 @@ async def _get_claude_code_version() -> Optional[str]:
 async def _get_active_count(db: AsyncSession) -> int:
     service = PresenceService()
     sessions = await service.get_all_sessions(db)
-    return sum(1 for s in sessions if s.status == "active")
+    return sum(1 for s in sessions if s.status == SessionStatus.ACTIVE)
 
 
 @router.get("/status", response_model=SystemStatusResponse)

--- a/backend/app/models/constants.py
+++ b/backend/app/models/constants.py
@@ -1,0 +1,10 @@
+"""Shared constants for the application."""
+from enum import StrEnum
+
+
+class SessionStatus(StrEnum):
+    """Presence session status values."""
+    ACTIVE = "active"
+    IDLE = "idle"
+    ERROR = "error"
+    STOPPED = "stopped"

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -1,5 +1,5 @@
 """SQLAlchemy database models."""
-from datetime import datetime
+from datetime import datetime, timezone
 from sqlalchemy import String, Integer, Boolean, DateTime, ForeignKey, JSON, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -118,3 +118,52 @@ class MCPServerCache(Base):
     __table_args__ = (
         UniqueConstraint('server_name', 'server_scope', name='uix_server_name_scope'),
     )
+
+
+class PresenceEvent(Base):
+    """Raw event log from Claude Code HTTP hooks."""
+
+    __tablename__ = "presence_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    session_id: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    event_type: Mapped[str] = mapped_column(String, nullable=False)
+    tool_name: Mapped[str | None] = mapped_column(String, nullable=True)
+    tool_input: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    tool_result: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    message: Mapped[str | None] = mapped_column(String, nullable=True)
+    cwd: Mapped[str | None] = mapped_column(String, nullable=True)
+    timestamp: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+    received_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+
+
+class PresenceSession(Base):
+    """Aggregated per-session state for the Presence Dashboard."""
+
+    __tablename__ = "presence_sessions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    session_id: Mapped[str] = mapped_column(String, unique=True, index=True, nullable=False)
+    label: Mapped[str | None] = mapped_column(String, nullable=True)
+    project_path: Mapped[str | None] = mapped_column(String, nullable=True)
+    status: Mapped[str] = mapped_column(String, default="active", nullable=False)
+    last_narrative: Mapped[str | None] = mapped_column(String, nullable=True)
+    last_narrative_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    modified_files: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    last_command: Mapped[str | None] = mapped_column(String, nullable=True)
+    last_command_exit: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    activity_buckets: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    bucket_start: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    total_events: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    error_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+    last_event_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+    ended_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -4,6 +4,7 @@ from sqlalchemy import String, Integer, Boolean, DateTime, ForeignKey, JSON, Uni
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
+from app.models.constants import SessionStatus
 
 
 class Project(Base):
@@ -150,7 +151,8 @@ class PresenceSession(Base):
     session_id: Mapped[str] = mapped_column(String, unique=True, index=True, nullable=False)
     label: Mapped[str | None] = mapped_column(String, nullable=True)
     project_path: Mapped[str | None] = mapped_column(String, nullable=True)
-    status: Mapped[str] = mapped_column(String, default="active", nullable=False)
+    status: Mapped[str] = mapped_column(String, default=SessionStatus.ACTIVE, nullable=False)
+    status_text: Mapped[str | None] = mapped_column(String, nullable=True)
     last_narrative: Mapped[str | None] = mapped_column(String, nullable=True)
     last_narrative_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     modified_files: Mapped[list | None] = mapped_column(JSON, nullable=True)

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -169,3 +169,4 @@ class PresenceSession(Base):
         DateTime, default=lambda: datetime.now(timezone.utc), nullable=False
     )
     ended_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    last_user_prompt: Mapped[str | None] = mapped_column(String, nullable=True)

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1762,6 +1762,7 @@ class PresenceSessionResponse(BaseModel):
     label: Optional[str] = None
     project_path: Optional[str] = None
     status: str = "active"
+    status_text: Optional[str] = None
     last_narrative: Optional[str] = None
     last_narrative_at: Optional[str] = None
     modified_files: Optional[List[str]] = None

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1750,6 +1750,7 @@ class PresenceEventIn(BaseModel):
     tool_input: Optional[Dict[str, Any]] = None
     tool_result: Optional[Dict[str, Any]] = None
     message: Optional[str] = None
+    user_prompt: Optional[str] = None
     cwd: Optional[str] = None
     transcript_path: Optional[str] = None
     permission_mode: Optional[str] = None

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1795,3 +1795,10 @@ class PresenceConfigSnippet(BaseModel):
 
     snippet: Dict[str, Any]
     instructions: str
+
+
+class SystemStatusResponse(BaseModel):
+    """System status for header indicators."""
+
+    claude_code_version: Optional[str] = None
+    active_sessions: int = 0

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1,5 +1,5 @@
 """Pydantic schemas for API models."""
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 from pydantic import BaseModel
 
 
@@ -1765,7 +1765,8 @@ class PresenceSessionResponse(BaseModel):
     status_text: Optional[str] = None
     last_narrative: Optional[str] = None
     last_narrative_at: Optional[str] = None
-    modified_files: Optional[List[str]] = None
+    modified_files: Optional[List[Union[str, dict]]] = None
+    last_user_prompt: Optional[str] = None
     last_command: Optional[str] = None
     last_command_exit: Optional[int] = None
     activity_buckets: Optional[List[int]] = None

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -568,7 +568,7 @@ class Hook(BaseModel):
     id: str
     event: str  # PreToolUse, PostToolUse, PostToolUseFailure, Stop, SessionStart, SessionEnd, UserPromptSubmit, PermissionRequest, Notification, SubagentStart, SubagentStop, PreCompact
     matcher: Optional[str] = None  # Tool matcher pattern (e.g., "Write(*.py)")
-    type: str = "command"  # "command", "prompt", or "agent"
+    type: str = "command"  # "command", "prompt", "agent", or "http"
     command: Optional[str] = None  # Shell command to execute (for command type)
     prompt: Optional[str] = None  # Prompt to append (for prompt/agent type)
     model: Optional[str] = None  # Model to use (for agent type, e.g., "haiku")
@@ -576,6 +576,9 @@ class Hook(BaseModel):
     statusMessage: Optional[str] = None  # Custom spinner message
     once: Optional[bool] = None  # Run only once per session
     timeout: Optional[int] = None  # Timeout in seconds
+    url: Optional[str] = None  # URL for http-type hooks
+    headers: Optional[Dict[str, str]] = None  # Headers for http-type hooks
+    allowedEnvVars: Optional[List[str]] = None  # Env vars for http-type hooks
     scope: str  # "user" or "project"
 
     class Config:
@@ -588,7 +591,7 @@ class HookCreate(BaseModel):
 
     event: str
     matcher: Optional[str] = None
-    type: str = "command"  # "command", "prompt", or "agent"
+    type: str = "command"  # "command", "prompt", "agent", or "http"
     command: Optional[str] = None
     prompt: Optional[str] = None
     model: Optional[str] = None  # For agent hooks
@@ -596,6 +599,9 @@ class HookCreate(BaseModel):
     statusMessage: Optional[str] = None  # Custom spinner message
     once: Optional[bool] = None  # Run only once per session
     timeout: Optional[int] = None
+    url: Optional[str] = None  # URL for http-type hooks
+    headers: Optional[Dict[str, str]] = None  # Headers for http-type hooks
+    allowedEnvVars: Optional[List[str]] = None  # Env vars for http-type hooks
     scope: str  # "user" or "project"
 
 
@@ -612,6 +618,9 @@ class HookUpdate(BaseModel):
     statusMessage: Optional[str] = None
     once: Optional[bool] = None
     timeout: Optional[int] = None
+    url: Optional[str] = None
+    headers: Optional[Dict[str, str]] = None
+    allowedEnvVars: Optional[List[str]] = None
 
 
 class HookListResponse(BaseModel):
@@ -1727,3 +1736,62 @@ class MCPRegistryInstallResponse(BaseModel):
     server_name: str
     config: Dict[str, Any]
     scope: str
+
+
+# Presence Dashboard Schemas
+
+
+class PresenceEventIn(BaseModel):
+    """Incoming webhook payload from Claude Code HTTP hooks."""
+
+    session_id: str
+    hook_event_name: str
+    tool_name: Optional[str] = None
+    tool_input: Optional[Dict[str, Any]] = None
+    tool_result: Optional[Dict[str, Any]] = None
+    message: Optional[str] = None
+    cwd: Optional[str] = None
+    transcript_path: Optional[str] = None
+    permission_mode: Optional[str] = None
+
+
+class PresenceSessionResponse(BaseModel):
+    """Single session state for API/WebSocket."""
+
+    session_id: str
+    label: Optional[str] = None
+    project_path: Optional[str] = None
+    status: str = "active"
+    last_narrative: Optional[str] = None
+    last_narrative_at: Optional[str] = None
+    modified_files: Optional[List[str]] = None
+    last_command: Optional[str] = None
+    last_command_exit: Optional[int] = None
+    activity_buckets: Optional[List[int]] = None
+    total_events: int = 0
+    error_count: int = 0
+    started_at: str
+    last_event_at: str
+    ended_at: Optional[str] = None
+
+
+class PresenceSessionListResponse(BaseModel):
+    """List of presence sessions with totals."""
+
+    sessions: List[PresenceSessionResponse]
+    total: int = 0
+    active: int = 0
+    error: int = 0
+
+
+class PresenceSessionUpdate(BaseModel):
+    """Label update request."""
+
+    label: str
+
+
+class PresenceConfigSnippet(BaseModel):
+    """Generated setup snippet."""
+
+    snippet: Dict[str, Any]
+    instructions: str

--- a/backend/app/services/cc_bridge/discovery.py
+++ b/backend/app/services/cc_bridge/discovery.py
@@ -3,6 +3,8 @@ import logging
 import subprocess
 from pathlib import Path
 
+from app.models.constants import SessionStatus
+
 logger = logging.getLogger(__name__)
 
 _PANE_FORMAT = (
@@ -109,7 +111,7 @@ def discover_cc_sessions() -> list[dict]:
                 "pane_id": pane_id,
                 "cwd": cwd,
                 "pid": pid,
-                "status": "active",
+                "status": SessionStatus.ACTIVE,
             })
     return results
 

--- a/backend/app/services/cc_bridge/discovery.py
+++ b/backend/app/services/cc_bridge/discovery.py
@@ -1,6 +1,7 @@
 """Discover Claude Code sessions running in tmux."""
 import logging
 import subprocess
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -15,9 +16,64 @@ _PANE_FORMAT = (
 )
 
 
-def _is_claude_code(command: str) -> bool:
-    """Check if a tmux pane command looks like Claude Code."""
-    return command.strip().lower() == "claude"
+_MAX_TREE_DEPTH = 4
+
+
+def _has_claude_descendant(pid: str, *, _depth: int = 0, _visited: set | None = None) -> bool:
+    """Check if any descendant process of `pid` is the Claude Code binary.
+
+    This handles wrappers (e.g. node-based launchers) that spawn `claude`
+    as a child process. Uses pgrep to walk the descendant tree with depth
+    and cycle guards to prevent unbounded recursion.
+    """
+    if _depth > _MAX_TREE_DEPTH:
+        return False
+    if _visited is None:
+        _visited = set()
+    if pid in _visited:
+        return False
+    _visited.add(pid)
+
+    try:
+        result = subprocess.run(
+            ["pgrep", "-a", "-P", pid],
+            capture_output=True, text=True, timeout=5,
+        )
+        for line in result.stdout.strip().splitlines():
+            # pgrep -a output: "<pid> <cmdline>"
+            parts = line.split(None, 1)
+            if len(parts) < 2:
+                continue
+            child_pid, cmdline = parts
+            # Check if this process IS claude
+            argv0 = cmdline.split()[0] if cmdline else ""
+            if Path(argv0).name == "claude":
+                return True
+            # Recurse into this child's descendants
+            if _has_claude_descendant(child_pid, _depth=_depth + 1, _visited=_visited):
+                return True
+    except (subprocess.SubprocessError, OSError):
+        pass
+    return False
+
+
+def _is_claude_code(command: str, pid: str) -> bool:
+    """Check if a tmux pane is running Claude Code.
+
+    Matches when the pane command is 'claude' directly, or when
+    a node-based wrapper has spawned `claude` as a descendant process.
+    """
+    if command.strip().lower() == "claude":
+        return True
+
+    # When launched via a node wrapper (shebang), pane_current_command
+    # is 'node'. Walk the descendant tree for the real claude binary.
+    if command.strip().lower() == "node":
+        if not pid.isdigit():
+            return False
+        return _has_claude_descendant(pid)
+
+    return False
 
 
 def discover_cc_sessions() -> list[dict]:
@@ -45,7 +101,7 @@ def discover_cc_sessions() -> list[dict]:
         if len(parts) != 7:
             continue
         target, session_name, window_name, pane_id, cwd, pid, command = parts
-        if _is_claude_code(command):
+        if _is_claude_code(command, pid):
             results.append({
                 "tmux_target": target,
                 "session_name": session_name,

--- a/backend/app/services/hook_service.py
+++ b/backend/app/services/hook_service.py
@@ -33,6 +33,9 @@ class HookService:
             statusMessage=hook_data.get("statusMessage"),
             once=hook_data.get("once"),
             timeout=hook_data.get("timeout"),
+            url=hook_data.get("url"),
+            headers=hook_data.get("headers"),
+            allowedEnvVars=hook_data.get("allowedEnvVars"),
             scope=scope
         )
 
@@ -171,6 +174,12 @@ class HookService:
             hook_data["once"] = hook.once
         if hook.timeout:
             hook_data["timeout"] = hook.timeout
+        if hook.url:
+            hook_data["url"] = hook.url
+        if hook.headers:
+            hook_data["headers"] = hook.headers
+        if hook.allowedEnvVars:
+            hook_data["allowedEnvVars"] = hook.allowedEnvVars
 
         # Add hook to settings
         settings["hooks"][hook.event].append(hook_data)
@@ -191,6 +200,9 @@ class HookService:
             statusMessage=hook.statusMessage,
             once=hook.once,
             timeout=hook.timeout,
+            url=hook.url,
+            headers=hook.headers,
+            allowedEnvVars=hook.allowedEnvVars,
             scope=hook.scope
         )
 
@@ -271,6 +283,12 @@ class HookService:
                             hook_data["once"] = hook_update.once
                         if hook_update.timeout is not None:
                             hook_data["timeout"] = hook_update.timeout
+                        if hook_update.url is not None:
+                            hook_data["url"] = hook_update.url
+                        if hook_update.headers is not None:
+                            hook_data["headers"] = hook_update.headers
+                        if hook_update.allowedEnvVars is not None:
+                            hook_data["allowedEnvVars"] = hook_update.allowedEnvVars
 
                         updated_hook = Hook(
                             id=hook_id,
@@ -284,6 +302,9 @@ class HookService:
                             statusMessage=hook_data.get("statusMessage"),
                             once=hook_data.get("once"),
                             timeout=hook_data.get("timeout"),
+                            url=hook_data.get("url"),
+                            headers=hook_data.get("headers"),
+                            allowedEnvVars=hook_data.get("allowedEnvVars"),
                             scope=scope
                         )
                         break

--- a/backend/app/services/hook_service.py
+++ b/backend/app/services/hook_service.py
@@ -43,6 +43,37 @@ class HookService:
         """Validate that an event type is valid."""
         return event in VALID_HOOK_EVENTS
 
+    def _iter_hooks_from_settings(self, hooks_section: dict, scope: str):
+        """Yield Hook objects from a hooks section of settings.json.
+
+        Claude Code uses a nested format where each event maps to a list
+        of hook groups, each with an optional matcher and a ``hooks`` array::
+
+            "Notification": [{"matcher": "", "hooks": [{"type": "http", ...}]}]
+
+        For backwards compatibility, also handles flat format where each
+        event maps directly to a list of hook definitions::
+
+            "Notification": [{"type": "http", ...}]
+        """
+        for event, event_hooks in hooks_section.items():
+            if not isinstance(event_hooks, list):
+                continue
+            for entry in event_hooks:
+                if not isinstance(entry, dict):
+                    continue
+                if "hooks" in entry and isinstance(entry["hooks"], list):
+                    # Nested format: entry is a hook group
+                    group_matcher = entry.get("matcher", "")
+                    for hook_data in entry["hooks"]:
+                        if isinstance(hook_data, dict):
+                            if group_matcher and "matcher" not in hook_data:
+                                hook_data = {**hook_data, "matcher": group_matcher}
+                            yield self._parse_hook_from_data(hook_data, event, scope)
+                else:
+                    # Flat format: entry is a hook definition itself
+                    yield self._parse_hook_from_data(entry, event, scope)
+
     def list_hooks(self, project_path: Optional[str] = None) -> List[Hook]:
         """
         List all hooks from user and project settings files.
@@ -61,13 +92,9 @@ class HookService:
             try:
                 with open(user_settings_file, "r") as f:
                     user_settings = json.load(f)
-                    user_hooks = user_settings.get("hooks", {})
-
-                    # Hooks are organized by event type in settings.json
-                    for event, event_hooks in user_hooks.items():
-                        if isinstance(event_hooks, list):
-                            for hook_data in event_hooks:
-                                hooks.append(self._parse_hook_from_data(hook_data, event, "user"))
+                    hooks.extend(self._iter_hooks_from_settings(
+                        user_settings.get("hooks", {}), "user"
+                    ))
             except (json.JSONDecodeError, IOError):
                 pass
 
@@ -78,12 +105,9 @@ class HookService:
                 try:
                     with open(project_settings_file, "r") as f:
                         project_settings = json.load(f)
-                        project_hooks = project_settings.get("hooks", {})
-
-                        for event, event_hooks in project_hooks.items():
-                            if isinstance(event_hooks, list):
-                                for hook_data in event_hooks:
-                                    hooks.append(self._parse_hook_from_data(hook_data, event, "project"))
+                        hooks.extend(self._iter_hooks_from_settings(
+                            project_settings.get("hooks", {}), "project"
+                        ))
                 except (json.JSONDecodeError, IOError):
                     pass
 
@@ -181,8 +205,23 @@ class HookService:
         if hook.allowedEnvVars:
             hook_data["allowedEnvVars"] = hook.allowedEnvVars
 
-        # Add hook to settings
-        settings["hooks"][hook.event].append(hook_data)
+        # Add hook to settings using Claude Code's nested format
+        # Each event has a list of hook groups: [{"matcher": "", "hooks": [...]}]
+        event_groups = settings["hooks"][hook.event]
+        matcher = hook.matcher or ""
+
+        # Find an existing group with the same matcher, or create one
+        target_group = None
+        for group in event_groups:
+            if isinstance(group, dict) and "hooks" in group and group.get("matcher", "") == matcher:
+                target_group = group
+                break
+
+        if target_group is None:
+            target_group = {"matcher": matcher, "hooks": []}
+            event_groups.append(target_group)
+
+        target_group["hooks"].append(hook_data)
 
         # Write settings back
         with open(settings_file, "w") as f:
@@ -247,67 +286,64 @@ class HookService:
 
         hooks_section = settings.get("hooks", {})
 
-        # Find and update hook
+        # Find and update hook (handles both nested and flat formats)
         updated_hook = None
         for event, event_hooks in hooks_section.items():
-            if isinstance(event_hooks, list):
-                for i, hook_data in enumerate(event_hooks):
-                    if hook_data.get("id") == hook_id:
-                        # Update fields
-                        if hook_update.event:
-                            # Move to different event if needed
-                            if hook_update.event != event:
-                                # Remove from current event
-                                event_hooks.pop(i)
-                                # Add to new event
-                                if hook_update.event not in hooks_section:
-                                    hooks_section[hook_update.event] = []
-                                hooks_section[hook_update.event].append(hook_data)
-                                event = hook_update.event
+            if not isinstance(event_hooks, list):
+                continue
+            for gi, group in enumerate(event_hooks):
+                if not isinstance(group, dict):
+                    continue
+                is_nested = "hooks" in group and isinstance(group["hooks"], list)
+                inner_hooks = group["hooks"] if is_nested else [group]
 
-                        if hook_update.matcher is not None:
-                            hook_data["matcher"] = hook_update.matcher
-                        if hook_update.type is not None:
-                            hook_data["type"] = hook_update.type
-                        if hook_update.command is not None:
-                            hook_data["command"] = hook_update.command
-                        if hook_update.prompt is not None:
-                            hook_data["prompt"] = hook_update.prompt
-                        if hook_update.model is not None:
-                            hook_data["model"] = hook_update.model
-                        if hook_update.async_ is not None:
-                            hook_data["async"] = hook_update.async_
-                        if hook_update.statusMessage is not None:
-                            hook_data["statusMessage"] = hook_update.statusMessage
-                        if hook_update.once is not None:
-                            hook_data["once"] = hook_update.once
-                        if hook_update.timeout is not None:
-                            hook_data["timeout"] = hook_update.timeout
-                        if hook_update.url is not None:
-                            hook_data["url"] = hook_update.url
-                        if hook_update.headers is not None:
-                            hook_data["headers"] = hook_update.headers
-                        if hook_update.allowedEnvVars is not None:
-                            hook_data["allowedEnvVars"] = hook_update.allowedEnvVars
+                for i, hook_data in enumerate(inner_hooks):
+                    if hook_data.get("id") != hook_id:
+                        continue
 
-                        updated_hook = Hook(
-                            id=hook_id,
-                            event=event,
-                            matcher=hook_data.get("matcher"),
-                            type=hook_data.get("type", "command"),
-                            command=hook_data.get("command"),
-                            prompt=hook_data.get("prompt"),
-                            model=hook_data.get("model"),
-                            async_=hook_data.get("async"),
-                            statusMessage=hook_data.get("statusMessage"),
-                            once=hook_data.get("once"),
-                            timeout=hook_data.get("timeout"),
-                            url=hook_data.get("url"),
-                            headers=hook_data.get("headers"),
-                            allowedEnvVars=hook_data.get("allowedEnvVars"),
-                            scope=scope
+                    # Apply updates
+                    if hook_update.matcher is not None:
+                        hook_data["matcher"] = hook_update.matcher
+                    if hook_update.type is not None:
+                        hook_data["type"] = hook_update.type
+                    if hook_update.command is not None:
+                        hook_data["command"] = hook_update.command
+                    if hook_update.prompt is not None:
+                        hook_data["prompt"] = hook_update.prompt
+                    if hook_update.model is not None:
+                        hook_data["model"] = hook_update.model
+                    if hook_update.async_ is not None:
+                        hook_data["async"] = hook_update.async_
+                    if hook_update.statusMessage is not None:
+                        hook_data["statusMessage"] = hook_update.statusMessage
+                    if hook_update.once is not None:
+                        hook_data["once"] = hook_update.once
+                    if hook_update.timeout is not None:
+                        hook_data["timeout"] = hook_update.timeout
+                    if hook_update.url is not None:
+                        hook_data["url"] = hook_update.url
+                    if hook_update.headers is not None:
+                        hook_data["headers"] = hook_update.headers
+                    if hook_update.allowedEnvVars is not None:
+                        hook_data["allowedEnvVars"] = hook_update.allowedEnvVars
+
+                    # Handle event change
+                    if hook_update.event and hook_update.event != event:
+                        if is_nested:
+                            inner_hooks.pop(i)
+                            if not inner_hooks:
+                                event_hooks.pop(gi)
+                        else:
+                            event_hooks.pop(gi)
+                        if hook_update.event not in hooks_section:
+                            hooks_section[hook_update.event] = []
+                        hooks_section[hook_update.event].append(
+                            {"matcher": "", "hooks": [hook_data]}
                         )
-                        break
+                        event = hook_update.event
+
+                    updated_hook = self._parse_hook_from_data(hook_data, event, scope)
+                    break
             if updated_hook:
                 break
 
@@ -349,13 +385,28 @@ class HookService:
 
         hooks_section = settings.get("hooks", {})
 
-        # Find and remove hook
+        # Find and remove hook (handles both nested and flat formats)
         removed = False
         for event, event_hooks in hooks_section.items():
-            if isinstance(event_hooks, list):
-                for i, hook_data in enumerate(event_hooks):
-                    if hook_data.get("id") == hook_id:
-                        event_hooks.pop(i)
+            if not isinstance(event_hooks, list):
+                continue
+            for gi, group in enumerate(event_hooks):
+                if not isinstance(group, dict):
+                    continue
+                if "hooks" in group and isinstance(group["hooks"], list):
+                    # Nested format
+                    for i, hook_data in enumerate(group["hooks"]):
+                        if hook_data.get("id") == hook_id:
+                            group["hooks"].pop(i)
+                            # Remove empty group
+                            if not group["hooks"]:
+                                event_hooks.pop(gi)
+                            removed = True
+                            break
+                else:
+                    # Flat format
+                    if group.get("id") == hook_id:
+                        event_hooks.pop(gi)
                         removed = True
                         break
             if removed:

--- a/backend/app/services/mcp_service.py
+++ b/backend/app/services/mcp_service.py
@@ -164,14 +164,30 @@ class MCPService:
             # Try .mcp.json first (legacy format)
             plugin_mcp_path = install_path / ".mcp.json"
             plugin_mcp_config = read_json_file(plugin_mcp_path)
-            if plugin_mcp_config:
-                mcp_servers.update(plugin_mcp_config)
+            if plugin_mcp_config and isinstance(plugin_mcp_config, dict):
+                # .mcp.json may have {"mcpServers": {...}} or be a flat dict of servers
+                if "mcpServers" in plugin_mcp_config and isinstance(plugin_mcp_config["mcpServers"], dict):
+                    mcp_servers.update(plugin_mcp_config["mcpServers"])
+                else:
+                    mcp_servers.update(plugin_mcp_config)
 
             # Also check .claude-plugin/plugin.json for mcpServers
             plugin_json_path = install_path / ".claude-plugin" / "plugin.json"
             plugin_json = read_json_file(plugin_json_path)
             if plugin_json and "mcpServers" in plugin_json:
-                mcp_servers.update(plugin_json["mcpServers"])
+                mcp_servers_value = plugin_json["mcpServers"]
+                if isinstance(mcp_servers_value, dict):
+                    mcp_servers.update(mcp_servers_value)
+                elif isinstance(mcp_servers_value, str):
+                    # String is a relative path to another JSON file (e.g. "./.mcp.json")
+                    ref_path = (plugin_json_path.parent / mcp_servers_value).resolve()
+                    # Ensure the resolved path stays within the plugin install directory
+                    if not str(ref_path).startswith(str(install_path.resolve()) + "/"):
+                        continue
+                    ref_data = read_json_file(ref_path)
+                    if ref_data and isinstance(ref_data, dict):
+                        if "mcpServers" in ref_data and isinstance(ref_data["mcpServers"], dict):
+                            mcp_servers.update(ref_data["mcpServers"])
 
             if not mcp_servers:
                 continue

--- a/backend/app/services/presence_service.py
+++ b/backend/app/services/presence_service.py
@@ -1,5 +1,6 @@
 """Service for Presence Dashboard — event processing and session aggregation."""
 import os
+import re
 from datetime import datetime, timezone, timedelta
 from typing import List, Optional
 
@@ -90,7 +91,8 @@ class PresenceService:
         if cwd and not session.project_path:
             session.project_path = cwd
         if cwd and not session.label:
-            session.label = self._derive_label(cwd)
+            base_label = self._derive_label(cwd)
+            session.label = await self._assign_unique_label(base_label, session_id, db)
 
         # Update based on event type
         if event_type == "Notification":
@@ -241,6 +243,21 @@ class PresenceService:
     def _derive_label(self, cwd: str) -> str:
         return os.path.basename(cwd.rstrip("/"))
 
+    async def _assign_unique_label(self, base_label: str, session_id: str, db: AsyncSession) -> str:
+        """Append a short session_id suffix if another session already uses this label."""
+        result = await db.execute(
+            select(PresenceSession).where(
+                PresenceSession.label == base_label,
+                PresenceSession.session_id != session_id,
+            )
+        )
+        existing = result.scalars().all()
+        if existing:
+            for s in existing:
+                s.label = f"{base_label} ({s.session_id[:6]})"
+            return f"{base_label} ({session_id[:6]})"
+        return base_label
+
     def _extract_exit_code(self, tool_result: dict) -> Optional[int]:
         # tool_result may have various structures
         if not tool_result:
@@ -251,8 +268,6 @@ class PresenceService:
         # Check content string for exit code pattern
         content = tool_result.get("content", "")
         if isinstance(content, str) and "exit code" in content.lower():
-            # Try to parse "exit code N" from the string
-            import re
             match = re.search(r'exit code[:\s]+(\d+)', content, re.IGNORECASE)
             if match:
                 return int(match.group(1))

--- a/backend/app/services/presence_service.py
+++ b/backend/app/services/presence_service.py
@@ -132,7 +132,7 @@ class PresenceService:
                 if exit_code and exit_code != 0:
                     session.error_count = (session.error_count or 0) + 1
                     session.status = SessionStatus.ERROR
-                session.status_text = f"Ran: {cmd[:60]}" if cmd else "Ran command"
+                session.status_text = "Ran command"
             else:
                 session.status_text = f"Used tool: {tool_name}"
 

--- a/backend/app/services/presence_service.py
+++ b/backend/app/services/presence_service.py
@@ -101,7 +101,7 @@ class PresenceService:
             if msg:
                 session.last_narrative = msg
                 session.last_narrative_at = now
-                session.status_text = msg[:120]
+                session.status_text = msg.replace("\n", " ").strip()[:120]
 
         elif event_type == "PostToolUse":
             tool_name = payload.get("tool_name", "")
@@ -238,6 +238,7 @@ class PresenceService:
         )
         for session in result.scalars().all():
             session.status = SessionStatus.IDLE
+            session.status_text = None
 
     def _update_activity_buckets(self, session: PresenceSession, now: datetime):
         buckets = list(session.activity_buckets or [0] * BUCKET_COUNT)

--- a/backend/app/services/presence_service.py
+++ b/backend/app/services/presence_service.py
@@ -180,8 +180,8 @@ class PresenceService:
         session.last_event_at = now
         session.total_events = (session.total_events or 0) + 1
 
-        # Reactivate if we get an event for a stopped/idle session (except Stop/SessionEnd)
-        if event_type not in ("Stop", "SessionEnd") and session.status in (SessionStatus.IDLE, SessionStatus.STOPPED):
+        # Reactivate if we get an event for a stopped/idle session (except passive events)
+        if event_type not in ("Stop", "SessionEnd", "Notification", "SubagentStop") and session.status in (SessionStatus.IDLE, SessionStatus.STOPPED):
             session.status = SessionStatus.ACTIVE
             session.ended_at = None
 

--- a/backend/app/services/presence_service.py
+++ b/backend/app/services/presence_service.py
@@ -99,9 +99,12 @@ class PresenceService:
         if event_type == "Notification":
             msg = payload.get("message")
             if msg:
-                session.last_narrative = msg
-                session.last_narrative_at = now
-                session.status_text = msg.replace("\n", " ").strip()[:120]
+                # Skip generic "waiting" notifications — redundant with Stop event
+                waiting_phrases = ("waiting for your input", "waiting for input")
+                if not any(p in msg.lower() for p in waiting_phrases):
+                    session.last_narrative = msg
+                    session.last_narrative_at = now
+                    session.status_text = msg.replace("\n", " ").strip()[:120]
 
         elif event_type == "PostToolUse":
             tool_name = payload.get("tool_name", "")

--- a/backend/app/services/presence_service.py
+++ b/backend/app/services/presence_service.py
@@ -2,7 +2,7 @@
 import os
 import re
 from datetime import datetime, timezone, timedelta
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from fastapi import WebSocket
 from sqlalchemy import select
@@ -111,10 +111,11 @@ class PresenceService:
             if tool_name in FILE_EDIT_TOOLS:
                 file_path = tool_input.get("file_path") or tool_input.get("path")
                 if file_path:
+                    # Write can also overwrite existing files, but we label it "created" for simplicity
+                    op = "created" if tool_name == "Write" else "modified"
                     files = list(session.modified_files or [])
-                    if file_path in files:
-                        files.remove(file_path)
-                    files.append(file_path)
+                    files = [f for f in files if self._get_file_path(f) != file_path]
+                    files.append({"path": file_path, "op": op})
                     session.modified_files = files[-10:]
                     basename = os.path.basename(file_path)
                     session.status_text = f"Edited {basename}"
@@ -137,6 +138,9 @@ class PresenceService:
             session.status_text = f"Running tool: {tool_name}..."
 
         elif event_type == "UserPromptSubmit":
+            msg = payload.get("message")
+            if msg:
+                session.last_user_prompt = msg.strip()[:500]
             session.status_text = "Processing user message..."
 
         elif event_type == "SubagentStart":
@@ -162,6 +166,7 @@ class PresenceService:
             session.error_count = 0
             session.modified_files = []
             session.last_narrative = None
+            session.last_user_prompt = None
             session.last_command = None
             session.last_command_exit = None
             session.activity_buckets = [0] * BUCKET_COUNT
@@ -284,6 +289,12 @@ class PresenceService:
             return f"{base_label} ({session_id[:6]})"
         return base_label
 
+    def _get_file_path(self, entry: Union[str, dict]) -> str:
+        """Extract path from either a string (legacy) or dict (new format)."""
+        if isinstance(entry, str):
+            return entry
+        return entry.get("path", "")
+
     def _extract_exit_code(self, tool_result: dict) -> Optional[int]:
         # tool_result may have various structures
         if not tool_result:
@@ -312,6 +323,7 @@ class PresenceService:
             last_narrative=session.last_narrative,
             last_narrative_at=session.last_narrative_at.isoformat() if session.last_narrative_at else None,
             modified_files=session.modified_files,
+            last_user_prompt=session.last_user_prompt,
             last_command=session.last_command,
             last_command_exit=session.last_command_exit,
             activity_buckets=session.activity_buckets,

--- a/backend/app/services/presence_service.py
+++ b/backend/app/services/presence_service.py
@@ -138,7 +138,7 @@ class PresenceService:
             session.status_text = f"Running tool: {tool_name}..."
 
         elif event_type == "UserPromptSubmit":
-            msg = payload.get("message")
+            msg = payload.get("user_prompt") or payload.get("message")
             if msg:
                 session.last_user_prompt = msg.strip()[:500]
             session.status_text = "Processing user message..."

--- a/backend/app/services/presence_service.py
+++ b/backend/app/services/presence_service.py
@@ -1,0 +1,281 @@
+"""Service for Presence Dashboard — event processing and session aggregation."""
+import os
+from datetime import datetime, timezone, timedelta
+from typing import List, Optional
+
+from fastapi import WebSocket
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.database import PresenceEvent, PresenceSession
+from app.models.schemas import PresenceSessionResponse
+
+
+class ConnectionManager:
+    """Manages WebSocket connections for live presence updates."""
+
+    def __init__(self):
+        self.active_connections: list[WebSocket] = []
+
+    async def connect(self, ws: WebSocket):
+        await ws.accept()
+        self.active_connections.append(ws)
+
+    def disconnect(self, ws: WebSocket):
+        if ws in self.active_connections:
+            self.active_connections.remove(ws)
+
+    async def broadcast(self, message: str):
+        disconnected = []
+        for ws in self.active_connections:
+            try:
+                await ws.send_text(message)
+            except Exception:
+                disconnected.append(ws)
+        for ws in disconnected:
+            self.disconnect(ws)
+
+
+manager = ConnectionManager()
+
+IDLE_TIMEOUT_MINUTES = 5
+BUCKET_COUNT = 30
+FILE_EDIT_TOOLS = {"Write", "Edit", "MultiEdit"}
+
+
+class PresenceService:
+    """Processes webhook events and maintains aggregated session state."""
+
+    async def process_event(self, payload: dict, db: AsyncSession) -> PresenceSessionResponse:
+        now = datetime.now(timezone.utc)
+        session_id = payload["session_id"]
+        event_type = payload.get("hook_event_name", "Unknown")
+
+        # Store raw event
+        raw_event = PresenceEvent(
+            session_id=session_id,
+            event_type=event_type,
+            tool_name=payload.get("tool_name"),
+            tool_input=payload.get("tool_input"),
+            tool_result=payload.get("tool_result"),
+            message=payload.get("message"),
+            cwd=payload.get("cwd"),
+            timestamp=now,
+            received_at=now,
+        )
+        db.add(raw_event)
+
+        # Upsert presence session
+        result = await db.execute(
+            select(PresenceSession).where(PresenceSession.session_id == session_id)
+        )
+        session = result.scalar_one_or_none()
+
+        if session is None:
+            session = PresenceSession(
+                session_id=session_id,
+                status="active",
+                started_at=now,
+                last_event_at=now,
+                total_events=0,
+                error_count=0,
+                activity_buckets=[0] * BUCKET_COUNT,
+                bucket_start=now,
+                modified_files=[],
+            )
+            db.add(session)
+
+        # Derive project_path / label from cwd
+        cwd = payload.get("cwd")
+        if cwd and not session.project_path:
+            session.project_path = cwd
+        if cwd and not session.label:
+            session.label = self._derive_label(cwd)
+
+        # Update based on event type
+        if event_type == "Notification":
+            msg = payload.get("message")
+            if msg:
+                session.last_narrative = msg
+                session.last_narrative_at = now
+
+        elif event_type == "PostToolUse":
+            tool_name = payload.get("tool_name", "")
+            tool_input = payload.get("tool_input") or {}
+            tool_result = payload.get("tool_result") or {}
+
+            if tool_name in FILE_EDIT_TOOLS:
+                file_path = tool_input.get("file_path") or tool_input.get("path")
+                if file_path:
+                    files = list(session.modified_files or [])
+                    if file_path in files:
+                        files.remove(file_path)
+                    files.append(file_path)
+                    session.modified_files = files[-10:]
+
+            if tool_name == "Bash":
+                cmd = tool_input.get("command", "")
+                session.last_command = cmd[:500] if cmd else None
+                # Extract exit code from tool_result
+                exit_code = self._extract_exit_code(tool_result)
+                session.last_command_exit = exit_code
+                if exit_code and exit_code != 0:
+                    session.error_count = (session.error_count or 0) + 1
+                    session.status = "error"
+
+        elif event_type in ("Stop", "SessionEnd"):
+            session.status = "stopped"
+            session.ended_at = now
+
+        elif event_type == "SessionStart":
+            # Reset session if restarted
+            session.status = "active"
+            session.ended_at = None
+            session.started_at = now
+            session.total_events = 0
+            session.error_count = 0
+            session.modified_files = []
+            session.last_narrative = None
+            session.last_command = None
+            session.last_command_exit = None
+            session.activity_buckets = [0] * BUCKET_COUNT
+            session.bucket_start = now
+
+        # Common updates for all events
+        session.last_event_at = now
+        session.total_events = (session.total_events or 0) + 1
+
+        # Reactivate if we get an event for a stopped/idle session (except Stop/SessionEnd)
+        if event_type not in ("Stop", "SessionEnd") and session.status in ("idle", "stopped"):
+            session.status = "active"
+            session.ended_at = None
+
+        # Update activity buckets
+        self._update_activity_buckets(session, now)
+
+        await db.flush()
+
+        # Mark idle sessions while we're here
+        await self._mark_idle_sessions(db, now)
+
+        return self._to_response(session)
+
+    async def get_all_sessions(self, db: AsyncSession) -> List[PresenceSessionResponse]:
+        now = datetime.now(timezone.utc)
+        await self._mark_idle_sessions(db, now)
+
+        result = await db.execute(
+            select(PresenceSession).order_by(PresenceSession.last_event_at.desc())
+        )
+        sessions = result.scalars().all()
+        return [self._to_response(s) for s in sessions]
+
+    async def update_label(self, session_id: str, label: str, db: AsyncSession) -> Optional[PresenceSessionResponse]:
+        result = await db.execute(
+            select(PresenceSession).where(PresenceSession.session_id == session_id)
+        )
+        session = result.scalar_one_or_none()
+        if not session:
+            return None
+        session.label = label
+        await db.flush()
+        return self._to_response(session)
+
+    async def remove_session(self, session_id: str, db: AsyncSession) -> bool:
+        result = await db.execute(
+            select(PresenceSession).where(PresenceSession.session_id == session_id)
+        )
+        session = result.scalar_one_or_none()
+        if not session:
+            return False
+        await db.delete(session)
+        await db.flush()
+        return True
+
+    async def clear_all_sessions(self, db: AsyncSession) -> int:
+        result = await db.execute(select(PresenceSession))
+        sessions = result.scalars().all()
+        count = len(sessions)
+        for s in sessions:
+            await db.delete(s)
+        await db.flush()
+        return count
+
+    async def _mark_idle_sessions(self, db: AsyncSession, now: datetime):
+        cutoff = now - timedelta(minutes=IDLE_TIMEOUT_MINUTES)
+        result = await db.execute(
+            select(PresenceSession).where(
+                PresenceSession.status == "active",
+                PresenceSession.last_event_at < cutoff,
+            )
+        )
+        for session in result.scalars().all():
+            session.status = "idle"
+
+    def _update_activity_buckets(self, session: PresenceSession, now: datetime):
+        buckets = list(session.activity_buckets or [0] * BUCKET_COUNT)
+        bucket_start = session.bucket_start
+
+        if not bucket_start:
+            session.bucket_start = now
+            session.activity_buckets = [0] * (BUCKET_COUNT - 1) + [1]
+            return
+
+        # Make bucket_start timezone-aware if it isn't
+        if bucket_start.tzinfo is None:
+            bucket_start = bucket_start.replace(tzinfo=timezone.utc)
+
+        offset = int((now - bucket_start).total_seconds() / 60)
+
+        if offset >= BUCKET_COUNT:
+            shift = offset - BUCKET_COUNT + 1
+            buckets = buckets[shift:] + [0] * shift
+            session.bucket_start = bucket_start + timedelta(minutes=shift)
+            offset = BUCKET_COUNT - 1
+
+        if 0 <= offset < len(buckets):
+            buckets[offset] = buckets[offset] + 1
+
+        session.activity_buckets = buckets
+
+    def _derive_label(self, cwd: str) -> str:
+        return os.path.basename(cwd.rstrip("/"))
+
+    def _extract_exit_code(self, tool_result: dict) -> Optional[int]:
+        # tool_result may have various structures
+        if not tool_result:
+            return None
+        # Check direct exit_code field
+        if "exit_code" in tool_result:
+            return tool_result["exit_code"]
+        # Check content string for exit code pattern
+        content = tool_result.get("content", "")
+        if isinstance(content, str) and "exit code" in content.lower():
+            # Try to parse "exit code N" from the string
+            import re
+            match = re.search(r'exit code[:\s]+(\d+)', content, re.IGNORECASE)
+            if match:
+                return int(match.group(1))
+        # Check for stderr / error indicators
+        if tool_result.get("is_error"):
+            return 1
+        return 0
+
+    def _to_response(self, session: PresenceSession) -> PresenceSessionResponse:
+        return PresenceSessionResponse(
+            session_id=session.session_id,
+            label=session.label,
+            project_path=session.project_path,
+            status=session.status,
+            last_narrative=session.last_narrative,
+            last_narrative_at=session.last_narrative_at.isoformat() if session.last_narrative_at else None,
+            modified_files=session.modified_files,
+            last_command=session.last_command,
+            last_command_exit=session.last_command_exit,
+            activity_buckets=session.activity_buckets,
+            total_events=session.total_events or 0,
+            error_count=session.error_count or 0,
+            started_at=session.started_at.isoformat() if session.started_at else datetime.now(timezone.utc).isoformat(),
+            last_event_at=session.last_event_at.isoformat() if session.last_event_at else datetime.now(timezone.utc).isoformat(),
+            ended_at=session.ended_at.isoformat() if session.ended_at else None,
+        )

--- a/backend/app/services/presence_service.py
+++ b/backend/app/services/presence_service.py
@@ -8,6 +8,7 @@ from fastapi import WebSocket
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.constants import SessionStatus
 from app.models.database import PresenceEvent, PresenceSession
 from app.models.schemas import PresenceSessionResponse
 
@@ -39,7 +40,7 @@ class ConnectionManager:
 
 manager = ConnectionManager()
 
-IDLE_TIMEOUT_MINUTES = 5
+IDLE_TIMEOUT_MINUTES = 15
 BUCKET_COUNT = 30
 FILE_EDIT_TOOLS = {"Write", "Edit", "MultiEdit"}
 
@@ -75,7 +76,7 @@ class PresenceService:
         if session is None:
             session = PresenceSession(
                 session_id=session_id,
-                status="active",
+                status=SessionStatus.ACTIVE,
                 started_at=now,
                 last_event_at=now,
                 total_events=0,
@@ -100,6 +101,7 @@ class PresenceService:
             if msg:
                 session.last_narrative = msg
                 session.last_narrative_at = now
+                session.status_text = msg[:120]
 
         elif event_type == "PostToolUse":
             tool_name = payload.get("tool_name", "")
@@ -114,24 +116,46 @@ class PresenceService:
                         files.remove(file_path)
                     files.append(file_path)
                     session.modified_files = files[-10:]
-
-            if tool_name == "Bash":
+                    basename = os.path.basename(file_path)
+                    session.status_text = f"Edited {basename}"
+                else:
+                    session.status_text = f"Used tool: {tool_name}"
+            elif tool_name == "Bash":
                 cmd = tool_input.get("command", "")
                 session.last_command = cmd[:500] if cmd else None
-                # Extract exit code from tool_result
                 exit_code = self._extract_exit_code(tool_result)
                 session.last_command_exit = exit_code
                 if exit_code and exit_code != 0:
                     session.error_count = (session.error_count or 0) + 1
-                    session.status = "error"
+                    session.status = SessionStatus.ERROR
+                session.status_text = f"Ran: {cmd[:60]}" if cmd else "Ran command"
+            else:
+                session.status_text = f"Used tool: {tool_name}"
 
-        elif event_type in ("Stop", "SessionEnd"):
-            session.status = "stopped"
+        elif event_type == "PreToolUse":
+            tool_name = payload.get("tool_name", "unknown")
+            session.status_text = f"Running tool: {tool_name}..."
+
+        elif event_type == "UserPromptSubmit":
+            session.status_text = "Processing user message..."
+
+        elif event_type == "SubagentStart":
+            session.status_text = "Started subagent"
+
+        elif event_type == "SubagentStop":
+            session.status_text = "Subagent completed"
+
+        elif event_type == "Stop":
+            session.status = SessionStatus.STOPPED
+            session.status_text = "Waiting for input"
+
+        elif event_type == "SessionEnd":
+            session.status = SessionStatus.STOPPED
             session.ended_at = now
+            session.status_text = "Session ended"
 
         elif event_type == "SessionStart":
-            # Reset session if restarted
-            session.status = "active"
+            session.status = SessionStatus.ACTIVE
             session.ended_at = None
             session.started_at = now
             session.total_events = 0
@@ -142,14 +166,15 @@ class PresenceService:
             session.last_command_exit = None
             session.activity_buckets = [0] * BUCKET_COUNT
             session.bucket_start = now
+            session.status_text = "Session started"
 
         # Common updates for all events
         session.last_event_at = now
         session.total_events = (session.total_events or 0) + 1
 
         # Reactivate if we get an event for a stopped/idle session (except Stop/SessionEnd)
-        if event_type not in ("Stop", "SessionEnd") and session.status in ("idle", "stopped"):
-            session.status = "active"
+        if event_type not in ("Stop", "SessionEnd") and session.status in (SessionStatus.IDLE, SessionStatus.STOPPED):
+            session.status = SessionStatus.ACTIVE
             session.ended_at = None
 
         # Update activity buckets
@@ -207,12 +232,12 @@ class PresenceService:
         cutoff = now - timedelta(minutes=IDLE_TIMEOUT_MINUTES)
         result = await db.execute(
             select(PresenceSession).where(
-                PresenceSession.status == "active",
+                PresenceSession.status == SessionStatus.ACTIVE,
                 PresenceSession.last_event_at < cutoff,
             )
         )
         for session in result.scalars().all():
-            session.status = "idle"
+            session.status = SessionStatus.IDLE
 
     def _update_activity_buckets(self, session: PresenceSession, now: datetime):
         buckets = list(session.activity_buckets or [0] * BUCKET_COUNT)
@@ -282,6 +307,7 @@ class PresenceService:
             label=session.label,
             project_path=session.project_path,
             status=session.status,
+            status_text=session.status_text,
             last_narrative=session.last_narrative,
             last_narrative_at=session.last_narrative_at.isoformat() if session.last_narrative_at else None,
             modified_files=session.modified_files,

--- a/backend/app/services/session_service.py
+++ b/backend/app/services/session_service.py
@@ -48,7 +48,6 @@ class SessionService:
         result = await self.db.execute(
             select(SessionCache).where(
                 SessionCache.session_id == session_id,
-                SessionCache.project_folder == project_folder
             )
         )
         cache_entry = result.scalar_one_or_none()
@@ -87,16 +86,17 @@ class SessionService:
 
         file_hash = await self.get_file_hash(filepath)
 
-        # Upsert cache entry
+        # Upsert cache entry (session_id has a unique constraint)
         result = await self.db.execute(
             select(SessionCache).where(
                 SessionCache.session_id == summary.id,
-                SessionCache.project_folder == summary.project_folder
             )
         )
         cache_entry = result.scalar_one_or_none()
 
         if cache_entry:
+            cache_entry.project_folder = summary.project_folder
+            cache_entry.project_name = summary.project_name
             cache_entry.summary = summary.summary
             cache_entry.modified_at = datetime.fromisoformat(summary.modified_at)
             cache_entry.size_bytes = summary.size_bytes

--- a/docs/plans/2026-03-06-agent-orchestration-design.md
+++ b/docs/plans/2026-03-06-agent-orchestration-design.md
@@ -1,0 +1,306 @@
+# Agent Orchestration Platform — Design Document
+
+**Date:** 2026-03-06  
+**Status:** Proposal  
+**Author:** Galactus (OpenClaw AI)
+
+---
+
+## Overview
+
+Claude Deck today is a monitoring dashboard for Claude Code sessions. This document proposes evolving it into a **full agent orchestration platform** — a system where OpenClaw (Galactus) can spawn, steer, and monitor fleets of Claude Code agents working in parallel on large tasks, with Claude Deck as the mission control surface.
+
+The killer feature: **Deck becomes the nervous system connecting OpenClaw and CC instances**, enabling end-to-end execution of large tasks (PRDs, migrations, feature buildouts) that would be too large for a single agent context.
+
+---
+
+## Problem Statement
+
+Large engineering tasks exceed what a single Claude Code session can do reliably:
+- Context limits prevent holding the full codebase + task in one session
+- Sequential execution is slow — many subtasks are parallelisable
+- No visibility into what agents are doing across sessions
+- No mechanism for an orchestrating agent to steer individual workers mid-task
+- No way to recover gracefully when one agent gets stuck or goes wrong
+
+---
+
+## Architecture
+
+### Three-layer model
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  CONTROL PLANE                       │
+│   OpenClaw (Galactus) + ACP sessions                 │
+│   Orchestrates agents, holds the plan, makes         │
+│   decisions, steers workers                          │
+└────────────────────┬────────────────────────────────┘
+                     │ sessions_send / completion events
+┌────────────────────▼────────────────────────────────┐
+│                  SURFACE LAYER                       │
+│   Claude Deck (backend + frontend)                   │
+│   Visualises state, relays events, exposes           │
+│   steer controls, shows telemetry                    │
+└────────┬───────────────────────────┬────────────────┘
+         │ CC HTTP hooks             │ ACP events
+┌────────▼──────────┐    ┌──────────▼────────────────┐
+│   DATA PLANE      │    │   CONTROL PLANE WORKERS    │
+│   CC instances    │    │   ACP sub-agents           │
+│   (tool calls,    │    │   (each drives one CC      │
+│   file edits,     │    │   instance, reports back   │
+│   completions)    │    │   to Galactus)             │
+└───────────────────┘    └───────────────────────────┘
+```
+
+### Component roles
+
+| Component | Role |
+|-----------|------|
+| **Galactus (OpenClaw)** | Orchestrator. Breaks down tasks, spawns ACP sub-agents, makes steering decisions, synthesises outputs |
+| **ACP sub-agents** | Worker agents. Each owns one subtask, drives a CC instance, reports completion back to Galactus |
+| **CC instances** | Executors. Do the actual code work — edit files, run tests, commit |
+| **CC HTTP hooks** | Telemetry. Fire events on every meaningful action (tool call, file edit, session end) |
+| **Deck backend** | Relay + store. Receives CC hooks, persists them, forwards to OpenClaw Gateway, manages WebSocket connections |
+| **OpenClaw Gateway** | Message bus. Routes events from Deck to Galactus, routes Galactus replies to Deck |
+| **Deck frontend** | Mission control. Shows agent fleet, plan tree, telemetry stream, steer controls |
+
+---
+
+## Workflow: Large Task Execution
+
+### Phase 1 — Inception
+
+1. User describes the goal to Galactus (TUI or Slack): *"Build the billing module — stripe integration, webhook handling, subscription management, usage metering"*
+2. Galactus produces a **task breakdown**:
+   - Phases (sequential gates)
+   - Subtasks within each phase (parallelisable)
+   - Dependencies between subtasks
+   - Acceptance criteria per subtask
+   - Estimated token budget per agent
+3. Galactus writes `PLAN.md` to the repo root — the shared source of truth
+4. Deck displays the plan tree in a new **Orchestration view**
+
+### Phase 2 — Dispatch
+
+1. Galactus calls `sessions_spawn(runtime="acp")` for each ready subtask
+2. Each ACP sub-agent receives:
+   - Its slice of `PLAN.md`
+   - A `TASK.md` with specific instructions, scope boundaries, and acceptance criteria
+   - The repo path and branch to work on
+3. Each sub-agent spawns or attaches to a CC instance in its working directory
+4. Sub-agents register their session IDs with Deck so events can be correlated
+
+### Phase 3 — Execution + Monitoring
+
+CC instances work autonomously, firing HTTP hooks to Deck on every action:
+
+```
+POST /api/hooks/inbound
+{
+  "session_id": "abc123",
+  "event": "tool_call",
+  "tool": "write_file",
+  "path": "src/billing/stripe.ts",
+  "timestamp": "..."
+}
+```
+
+Deck:
+- Persists each event to its DB
+- Updates the frontend via WebSocket (live feed)
+- Forwards significant events to OpenClaw Gateway for Galactus awareness
+
+Galactus monitors the fleet passively, intervening when:
+- An agent signals it needs a decision (`event: "waiting_for_input"`)
+- An agent has been idle too long (timeout heuristic)
+- A completion event arrives (subtask done → check acceptance criteria)
+- A blocking error is detected
+
+### Phase 4 — Steering
+
+When Galactus decides to steer an agent:
+
+```
+Galactus
+  → sessions_send(subAgentSessionKey, "The schema changed, use UUID not int for IDs")
+  → ACP sub-agent receives the message
+  → Sub-agent injects the instruction into its CC session
+  → CC continues with updated context
+```
+
+From Deck, the user can also steer directly:
+- Click an agent card → open steer panel → type instruction → routes via OpenClaw Gateway → ACP sub-agent → CC
+
+### Phase 5 — Completion + Synthesis
+
+1. Each sub-agent fires a completion event when its CC session finishes
+2. ACP push notification reaches Galactus
+3. Galactus reviews the output (reads changed files, checks acceptance criteria)
+4. If accepted: marks subtask done in `PLAN.md`, unlocks dependent subtasks, dispatches next phase
+5. If rejected: re-steers the agent or spawns a new one with a corrected brief
+6. Final phase: Galactus runs a synthesis pass — resolves any conflicts between parallel agents, writes a summary PR, updates docs
+
+---
+
+## New Deck Components
+
+### 1. Orchestration View (new page)
+
+The top-level view for multi-agent tasks.
+
+**Plan tree panel:**
+- Hierarchical view: Task → Phases → Subtasks → Agent
+- Node states: `pending` / `running` / `blocked` / `done` / `failed`
+- Dependency arrows between subtasks
+- Click a node → focus that agent's detail view
+
+**Fleet summary bar:**
+- N agents running / M done / K blocked
+- Total token burn + burn rate
+- Estimated completion (based on per-agent progress)
+
+### 2. Agent Detail Card (enhanced Presence card)
+
+Per-agent panel showing:
+- Current status and last action
+- Live event stream (last N hook events)
+- Files modified (linked, browsable)
+- Token usage + cost
+- Time elapsed
+- **Steer input** — type a message, hit send, routes to that agent
+
+### 3. Event Stream (new panel)
+
+Live feed of all hook events across all agents, similar to a log tail:
+```
+[09:42:11] agent-stripe  write_file  src/billing/stripe.ts
+[09:42:13] agent-webhooks run_command  npm test -- billing
+[09:42:18] agent-stripe  waiting_for_input  "Should I use idempotency keys?"
+[09:42:19] ← Galactus   steer       "Yes, always pass idempotency_key=..."
+```
+
+Filterable by agent, event type, or file path.
+
+### 4. Artifacts Panel (new panel)
+
+Files produced/modified by the fleet, browsable without leaving Deck:
+- File tree of all touched paths
+- Diff view per file
+- "Open in editor" link
+
+### 5. Gateway Bridge (new backend module)
+
+The relay between Deck and OpenClaw:
+
+```python
+# On receiving a CC hook event
+async def on_hook_event(event: HookEvent):
+    await db.store(event)
+    await websocket.broadcast(event)          # → Deck frontend
+    await gateway.forward(event)              # → OpenClaw Gateway → Galactus
+
+# On receiving a steer command from Galactus via Gateway
+async def on_galactus_steer(session_id: str, message: str):
+    await db.store_steer(session_id, message)
+    await websocket.broadcast_steer(session_id, message)  # → Deck frontend
+    # ACP sub-agent handles actual injection into CC
+```
+
+**OpenClaw Gateway endpoint (new):**
+```
+POST /api/inbound-event   ← Deck forwards CC hook events here
+POST /api/steer           ← Galactus sends steering commands here → Deck
+```
+
+---
+
+## What CC Bridge Becomes
+
+CC Bridge (PTY relay) remains useful but scoped to **manually-run CC sessions** — when you open CC yourself in tmux and want a web terminal view. It is **not** part of the ACP orchestration path.
+
+In the orchestration flow, ACP sub-agents communicate with CC via message passing, not PTY relay. Deck's visibility into those sessions comes from CC HTTP hooks, not CC Bridge.
+
+The two coexist as separate Deck features:
+- **CC Bridge tab** — manual sessions, PTY view, existing workflow
+- **Orchestration tab** — Galactus-managed fleet, plan tree, hook telemetry
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Gateway Bridge (foundation)
+*Prerequisite for everything else*
+
+- Add `POST /api/hooks/forward` to Deck backend — forwards hook events to OpenClaw Gateway
+- Add `/api/inbound-event` endpoint to OpenClaw Gateway
+- Add `/api/steer` endpoint to Deck backend — accepts commands from Galactus, routes to correct agent
+- Wire Gateway → Galactus session delivery (treat as inbound message to main session)
+
+**Deliverable:** Galactus receives CC hook events in real time. Galactus can send steer messages that appear in Deck.
+
+### Phase 2 — Orchestration View skeleton
+*Deck frontend*
+
+- New `/orchestration` page
+- Plan tree component (static JSON for now, no live updates yet)
+- Agent cards with hook event feed
+- Event stream panel
+
+**Deliverable:** You can see a task plan and live hook events from CC agents in Deck.
+
+### Phase 3 — ACP sub-agent integration
+*OpenClaw side*
+
+- Galactus can spawn ACP sub-agents with a task brief
+- Sub-agents register their session with Deck on startup (`POST /api/agents/register`)
+- Sub-agents drive CC instances and relay CC hook events
+- Completion events propagate back to Galactus via ACP push
+
+**Deliverable:** Galactus can dispatch a multi-agent task and track completion without manual intervention.
+
+### Phase 4 — Steer controls
+*Full loop*
+
+- Steer input in Agent Detail Card
+- Galactus auto-steer on `waiting_for_input` hook events
+- User steer via Deck UI routes to Galactus → ACP sub-agent → CC
+- Conflict detection when parallel agents touch the same file
+
+**Deliverable:** Full control loop — spawn, monitor, steer, complete.
+
+### Phase 5 — Synthesis + PR generation
+*End-to-end*
+
+- Galactus synthesis pass on fleet completion
+- Auto-generated PR with summary of all agent outputs
+- `PLAN.md` final state written to repo
+- Deck shows completed task summary with cost breakdown
+
+**Deliverable:** Drop a goal in, get a merged PR out.
+
+---
+
+## Open Questions
+
+1. **Branch strategy** — Do parallel agents work on the same branch (conflict-prone) or feature branches per agent (merge complexity)? Recommendation: per-agent branches, Galactus does the merge.
+
+2. **Context budget** — How much shared context does each sub-agent get? Full codebase is too large. Recommendation: agent gets only the files relevant to its subtask (derived from plan + file ownership map).
+
+3. **Hook reliability** — CC hooks are fire-and-forget HTTP. If Deck is down, events are lost. Recommendation: agents should also commit progress checkpoints to git so Galactus can reconcile from state even with missed events.
+
+4. **Cost controls** — Multi-agent runs can burn tokens fast. Recommendation: per-agent token budget enforced by Galactus; auto-pause if budget exceeded, surface alert in Deck.
+
+5. **OpenClaw Gateway API** — Does Gateway expose an HTTP API for inbound events today, or does this need to be added? Needs investigation.
+
+---
+
+## Summary
+
+Claude Deck evolves from a monitoring dashboard into a **multi-agent orchestration platform** by wiring together three existing pieces:
+
+- **ACP** (control plane): Galactus spawns and steers sub-agents
+- **CC HTTP hooks** (data plane): telemetry from CC instances flows to Deck
+- **Deck** (surface): visualises the fleet, relays events, exposes steer controls
+
+The result is a system where you can hand Galactus a large engineering goal and watch it execute — with full visibility, the ability to intervene at any level, and a clean output at the end.

--- a/docs/plans/2026-03-08-presence-status-accuracy.md
+++ b/docs/plans/2026-03-08-presence-status-accuracy.md
@@ -1,0 +1,142 @@
+# Presence Dashboard: Status Accuracy Improvements
+
+**Date:** 2026-03-08
+**Status:** Proposed
+
+## Problem
+
+The Presence Dashboard cards don't show useful status information for most sessions. From a screenshot with 8 sessions:
+
+- **5 of 8 cards are nearly empty** — openclaw, both nano-banana-pipelines, claude-deck, and linode-migration show only a tiny activity sparkline with no narrative, commands, or files.
+- **"Active: 0" despite 8 sessions listed** — the 5-minute idle timeout aggressively marks sessions as idle even when Claude is actively thinking (just not triggering hook events).
+- **No status text** — the only indicator is a colored dot (green/gray/red), which doesn't communicate what the session is actually doing.
+
+### Root Cause
+
+The current status model has 4 states (`active`, `idle`, `error`, `stopped`) derived from **event timing**, not from what Claude is actually doing:
+
+- A session is `active` only while hook events are arriving frequently (< 5 min apart)
+- A session becomes `idle` after 5 minutes without events — but Claude may be thinking, waiting for a large tool response, or the user is reading output
+- Cards render sections conditionally (`last_narrative`, `modified_files`, `last_command`), so sessions that haven't triggered those specific events appear blank
+- There's no human-readable status text — just a dot color
+
+### Relevant Code
+
+**Backend status logic** (`backend/app/services/presence_service.py`):
+- `_mark_idle_sessions()`: marks any `active` session as `idle` if `last_event_at` is > 5 minutes ago
+- `process_event()`: sets status to `active` on any non-Stop/SessionEnd event, `stopped` on Stop/SessionEnd, `error` on non-zero Bash exit code
+- No concept of "waiting for input" vs "thinking" vs "running tool"
+
+**Frontend card rendering** (`frontend/src/features/presence/PresenceCard.tsx`):
+- Narrative section: only rendered if `session.last_narrative` exists
+- Modified files section: only rendered if `session.modified_files` has entries
+- Last command section: only rendered if `session.last_command` exists
+- When none of these exist, only the header (label + duration) and sparkline are shown
+
+**Hook events subscribed** (from ConnectDialog):
+- `Notification` — narrative text updates
+- `PostToolUse` — file edits, bash commands
+- `Stop` — session paused
+- `SessionStart` — session started
+- `SessionEnd` — session ended
+
+---
+
+## Proposed Solutions
+
+### Approach A: Richer Status from Existing Hooks (Recommended)
+
+**Effort:** Medium | **Impact:** High | **Risk:** Low
+
+Derive a human-readable `status_text` from the last event and always display it prominently on every card. No new dependencies or hook types needed.
+
+**Backend changes:**
+- Add `status_text` field to `PresenceSession` model (string, e.g., "Waiting for input", "Ran tool: Bash", "Edited 3 files", "Thinking...")
+- Update `process_event()` to set `status_text` based on event type:
+  - `Notification` with "waiting for input" → "Waiting for input"
+  - `PostToolUse` with `tool_name=Bash` → "Ran: `<command snippet>`"
+  - `PostToolUse` with `tool_name=Edit/Write` → "Edited `<filename>`"
+  - `PostToolUse` with other tools → "Used tool: `<tool_name>`"
+  - `SessionStart` → "Session started"
+  - `Stop`/`SessionEnd` → "Stopped"
+- Replace binary idle detection with graduated staleness:
+  - Show `last_event_at` as relative time ("2m ago", "15m ago") on every card
+  - Consider a longer idle timeout (15-20 min) or remove it entirely in favor of showing the "last seen" time
+
+**Frontend changes:**
+- Always show a status line on every card, even when no narrative/files/commands exist:
+  ```
+  [●] mercadona-cli                    11h 39m
+  Waiting for input · last event 2m ago
+  ```
+- Show `status_text` prominently below the header (not conditionally)
+- Show relative `last_event_at` time alongside status
+- Consider showing `total_events` count as a secondary indicator of session activity
+
+**Why recommended:** Gets 80% of the value with minimal changes. Every card will always show meaningful information. The "last event" time gives users an accurate sense of liveness without needing more hook types.
+
+---
+
+### Approach B: Poll Claude Code Status Directly
+
+**Effort:** High | **Impact:** Very High | **Risk:** Medium
+
+Add a backend polling mechanism that checks the actual state of Claude Code sessions independently of hook events.
+
+**How it would work:**
+- Backend periodically (every 10-30s) checks tmux panes for sessions known to be in tmux
+- Parse the tmux pane content to detect Claude Code status bar patterns (e.g., "Thinking...", "● claude-deck", idle prompt)
+- Could also check process status (is the Claude Code process still running?)
+- Update session status based on polled state, not just hook events
+
+**Pros:**
+- Most accurate real-time status — doesn't depend on hooks firing
+- Can detect when Claude is thinking (no hooks fire during inference)
+- Can detect crashed/hung sessions
+
+**Cons:**
+- Requires tmux dependency (not all sessions may use tmux)
+- Parsing terminal content is fragile
+- Adds background polling complexity
+- May duplicate CC Bridge functionality
+
+---
+
+### Approach C: Subscribe to Additional Hook Events
+
+**Effort:** Medium | **Impact:** High | **Risk:** Low-Medium
+
+Claude Code supports more hook events than currently subscribed. Adding more events gives finer-grained status.
+
+**Additional events to consider:**
+- `PreToolUse` — fires before a tool runs, so we know Claude is about to execute something
+- `UserMessage` — fires when the user sends a message, confirming the session is interactive
+- `SubagentStart`/`SubagentEnd` — track when subagents are spawned
+
+**How it improves status:**
+- `PreToolUse` → status: "Running tool: `<name>`..." (before it completes)
+- `UserMessage` → status: "Processing user message..." / resets idle timer
+- Gap between `PreToolUse` and `PostToolUse` → "Tool running..." with elapsed time
+- Long gap after `PostToolUse` with no new events → "Thinking..." (Claude is generating)
+
+**Pros:**
+- More accurate status without polling
+- Leverages existing hook infrastructure
+- Can detect "thinking" state (gap between events)
+
+**Cons:**
+- Requires user to update their hook configuration (re-run connect dialog)
+- More events = more webhook traffic
+- Still can't detect truly idle vs. thinking if no events fire
+
+---
+
+## Recommendation
+
+**Start with Approach A**, then layer in Approach C later if needed.
+
+Approach A is the quickest path to useful cards — every card will always show what the session last did and when. The "last event X ago" pattern is well-understood from tools like `kubectl get pods` (showing age) and gives users an intuitive sense of liveness.
+
+Approach C can be added incrementally to get finer-grained "Running tool..." / "Thinking..." states, but it requires users to update their hook config, so it's better as a follow-up.
+
+Approach B should only be considered if the tmux-based CC Bridge is always available and the polling approach can be shared between features.

--- a/docs/plans/2026-03-08-presence-status-accuracy.md
+++ b/docs/plans/2026-03-08-presence-status-accuracy.md
@@ -1,7 +1,7 @@
 # Presence Dashboard: Status Accuracy Improvements
 
 **Date:** 2026-03-08
-**Status:** Proposed
+**Status:** Implemented
 
 ## Problem
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -19,5 +19,8 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      'react-hooks/set-state-in-effect': 'warn',
+    },
   },
 ])

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import { ContextPage } from './features/context/ContextPage'
 import { PlansPage } from './features/plans/PlansPage'
 import { PlanDetailPage } from './features/plans/PlanDetailPage'
 import { CCBridgePage } from './features/cc-bridge/CCBridgePage'
+import { PresencePage } from './features/presence/PresencePage'
 
 function App() {
   return (
@@ -50,6 +51,7 @@ function App() {
               <Route path="sessions/:projectFolder/:sessionId" element={<SessionViewPage />} />
               <Route path="sessions" element={<SessionsPage />} />
               <Route path="cc-bridge" element={<CCBridgePage />} />
+              <Route path="presence" element={<PresencePage />} />
               <Route path="plans/:filename" element={<PlanDetailPage />} />
               <Route path="plans" element={<PlansPage />} />
               <Route path="context" element={<ContextPage />} />

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,8 +1,13 @@
+import { Terminal, Radio } from "lucide-react";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
+import { Badge } from "@/components/ui/badge";
 import { useTheme } from "@/contexts/ThemeContext";
+import { useSystemStatus } from "@/hooks/useSystemStatus";
+import { cn } from "@/lib/utils";
 
 export function Header() {
   const { theme } = useTheme();
+  const status = useSystemStatus();
 
   return (
     <header className="border-b bg-background">
@@ -18,7 +23,29 @@ export function Header() {
             <p className="text-xs text-muted-foreground">Your Claude Code command centre</p>
           </div>
         </div>
-        <ThemeToggle />
+        <div className="flex items-center gap-2">
+          {status && (
+            <>
+              {status.claudeCodeVersion && (
+                <Badge variant="outline" className="gap-1 font-mono text-xs">
+                  <Terminal className="h-3 w-3" />
+                  Claude Code v{status.claudeCodeVersion}
+                </Badge>
+              )}
+              <Badge
+                variant="secondary"
+                className={cn(
+                  "gap-1 text-xs",
+                  status.activeSessions > 0 && "bg-green-500/15 text-green-600 dark:text-green-400"
+                )}
+              >
+                <Radio className="h-3 w-3" />
+                {status.activeSessions} active
+              </Badge>
+            </>
+          )}
+          <ThemeToggle />
+        </div>
       </div>
     </header>
   )

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -22,6 +22,7 @@ import {
   Gauge,
   ClipboardList,
   MonitorPlay,
+  Radio,
   PanelLeftClose,
   PanelLeftOpen,
   type LucideIcon,
@@ -49,6 +50,7 @@ const navigation: { name: string; href: string; icon: LucideIcon }[] = [
 
   // Tier 4: Monitoring & Tools
   { name: 'Sessions', href: '/sessions', icon: MessageSquare },
+  { name: 'Presence', href: '/presence', icon: Radio },
   { name: 'CC Bridge', href: '/cc-bridge', icon: MonitorPlay },
   { name: 'Plans', href: '/plans', icon: ClipboardList },
   { name: 'Context', href: '/context', icon: Gauge },

--- a/frontend/src/features/presence/ActivitySparkline.tsx
+++ b/frontend/src/features/presence/ActivitySparkline.tsx
@@ -1,0 +1,26 @@
+import { BarChart, Bar, ResponsiveContainer } from 'recharts'
+
+interface ActivitySparklineProps {
+  buckets: number[]
+}
+
+export function ActivitySparkline({ buckets }: ActivitySparklineProps) {
+  const data = buckets.map((value, i) => ({ i, v: value }))
+
+  return (
+    <div className="h-5 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data} margin={{ top: 0, right: 0, bottom: 0, left: 0 }}>
+          <Bar
+            dataKey="v"
+            fill="hsl(var(--primary) / 0.5)"
+            radius={[1, 1, 0, 0]}
+            isAnimationActive={false}
+            maxBarSize={8}
+            background={{ fill: 'hsl(var(--muted) / 0.3)', radius: [1, 1, 0, 0] as unknown as number }}
+          />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/frontend/src/features/presence/ConnectDialog.tsx
+++ b/frontend/src/features/presence/ConnectDialog.tsx
@@ -10,19 +10,17 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { MODAL_SIZES } from '@/lib/constants'
 import { cn } from '@/lib/utils'
-import { fetchConfigSnippet } from './api'
+import { fetchConfigSnippet, fetchPresenceHooks, buildPresenceEventsUrl } from './api'
 import { apiClient } from '@/lib/api'
 import type { PresenceConfigSnippet } from '@/types/presence'
 import type { Hook, HookEvent } from '@/types/hooks'
-import { Copy, Check, Plug, Unplug, Loader2, FileCode } from 'lucide-react'
+import { Copy, Check, Plug, Unplug, Loader2, FileCode, AlertTriangle, ArrowRight } from 'lucide-react'
 
 interface ConnectDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   projectPath?: string
 }
-
-const PRESENCE_URL = 'http://localhost:8000/api/v1/presence/events'
 
 const PRESENCE_EVENTS: { event: HookEvent; label: string }[] = [
   { event: 'Notification', label: 'Notifications (narrative text)' },
@@ -50,12 +48,7 @@ export function ConnectDialog({ open, onOpenChange, projectPath }: ConnectDialog
   const fetchExisting = useCallback(async () => {
     setLoading(true)
     try {
-      const params = projectPath ? `?project_path=${encodeURIComponent(projectPath)}` : ''
-      const res = await apiClient<{ hooks: Hook[] }>(`hooks${params}`)
-      const presenceHooks = res.hooks.filter(
-        (h) => h.type === 'http' && h.url === PRESENCE_URL
-      )
-      setExistingHooks(presenceHooks)
+      setExistingHooks(await fetchPresenceHooks(projectPath))
     } catch {
       setExistingHooks([])
     }
@@ -99,7 +92,7 @@ export function ConnectDialog({ open, onOpenChange, projectPath }: ConnectDialog
           body: JSON.stringify({
             event,
             type: 'http',
-            url: PRESENCE_URL,
+            url: buildPresenceEventsUrl(),
             scope,
           }),
         })
@@ -189,9 +182,33 @@ export function ConnectDialog({ open, onOpenChange, projectPath }: ConnectDialog
           </div>
         ) : tab === 'auto' ? (
           <div className="space-y-4">
-            {/* Already connected — show disconnect */}
+            {/* Already connected — show status + restart warning */}
             {isConnected && (
               <div className="space-y-3">
+                {results.some((r) => r.ok) && (
+                  <>
+                    <div className="rounded-md border border-yellow-500/50 bg-yellow-500/10 p-3 space-y-2">
+                      <div className="flex items-center gap-2 text-sm font-medium text-yellow-600 dark:text-yellow-400">
+                        <AlertTriangle className="h-4 w-4 shrink-0" />
+                        Restart running sessions
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        Hooks only take effect for <strong>new</strong> Claude Code sessions. Any currently running sessions won&apos;t send events until restarted.
+                      </p>
+                    </div>
+                    <div className="rounded-md border bg-muted/50 p-3 space-y-1.5">
+                      <span className="text-xs font-medium">What&apos;s next</span>
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <ArrowRight className="h-3 w-3 shrink-0" />
+                        Start (or restart) a Claude Code session
+                      </div>
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <ArrowRight className="h-3 w-3 shrink-0" />
+                        Come back to this page — cards will appear in real-time
+                      </div>
+                    </div>
+                  </>
+                )}
                 <div className="space-y-1">
                   {existingHooks.map((h) => (
                     <div key={h.id} className="flex items-center gap-2 text-sm">
@@ -241,7 +258,7 @@ export function ConnectDialog({ open, onOpenChange, projectPath }: ConnectDialog
                       size="sm"
                       onClick={() => setScope('user')}
                     >
-                      User (all projects)
+                      All projects
                     </Button>
                     <Button
                       variant={scope === 'project' ? 'default' : 'outline'}
@@ -249,9 +266,16 @@ export function ConnectDialog({ open, onOpenChange, projectPath }: ConnectDialog
                       onClick={() => setScope('project')}
                       disabled={!projectPath}
                     >
-                      Project only
+                      This project only
                     </Button>
                   </div>
+                  <p className="text-xs text-muted-foreground">
+                    {scope === 'user'
+                      ? 'Hooks apply to all Claude Code sessions regardless of project.'
+                      : projectPath
+                        ? `Hooks apply only to sessions in ${projectPath.replace(/\/+$/, '').split('/').pop() || projectPath}.`
+                        : 'Select a project in the sidebar to enable project-scoped hooks.'}
+                  </p>
                 </div>
 
                 {/* Results */}

--- a/frontend/src/features/presence/ConnectDialog.tsx
+++ b/frontend/src/features/presence/ConnectDialog.tsx
@@ -24,10 +24,14 @@ interface ConnectDialogProps {
 
 const PRESENCE_EVENTS: { event: HookEvent; label: string }[] = [
   { event: 'Notification', label: 'Notifications (narrative text)' },
+  { event: 'PreToolUse', label: 'Pre Tool Use (tool about to run)' },
   { event: 'PostToolUse', label: 'Post Tool Use (file edits, commands)' },
+  { event: 'UserPromptSubmit', label: 'User Prompt (user sent a message)' },
   { event: 'Stop', label: 'Stop (session paused)' },
   { event: 'SessionStart', label: 'Session Start' },
   { event: 'SessionEnd', label: 'Session End' },
+  { event: 'SubagentStart', label: 'Subagent Start' },
+  { event: 'SubagentStop', label: 'Subagent Stop' },
 ]
 
 type TabId = 'auto' | 'manual'

--- a/frontend/src/features/presence/ConnectDialog.tsx
+++ b/frontend/src/features/presence/ConnectDialog.tsx
@@ -1,0 +1,320 @@
+import { useState, useEffect, useCallback } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { MODAL_SIZES } from '@/lib/constants'
+import { cn } from '@/lib/utils'
+import { fetchConfigSnippet } from './api'
+import { apiClient } from '@/lib/api'
+import type { PresenceConfigSnippet } from '@/types/presence'
+import type { Hook, HookEvent } from '@/types/hooks'
+import { Copy, Check, Plug, Unplug, Loader2, FileCode } from 'lucide-react'
+
+interface ConnectDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  projectPath?: string
+}
+
+const PRESENCE_URL = 'http://localhost:8000/api/v1/presence/events'
+
+const PRESENCE_EVENTS: { event: HookEvent; label: string }[] = [
+  { event: 'Notification', label: 'Notifications (narrative text)' },
+  { event: 'PostToolUse', label: 'Post Tool Use (file edits, commands)' },
+  { event: 'Stop', label: 'Stop (session paused)' },
+  { event: 'SessionStart', label: 'Session Start' },
+  { event: 'SessionEnd', label: 'Session End' },
+]
+
+type TabId = 'auto' | 'manual'
+
+export function ConnectDialog({ open, onOpenChange, projectPath }: ConnectDialogProps) {
+  const [tab, setTab] = useState<TabId>('auto')
+  const [selectedEvents, setSelectedEvents] = useState<Set<HookEvent>>(
+    new Set(PRESENCE_EVENTS.map((e) => e.event))
+  )
+  const [scope, setScope] = useState<'user' | 'project'>('user')
+  const [existingHooks, setExistingHooks] = useState<Hook[]>([])
+  const [loading, setLoading] = useState(false)
+  const [creating, setCreating] = useState(false)
+  const [snippet, setSnippet] = useState<PresenceConfigSnippet | null>(null)
+  const [copied, setCopied] = useState(false)
+  const [results, setResults] = useState<{ event: string; ok: boolean }[]>([])
+
+  const fetchExisting = useCallback(async () => {
+    setLoading(true)
+    try {
+      const params = projectPath ? `?project_path=${encodeURIComponent(projectPath)}` : ''
+      const res = await apiClient<{ hooks: Hook[] }>(`hooks${params}`)
+      const presenceHooks = res.hooks.filter(
+        (h) => h.type === 'http' && h.url === PRESENCE_URL
+      )
+      setExistingHooks(presenceHooks)
+    } catch {
+      setExistingHooks([])
+    }
+    setLoading(false)
+  }, [projectPath])
+
+  useEffect(() => {
+    if (open) {
+      fetchExisting()
+      setResults([])
+    }
+  }, [open, fetchExisting])
+
+  const toggleEvent = (event: HookEvent) => {
+    setSelectedEvents((prev) => {
+      const next = new Set(prev)
+      if (next.has(event)) next.delete(event)
+      else next.add(event)
+      return next
+    })
+  }
+
+  const handleConnect = async () => {
+    setCreating(true)
+    setResults([])
+    const newResults: { event: string; ok: boolean }[] = []
+
+    for (const { event } of PRESENCE_EVENTS) {
+      if (!selectedEvents.has(event)) continue
+      // Skip if already exists
+      if (existingHooks.some((h) => h.event === event)) {
+        newResults.push({ event, ok: true })
+        continue
+      }
+      try {
+        const params = scope === 'project' && projectPath
+          ? `?project_path=${encodeURIComponent(projectPath)}`
+          : ''
+        await apiClient<Hook>(`hooks${params}`, {
+          method: 'POST',
+          body: JSON.stringify({
+            event,
+            type: 'http',
+            url: PRESENCE_URL,
+            scope,
+          }),
+        })
+        newResults.push({ event, ok: true })
+      } catch {
+        newResults.push({ event, ok: false })
+      }
+    }
+
+    setResults(newResults)
+    await fetchExisting()
+    setCreating(false)
+  }
+
+  const handleDisconnect = async () => {
+    setCreating(true)
+    for (const hook of existingHooks) {
+      try {
+        const params = `?scope=${hook.scope}${hook.scope === 'project' && projectPath ? `&project_path=${encodeURIComponent(projectPath)}` : ''}`
+        await apiClient(`hooks/${hook.id}${params}`, { method: 'DELETE' })
+      } catch {
+        // Ignore individual failures
+      }
+    }
+    await fetchExisting()
+    setResults([])
+    setCreating(false)
+  }
+
+  const loadSnippet = async () => {
+    if (!snippet) {
+      const s = await fetchConfigSnippet()
+      setSnippet(s)
+    }
+  }
+
+  const copySnippet = () => {
+    if (snippet) {
+      navigator.clipboard.writeText(JSON.stringify(snippet.snippet, null, 2))
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
+  }
+
+  const isConnected = existingHooks.length > 0
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className={cn(MODAL_SIZES.MD)}>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            {isConnected ? <Unplug className="h-5 w-5" /> : <Plug className="h-5 w-5" />}
+            {isConnected ? 'Connected to Deck' : 'Connect to Deck'}
+          </DialogTitle>
+          <DialogDescription>
+            {isConnected
+              ? `${existingHooks.length} HTTP hook(s) are sending events to the Presence Dashboard.`
+              : 'Set up HTTP hooks so Claude Code sessions report their activity here.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Tab switcher */}
+        <div className="flex gap-1 border-b">
+          <button
+            className={cn(
+              'px-3 py-1.5 text-sm transition-colors',
+              tab === 'auto' ? 'border-b-2 border-primary font-medium' : 'text-muted-foreground'
+            )}
+            onClick={() => setTab('auto')}
+          >
+            Auto-setup
+          </button>
+          <button
+            className={cn(
+              'px-3 py-1.5 text-sm transition-colors',
+              tab === 'manual' ? 'border-b-2 border-primary font-medium' : 'text-muted-foreground'
+            )}
+            onClick={() => { setTab('manual'); loadSnippet() }}
+          >
+            Manual snippet
+          </button>
+        </div>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : tab === 'auto' ? (
+          <div className="space-y-4">
+            {/* Already connected — show disconnect */}
+            {isConnected && (
+              <div className="space-y-3">
+                <div className="space-y-1">
+                  {existingHooks.map((h) => (
+                    <div key={h.id} className="flex items-center gap-2 text-sm">
+                      <span className="h-2 w-2 rounded-full bg-green-500" />
+                      <span>{h.event}</span>
+                      <Badge variant="outline" className="text-[10px]">{h.scope}</Badge>
+                    </div>
+                  ))}
+                </div>
+                <Button
+                  variant="destructive"
+                  onClick={handleDisconnect}
+                  disabled={creating}
+                  className="w-full"
+                >
+                  {creating ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : <Unplug className="h-4 w-4 mr-2" />}
+                  Disconnect
+                </Button>
+              </div>
+            )}
+
+            {/* Not connected — show setup */}
+            {!isConnected && (
+              <>
+                {/* Events checklist */}
+                <div className="space-y-2">
+                  <span className="text-sm font-medium">Events to monitor</span>
+                  {PRESENCE_EVENTS.map(({ event, label }) => (
+                    <label key={event} className="flex items-center gap-2 text-sm cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={selectedEvents.has(event)}
+                        onChange={() => toggleEvent(event)}
+                        className="rounded"
+                      />
+                      {label}
+                    </label>
+                  ))}
+                </div>
+
+                {/* Scope */}
+                <div className="space-y-2">
+                  <span className="text-sm font-medium">Scope</span>
+                  <div className="flex gap-2">
+                    <Button
+                      variant={scope === 'user' ? 'default' : 'outline'}
+                      size="sm"
+                      onClick={() => setScope('user')}
+                    >
+                      User (all projects)
+                    </Button>
+                    <Button
+                      variant={scope === 'project' ? 'default' : 'outline'}
+                      size="sm"
+                      onClick={() => setScope('project')}
+                      disabled={!projectPath}
+                    >
+                      Project only
+                    </Button>
+                  </div>
+                </div>
+
+                {/* Results */}
+                {results.length > 0 && (
+                  <div className="space-y-1">
+                    {results.map((r) => (
+                      <div key={r.event} className="flex items-center gap-2 text-sm">
+                        {r.ok ? (
+                          <Check className="h-4 w-4 text-green-500" />
+                        ) : (
+                          <span className="h-4 w-4 text-red-500 text-center">!</span>
+                        )}
+                        {r.event}
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                <Button
+                  onClick={handleConnect}
+                  disabled={creating || selectedEvents.size === 0}
+                  className="w-full"
+                >
+                  {creating ? (
+                    <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                  ) : (
+                    <Plug className="h-4 w-4 mr-2" />
+                  )}
+                  Connect
+                </Button>
+              </>
+            )}
+          </div>
+        ) : (
+          /* Manual snippet tab */
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              {snippet?.instructions || 'Loading...'}
+            </p>
+            {snippet && (
+              <>
+                <div className="relative">
+                  <pre className="rounded-md bg-muted p-3 text-xs overflow-auto max-h-64">
+                    {JSON.stringify(snippet.snippet, null, 2)}
+                  </pre>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="absolute top-2 right-2 h-7 w-7"
+                    onClick={copySnippet}
+                  >
+                    {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+                  </Button>
+                </div>
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <FileCode className="h-3.5 w-3.5" />
+                  <code>~/.claude/settings.json</code>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/features/presence/PresenceCard.tsx
+++ b/frontend/src/features/presence/PresenceCard.tsx
@@ -44,20 +44,34 @@ function formatDuration(startedAt: string): string {
   return `${hours}h ${remainMins}m`
 }
 
+function formatRelativeTime(isoString: string): string {
+  const elapsed = Date.now() - new Date(isoString).getTime()
+  const secs = Math.floor(elapsed / 1000)
+  if (secs < 30) return 'just now'
+  const mins = Math.floor(secs / 60)
+  if (mins < 1) return `${secs}s ago`
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  return `${Math.floor(hours / 24)}d ago`
+}
+
 function getBasename(filePath: string): string {
   return filePath.split('/').pop() || filePath
 }
 
 export function PresenceCard({ session, onRemove }: PresenceCardProps) {
   const [duration, setDuration] = useState(() => formatDuration(session.started_at))
+  const [lastEventAgo, setLastEventAgo] = useState(() => formatRelativeTime(session.last_event_at))
 
   useEffect(() => {
     if (session.status === 'stopped') return
     const timer = setInterval(() => {
       setDuration(formatDuration(session.started_at))
+      setLastEventAgo(formatRelativeTime(session.last_event_at))
     }, 1000)
     return () => clearInterval(timer)
-  }, [session.started_at, session.status])
+  }, [session.started_at, session.last_event_at, session.status])
 
   const files = session.modified_files || []
   const visibleFiles = files.slice(-5)
@@ -105,6 +119,15 @@ export function PresenceCard({ session, onRemove }: PresenceCardProps) {
               <X className="h-3 w-3" />
             </Button>
           </div>
+        </div>
+
+        {/* Status line — always visible */}
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <span className="truncate">
+            {session.status_text || session.status.charAt(0).toUpperCase() + session.status.slice(1)}
+          </span>
+          <span className="shrink-0">·</span>
+          <span className="shrink-0">{lastEventAgo}</span>
         </div>
 
         {/* Narrative */}

--- a/frontend/src/features/presence/PresenceCard.tsx
+++ b/frontend/src/features/presence/PresenceCard.tsx
@@ -4,7 +4,7 @@ import { Badge } from '@/components/ui/badge'
 import { CLICKABLE_CARD } from '@/lib/constants'
 import { cn } from '@/lib/utils'
 import { ActivitySparkline } from './ActivitySparkline'
-import type { PresenceSession } from '@/types/presence'
+import type { PresenceSession, FileChange } from '@/types/presence'
 import { X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 
@@ -61,6 +61,16 @@ function getBasename(filePath: string): string {
   return filePath.split('/').pop() || filePath
 }
 
+function normalizeFile(f: string | FileChange): FileChange {
+  if (typeof f === 'string') return { path: f, op: 'modified' }
+  return { path: f.path, op: f.op ?? 'modified' }
+}
+
+const FILE_OP_COLORS: Record<string, string> = {
+  created: 'border-green-500/50 text-green-600 dark:text-green-400',
+  modified: '',
+}
+
 export function PresenceCard({ session, onRemove }: PresenceCardProps) {
   const [duration, setDuration] = useState(() => formatDuration(session.started_at))
   const [lastEventAgo, setLastEventAgo] = useState(() => formatRelativeTime(session.last_event_at))
@@ -90,7 +100,7 @@ export function PresenceCard({ session, onRemove }: PresenceCardProps) {
       role="article"
       aria-label={`Session ${session.label || session.session_id}`}
     >
-      <CardContent className="p-4 space-y-3">
+      <CardContent className="p-4 space-y-2">
         {/* Header: status dot + label + duration + remove button */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2 min-w-0">
@@ -131,27 +141,42 @@ export function PresenceCard({ session, onRemove }: PresenceCardProps) {
           <span className="shrink-0">{lastEventAgo}</span>
         </div>
 
+        {/* User prompt */}
+        {session.last_user_prompt && (
+          <div className="text-xs text-muted-foreground">
+            <span className="font-medium text-foreground/70">You:</span>{' '}
+            <span className="line-clamp-2">{session.last_user_prompt}</span>
+          </div>
+        )}
+
         {/* Narrative */}
         {session.last_narrative && (
-          <div className="rounded-md bg-muted/50 border px-3 py-2">
+          <div className="rounded-md bg-muted/50 border-l-2 border-l-primary/30 px-3 py-1.5">
             <p className="text-xs text-muted-foreground italic line-clamp-2">
               &ldquo;{session.last_narrative}&rdquo;
             </p>
           </div>
         )}
 
-        {/* Modified files */}
+        {/* Changed files */}
         {visibleFiles.length > 0 && (
           <div className="space-y-1">
             <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
-              Modified files
+              Changed files
             </span>
             <div className="flex flex-wrap gap-1">
-              {visibleFiles.map((f) => (
-                <Badge key={f} variant="outline" className="text-[11px] font-mono px-1.5 py-0">
-                  {getBasename(f)}
-                </Badge>
-              ))}
+              {visibleFiles.map((raw) => {
+                const f = normalizeFile(raw)
+                return (
+                  <Badge
+                    key={f.path}
+                    variant="outline"
+                    className={cn("text-[11px] font-mono px-1.5 py-0", FILE_OP_COLORS[f.op] ?? '')}
+                  >
+                    {getBasename(f.path)}
+                  </Badge>
+                )
+              })}
               {extraCount > 0 && (
                 <Badge variant="secondary" className="text-[11px] px-1.5 py-0">
                   +{extraCount}

--- a/frontend/src/features/presence/PresenceCard.tsx
+++ b/frontend/src/features/presence/PresenceCard.tsx
@@ -1,0 +1,166 @@
+import { useState, useEffect } from 'react'
+import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { CLICKABLE_CARD } from '@/lib/constants'
+import { cn } from '@/lib/utils'
+import { ActivitySparkline } from './ActivitySparkline'
+import type { PresenceSession } from '@/types/presence'
+import { X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+interface PresenceCardProps {
+  session: PresenceSession
+  onRemove: (sessionId: string) => void
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  active: 'bg-green-500',
+  idle: 'bg-muted-foreground',
+  error: 'bg-red-500',
+  stopped: 'bg-muted-foreground',
+}
+
+const STATUS_BORDER_TOP: Record<string, string> = {
+  active: 'border-t-green-500',
+  idle: 'border-t-muted-foreground',
+  error: 'border-t-red-500',
+  stopped: 'border-t-muted-foreground/50',
+}
+
+const STATUS_PULSE: Record<string, string> = {
+  active: 'animate-pulse',
+  idle: '',
+  error: '',
+  stopped: '',
+}
+
+function formatDuration(startedAt: string): string {
+  const start = new Date(startedAt).getTime()
+  const now = Date.now()
+  const mins = Math.floor((now - start) / 60000)
+  if (mins < 60) return `${mins}m`
+  const hours = Math.floor(mins / 60)
+  const remainMins = mins % 60
+  return `${hours}h ${remainMins}m`
+}
+
+function getBasename(filePath: string): string {
+  return filePath.split('/').pop() || filePath
+}
+
+export function PresenceCard({ session, onRemove }: PresenceCardProps) {
+  const [duration, setDuration] = useState(() => formatDuration(session.started_at))
+
+  useEffect(() => {
+    if (session.status === 'stopped') return
+    const timer = setInterval(() => {
+      setDuration(formatDuration(session.started_at))
+    }, 1000)
+    return () => clearInterval(timer)
+  }, [session.started_at, session.status])
+
+  const files = session.modified_files || []
+  const visibleFiles = files.slice(-5)
+  const extraCount = files.length - visibleFiles.length
+  const buckets = session.activity_buckets || []
+
+  return (
+    <Card
+      className={cn(
+        CLICKABLE_CARD,
+        'relative overflow-hidden border-t-2',
+        STATUS_BORDER_TOP[session.status] || 'border-t-muted'
+      )}
+      tabIndex={0}
+      role="article"
+      aria-label={`Session ${session.label || session.session_id}`}
+    >
+      <CardContent className="p-4 space-y-3">
+        {/* Header: status dot + label + duration + remove button */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2 min-w-0">
+            <span
+              className={cn(
+                'h-2 w-2 rounded-full shrink-0',
+                STATUS_COLORS[session.status],
+                STATUS_PULSE[session.status]
+              )}
+            />
+            <span className="font-semibold text-sm truncate">
+              {session.label || session.session_id.slice(0, 8)}
+            </span>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <Badge variant="outline" className="text-xs font-normal">
+              {duration}
+            </Badge>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6"
+              onClick={(e) => { e.stopPropagation(); onRemove(session.session_id) }}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.stopPropagation(); onRemove(session.session_id) } }}
+              aria-label="Remove session"
+            >
+              <X className="h-3 w-3" />
+            </Button>
+          </div>
+        </div>
+
+        {/* Narrative */}
+        {session.last_narrative && (
+          <div className="rounded-md bg-muted/50 border px-3 py-2">
+            <p className="text-xs text-muted-foreground italic line-clamp-2">
+              &ldquo;{session.last_narrative}&rdquo;
+            </p>
+          </div>
+        )}
+
+        {/* Modified files */}
+        {visibleFiles.length > 0 && (
+          <div className="space-y-1">
+            <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+              Modified files
+            </span>
+            <div className="flex flex-wrap gap-1">
+              {visibleFiles.map((f) => (
+                <Badge key={f} variant="outline" className="text-[11px] font-mono px-1.5 py-0">
+                  {getBasename(f)}
+                </Badge>
+              ))}
+              {extraCount > 0 && (
+                <Badge variant="secondary" className="text-[11px] px-1.5 py-0">
+                  +{extraCount}
+                </Badge>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Last command */}
+        {session.last_command && (
+          <div className="flex items-center gap-1.5 rounded bg-muted/50 px-2.5 py-1.5 text-[11px]">
+            <span className="text-muted-foreground">$</span>
+            <span className="font-mono truncate flex-1">
+              {session.last_command.length > 80
+                ? session.last_command.slice(0, 80) + '...'
+                : session.last_command}
+            </span>
+            {session.last_command_exit != null && (
+              session.last_command_exit === 0 ? (
+                <span className="text-green-500 shrink-0">ok</span>
+              ) : (
+                <span className="text-red-500 shrink-0">exit {session.last_command_exit}</span>
+              )
+            )}
+          </div>
+        )}
+
+        {/* Activity sparkline */}
+        {buckets.length > 0 && (
+          <ActivitySparkline buckets={buckets} />
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/features/presence/PresenceCard.tsx
+++ b/frontend/src/features/presence/PresenceCard.tsx
@@ -91,7 +91,7 @@ export function PresenceCard({ session, onRemove }: PresenceCardProps) {
             </span>
           </div>
           <div className="flex items-center gap-2 shrink-0">
-            <Badge variant="outline" className="text-xs font-normal">
+            <Badge variant="outline" className="text-xs font-normal" title="Duration since session start">
               {duration}
             </Badge>
             <Button

--- a/frontend/src/features/presence/PresenceCard.tsx
+++ b/frontend/src/features/presence/PresenceCard.tsx
@@ -46,6 +46,7 @@ function formatDuration(startedAt: string): string {
 
 function formatRelativeTime(isoString: string): string {
   const elapsed = Date.now() - new Date(isoString).getTime()
+  if (!Number.isFinite(elapsed) || elapsed < 0) return 'just now'
   const secs = Math.floor(elapsed / 1000)
   if (secs < 30) return 'just now'
   const mins = Math.floor(secs / 60)
@@ -65,11 +66,11 @@ export function PresenceCard({ session, onRemove }: PresenceCardProps) {
   const [lastEventAgo, setLastEventAgo] = useState(() => formatRelativeTime(session.last_event_at))
 
   useEffect(() => {
-    if (session.status === 'stopped') return
+    const interval = session.status === 'stopped' ? 30000 : 1000
     const timer = setInterval(() => {
       setDuration(formatDuration(session.started_at))
       setLastEventAgo(formatRelativeTime(session.last_event_at))
-    }, 1000)
+    }, interval)
     return () => clearInterval(timer)
   }, [session.started_at, session.last_event_at, session.status])
 

--- a/frontend/src/features/presence/PresencePage.tsx
+++ b/frontend/src/features/presence/PresencePage.tsx
@@ -1,0 +1,225 @@
+import { useState, useCallback, useEffect } from 'react'
+import { Radio, Plug, Trash2 } from 'lucide-react'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { RefreshButton } from '@/components/shared/RefreshButton'
+import { PresenceCard } from './PresenceCard'
+import { ConnectDialog } from './ConnectDialog'
+import { fetchPresenceSessions, removeSession, clearAllSessions } from './api'
+import { usePresenceWebSocket } from '@/hooks/usePresenceWebSocket'
+import { useProjectContext } from '@/contexts/ProjectContext'
+import type { PresenceSession } from '@/types/presence'
+
+// Sort: active > error > idle > stopped
+const STATUS_ORDER: Record<string, number> = { active: 0, error: 1, idle: 2, stopped: 3 }
+
+function sortSessions(sessions: PresenceSession[]): PresenceSession[] {
+  return [...sessions].sort((a, b) => {
+    const sa = STATUS_ORDER[a.status] ?? 9
+    const sb = STATUS_ORDER[b.status] ?? 9
+    if (sa !== sb) return sa - sb
+    return new Date(b.last_event_at).getTime() - new Date(a.last_event_at).getTime()
+  })
+}
+
+export function PresencePage() {
+  const [sessions, setSessions] = useState<Map<string, PresenceSession>>(new Map())
+  const [loading, setLoading] = useState(true)
+  const [connectOpen, setConnectOpen] = useState(false)
+  const { activeProject } = useProjectContext()
+
+  const loadSessions = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetchPresenceSessions()
+      const map = new Map<string, PresenceSession>()
+      for (const s of res.sessions) {
+        map.set(s.session_id, s)
+      }
+      setSessions(map)
+    } catch {
+      // Ignore — empty state will show
+    }
+    setLoading(false)
+  }, [])
+
+  useEffect(() => {
+    loadSessions()
+  }, [loadSessions])
+
+  const onSessionUpdate = useCallback((session: PresenceSession) => {
+    setSessions((prev) => {
+      const next = new Map(prev)
+      next.set(session.session_id, session)
+      return next
+    })
+  }, [])
+
+  const onSessionRemove = useCallback((sessionId: string) => {
+    setSessions((prev) => {
+      const next = new Map(prev)
+      next.delete(sessionId)
+      return next
+    })
+  }, [])
+
+  const onSessionsCleared = useCallback(() => {
+    setSessions(new Map())
+  }, [])
+
+  const { connected, reconnecting } = usePresenceWebSocket({
+    onSessionUpdate,
+    onSessionRemove,
+    onSessionsCleared,
+    enabled: true,
+  })
+
+  const handleRemove = async (sessionId: string) => {
+    try {
+      await removeSession(sessionId)
+      onSessionRemove(sessionId)
+    } catch {
+      // Ignore
+    }
+  }
+
+  const handleClearStopped = async () => {
+    const stopped = [...sessions.values()].filter((s) => s.status === 'stopped' || s.status === 'idle')
+    for (const s of stopped) {
+      try {
+        await removeSession(s.session_id)
+        onSessionRemove(s.session_id)
+      } catch {
+        // Ignore individual failures
+      }
+    }
+  }
+
+  const handleClearAll = async () => {
+    try {
+      await clearAllSessions()
+      setSessions(new Map())
+    } catch {
+      // Ignore
+    }
+  }
+
+  const sortedSessions = sortSessions([...sessions.values()])
+  const totalEvents = sortedSessions.reduce((acc, s) => acc + s.total_events, 0)
+  const activeCount = sortedSessions.filter((s) => s.status === 'active').length
+  const errorCount = sortedSessions.filter((s) => s.status === 'error').length
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold flex items-center gap-2">
+            <Radio className="h-8 w-8" />
+            Presence
+          </h1>
+          <p className="text-muted-foreground">
+            Real-time monitoring of Claude Code sessions
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          {/* WS status indicator */}
+          <div className="flex items-center gap-1.5 text-xs">
+            <span
+              className={`h-2 w-2 rounded-full ${
+                connected ? 'bg-green-500 animate-pulse' : reconnecting ? 'bg-yellow-500 animate-pulse' : 'bg-muted-foreground'
+              }`}
+            />
+            <span className="text-muted-foreground">
+              {connected ? 'Live' : reconnecting ? 'Reconnecting...' : 'Disconnected'}
+            </span>
+          </div>
+          <RefreshButton onClick={loadSessions} loading={loading} />
+          <Button variant="outline" size="sm" onClick={() => setConnectOpen(true)}>
+            <Plug className="h-4 w-4 mr-1" />
+            Connect to Deck
+          </Button>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="grid gap-4 md:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Sessions</CardDescription>
+            <CardTitle className="text-3xl">{sortedSessions.length}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Active</CardDescription>
+            <CardTitle className="text-3xl text-green-500">{activeCount}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Errors</CardDescription>
+            <CardTitle className="text-3xl text-red-500">{errorCount}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Total Events</CardDescription>
+            <CardTitle className="text-3xl">{totalEvents}</CardTitle>
+          </CardHeader>
+        </Card>
+      </div>
+
+      {/* Action bar */}
+      {sortedSessions.length > 0 && (
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleClearStopped}
+            disabled={!sortedSessions.some((s) => s.status === 'stopped' || s.status === 'idle')}
+          >
+            Clear stopped
+          </Button>
+          <Button variant="outline" size="sm" onClick={handleClearAll}>
+            <Trash2 className="h-3.5 w-3.5 mr-1" />
+            Clear all
+          </Button>
+        </div>
+      )}
+
+      {/* Session grid */}
+      {sortedSessions.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {sortedSessions.map((s) => (
+            <PresenceCard key={s.session_id} session={s} onRemove={handleRemove} />
+          ))}
+        </div>
+      ) : (
+        !loading && (
+          <Card className="border-dashed">
+            <CardContent className="flex flex-col items-center justify-center py-12 text-center">
+              <Radio className="h-12 w-12 text-muted-foreground mb-4" />
+              <h3 className="text-lg font-semibold mb-2">No sessions yet</h3>
+              <p className="text-sm text-muted-foreground max-w-md mb-4">
+                Connect Claude Code to this dashboard using HTTP hooks. Sessions will appear here
+                in real-time as Claude works.
+              </p>
+              <Button onClick={() => setConnectOpen(true)}>
+                <Plug className="h-4 w-4 mr-2" />
+                Connect to Deck
+              </Button>
+            </CardContent>
+          </Card>
+        )
+      )}
+
+      {/* Connect Dialog */}
+      <ConnectDialog
+        open={connectOpen}
+        onOpenChange={setConnectOpen}
+        projectPath={activeProject?.path}
+      />
+    </div>
+  )
+}

--- a/frontend/src/features/presence/PresencePage.tsx
+++ b/frontend/src/features/presence/PresencePage.tsx
@@ -1,11 +1,11 @@
 import { useState, useCallback, useEffect } from 'react'
-import { Radio, Plug, Trash2 } from 'lucide-react'
+import { Radio, Plug, Unplug, Trash2 } from 'lucide-react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { RefreshButton } from '@/components/shared/RefreshButton'
 import { PresenceCard } from './PresenceCard'
 import { ConnectDialog } from './ConnectDialog'
-import { fetchPresenceSessions, removeSession, clearAllSessions } from './api'
+import { fetchPresenceSessions, removeSession, clearAllSessions, fetchPresenceHooks } from './api'
 import { usePresenceWebSocket } from '@/hooks/usePresenceWebSocket'
 import { useProjectContext } from '@/contexts/ProjectContext'
 import type { PresenceSession } from '@/types/presence'
@@ -26,7 +26,17 @@ export function PresencePage() {
   const [sessions, setSessions] = useState<Map<string, PresenceSession>>(new Map())
   const [loading, setLoading] = useState(true)
   const [connectOpen, setConnectOpen] = useState(false)
+  const [hooksConnected, setHooksConnected] = useState(false)
   const { activeProject } = useProjectContext()
+
+  const checkHooksStatus = useCallback(async () => {
+    try {
+      const hooks = await fetchPresenceHooks()
+      setHooksConnected(hooks.length > 0)
+    } catch {
+      // Ignore
+    }
+  }, [])
 
   const loadSessions = useCallback(async () => {
     setLoading(true)
@@ -45,7 +55,8 @@ export function PresencePage() {
 
   useEffect(() => {
     loadSessions()
-  }, [loadSessions])
+    checkHooksStatus()
+  }, [loadSessions, checkHooksStatus])
 
   const onSessionUpdate = useCallback((session: PresenceSession) => {
     setSessions((prev) => {
@@ -135,9 +146,22 @@ export function PresencePage() {
             </span>
           </div>
           <RefreshButton onClick={loadSessions} loading={loading} />
-          <Button variant="outline" size="sm" onClick={() => setConnectOpen(true)}>
-            <Plug className="h-4 w-4 mr-1" />
-            Connect to Deck
+          <Button
+            variant={hooksConnected ? 'outline' : 'default'}
+            size="sm"
+            onClick={() => setConnectOpen(true)}
+          >
+            {hooksConnected ? (
+              <>
+                <Unplug className="h-4 w-4 mr-1" />
+                Connected
+              </>
+            ) : (
+              <>
+                <Plug className="h-4 w-4 mr-1" />
+                Connect to Deck
+              </>
+            )}
           </Button>
         </div>
       </div>
@@ -217,7 +241,10 @@ export function PresencePage() {
       {/* Connect Dialog */}
       <ConnectDialog
         open={connectOpen}
-        onOpenChange={setConnectOpen}
+        onOpenChange={(open) => {
+          setConnectOpen(open)
+          if (!open) checkHooksStatus()
+        }}
         projectPath={activeProject?.path}
       />
     </div>

--- a/frontend/src/features/presence/api.ts
+++ b/frontend/src/features/presence/api.ts
@@ -1,7 +1,21 @@
 import { apiClient } from '@/lib/api'
 import type { PresenceSessionList, PresenceSession, PresenceConfigSnippet } from '@/types/presence'
+import type { Hook } from '@/types/hooks'
 
 const BASE = 'presence'
+
+export function buildPresenceEventsUrl(): string {
+  return `${window.location.origin}/api/v1/${BASE}/events`
+}
+
+export async function fetchPresenceHooks(projectPath?: string): Promise<Hook[]> {
+  const params = projectPath ? `?project_path=${encodeURIComponent(projectPath)}` : ''
+  const res = await apiClient<{ hooks: Hook[] }>(`hooks${params}`)
+  const eventsUrl = buildPresenceEventsUrl()
+  return res.hooks.filter(
+    (h) => h.type === 'http' && h.url === eventsUrl
+  )
+}
 
 export async function fetchPresenceSessions(): Promise<PresenceSessionList> {
   return apiClient<PresenceSessionList>(`${BASE}/sessions`)

--- a/frontend/src/features/presence/api.ts
+++ b/frontend/src/features/presence/api.ts
@@ -1,0 +1,37 @@
+import { apiClient } from '@/lib/api'
+import type { PresenceSessionList, PresenceSession, PresenceConfigSnippet } from '@/types/presence'
+
+const BASE = 'presence'
+
+export async function fetchPresenceSessions(): Promise<PresenceSessionList> {
+  return apiClient<PresenceSessionList>(`${BASE}/sessions`)
+}
+
+export async function updateSessionLabel(sessionId: string, label: string): Promise<PresenceSession> {
+  return apiClient<PresenceSession>(`${BASE}/sessions/${encodeURIComponent(sessionId)}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ label }),
+  })
+}
+
+export async function removeSession(sessionId: string): Promise<void> {
+  await apiClient<Record<string, never>>(`${BASE}/sessions/${encodeURIComponent(sessionId)}`, {
+    method: 'DELETE',
+  })
+}
+
+export async function clearAllSessions(): Promise<void> {
+  await apiClient<Record<string, never>>(`${BASE}/sessions`, {
+    method: 'DELETE',
+  })
+}
+
+export async function fetchConfigSnippet(): Promise<PresenceConfigSnippet> {
+  return apiClient<PresenceConfigSnippet>(`${BASE}/config-snippet`)
+}
+
+export function buildPresenceWsUrl(): string {
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+  const host = window.location.host
+  return `${protocol}//${host}/api/v1/${BASE}/ws`
+}

--- a/frontend/src/hooks/usePresenceWebSocket.ts
+++ b/frontend/src/hooks/usePresenceWebSocket.ts
@@ -1,0 +1,98 @@
+import { useEffect, useRef, useState, useCallback } from 'react'
+import type { PresenceSession, PresenceWsMessage } from '@/types/presence'
+import { buildPresenceWsUrl } from '@/features/presence/api'
+
+interface UsePresenceWebSocketOptions {
+  onSessionUpdate: (session: PresenceSession) => void
+  onSessionRemove: (sessionId: string) => void
+  onSessionsCleared?: () => void
+  enabled: boolean
+}
+
+export function usePresenceWebSocket(options: UsePresenceWebSocketOptions) {
+  const { onSessionUpdate, onSessionRemove, onSessionsCleared, enabled } = options
+  const [connected, setConnected] = useState(false)
+  const [reconnecting, setReconnecting] = useState(false)
+  const wsRef = useRef<WebSocket | null>(null)
+  const backoffRef = useRef(1000)
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const connect = useCallback(() => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) return
+
+    const url = buildPresenceWsUrl()
+    const ws = new WebSocket(url)
+    wsRef.current = ws
+
+    ws.onopen = () => {
+      setConnected(true)
+      setReconnecting(false)
+      backoffRef.current = 1000
+    }
+
+    ws.onmessage = (event) => {
+      try {
+        const msg: PresenceWsMessage = JSON.parse(event.data)
+        if (msg.type === 'session_update') {
+          onSessionUpdate(msg.session)
+        } else if (msg.type === 'session_remove') {
+          onSessionRemove(msg.session_id)
+        } else if (msg.type === 'sessions_cleared') {
+          onSessionsCleared?.()
+        }
+      } catch {
+        // Ignore non-JSON messages
+      }
+    }
+
+    ws.onclose = () => {
+      setConnected(false)
+      wsRef.current = null
+    }
+
+    ws.onerror = () => {
+      // onclose will fire after onerror
+    }
+  }, [onSessionUpdate, onSessionRemove, onSessionsCleared])
+
+  useEffect(() => {
+    if (!enabled) return
+
+    connect()
+
+    return () => {
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current)
+        reconnectTimerRef.current = null
+      }
+      if (wsRef.current) {
+        wsRef.current.close()
+        wsRef.current = null
+      }
+      setConnected(false)
+      setReconnecting(false)
+    }
+  }, [enabled, connect])
+
+  // Reconnection logic in a separate effect watching `connected`
+  useEffect(() => {
+    if (!enabled || connected) return
+
+    // Set reconnecting state and schedule reconnect
+    setReconnecting(true)
+    const delay = Math.min(backoffRef.current, 30000)
+    reconnectTimerRef.current = setTimeout(() => {
+      backoffRef.current = delay * 2
+      connect()
+    }, delay)
+
+    return () => {
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current)
+        reconnectTimerRef.current = null
+      }
+    }
+  }, [enabled, connected, connect])
+
+  return { connected, reconnecting }
+}

--- a/frontend/src/hooks/useSystemStatus.ts
+++ b/frontend/src/hooks/useSystemStatus.ts
@@ -1,0 +1,54 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { apiClient } from '@/lib/api'
+import { usePresenceWebSocket } from '@/hooks/usePresenceWebSocket'
+import type { SystemStatusResponse } from '@/types/status'
+
+interface SystemStatus {
+  claudeCodeVersion: string | null
+  activeSessions: number
+}
+
+function parseStatus(res: SystemStatusResponse): SystemStatus {
+  return {
+    claudeCodeVersion: res.claude_code_version,
+    activeSessions: res.active_sessions,
+  }
+}
+
+const DEBOUNCE_MS = 500
+
+export function useSystemStatus() {
+  const [status, setStatus] = useState<SystemStatus | null>(null)
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const fetchStatus = useCallback(() => {
+    apiClient<SystemStatusResponse>('status').then((res) => {
+      setStatus(parseStatus(res))
+    }).catch(() => { /* badges just won't show */ })
+  }, [])
+
+  const debouncedFetch = useCallback(() => {
+    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current)
+    debounceTimerRef.current = setTimeout(fetchStatus, DEBOUNCE_MS)
+  }, [fetchStatus])
+
+  const onSessionUpdate = useCallback(() => debouncedFetch(), [debouncedFetch])
+  const onSessionRemove = useCallback(() => debouncedFetch(), [debouncedFetch])
+  const onSessionsCleared = useCallback(() => { debouncedFetch() }, [debouncedFetch])
+
+  usePresenceWebSocket({
+    onSessionUpdate,
+    onSessionRemove,
+    onSessionsCleared,
+    enabled: true,
+  })
+
+  useEffect(() => {
+    fetchStatus()
+    return () => {
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current)
+    }
+  }, [fetchStatus])
+
+  return status
+}

--- a/frontend/src/types/hooks.ts
+++ b/frontend/src/types/hooks.ts
@@ -14,7 +14,7 @@ export type HookEvent =
   | "SubagentStop"
   | "PreCompact";
 
-export type HookType = "command" | "prompt" | "agent";
+export type HookType = "command" | "prompt" | "agent" | "http";
 
 export interface Hook {
   id: string;
@@ -28,6 +28,9 @@ export interface Hook {
   statusMessage?: string;  // Custom spinner message
   once?: boolean;  // Run only once per session
   timeout?: number;
+  url?: string;
+  headers?: Record<string, string>;
+  allowedEnvVars?: string[];
   scope: "user" | "project";
 }
 
@@ -42,6 +45,9 @@ export interface HookCreate {
   statusMessage?: string;
   once?: boolean;
   timeout?: number;
+  url?: string;
+  headers?: Record<string, string>;
+  allowedEnvVars?: string[];
   scope: "user" | "project";
 }
 
@@ -56,6 +62,9 @@ export interface HookUpdate {
   statusMessage?: string;
   once?: boolean;
   timeout?: number;
+  url?: string;
+  headers?: Record<string, string>;
+  allowedEnvVars?: string[];
 }
 
 export interface HookListResponse {
@@ -203,6 +212,7 @@ export interface HookTemplate {
   statusMessage?: string;
   once?: boolean;
   timeout?: number;
+  url?: string;
 }
 
 export const HOOK_TEMPLATES: HookTemplate[] = [
@@ -267,5 +277,12 @@ export const HOOK_TEMPLATES: HookTemplate[] = [
     prompt: "Summarize the key accomplishments and changes made during this session.",
     model: "haiku",
     once: true,
+  },
+  {
+    name: "Presence Dashboard Logger",
+    description: "Send events to Presence Dashboard via HTTP hook",
+    event: "PostToolUse",
+    type: "http",
+    url: "http://localhost:8000/api/v1/presence/events",
   },
 ];

--- a/frontend/src/types/presence.ts
+++ b/frontend/src/types/presence.ts
@@ -1,0 +1,34 @@
+export interface PresenceSession {
+  session_id: string
+  label?: string
+  project_path?: string
+  status: 'active' | 'idle' | 'error' | 'stopped'
+  last_narrative?: string
+  last_narrative_at?: string
+  modified_files?: string[]
+  last_command?: string
+  last_command_exit?: number | null
+  activity_buckets?: number[]
+  total_events: number
+  error_count: number
+  started_at: string
+  last_event_at: string
+  ended_at?: string
+}
+
+export interface PresenceSessionList {
+  sessions: PresenceSession[]
+  total: number
+  active: number
+  error: number
+}
+
+export type PresenceWsMessage =
+  | { type: 'session_update'; session: PresenceSession }
+  | { type: 'session_remove'; session_id: string }
+  | { type: 'sessions_cleared' }
+
+export interface PresenceConfigSnippet {
+  snippet: Record<string, unknown>
+  instructions: string
+}

--- a/frontend/src/types/presence.ts
+++ b/frontend/src/types/presence.ts
@@ -3,6 +3,7 @@ export interface PresenceSession {
   label?: string
   project_path?: string
   status: 'active' | 'idle' | 'error' | 'stopped'
+  status_text?: string
   last_narrative?: string
   last_narrative_at?: string
   modified_files?: string[]

--- a/frontend/src/types/presence.ts
+++ b/frontend/src/types/presence.ts
@@ -1,3 +1,8 @@
+export interface FileChange {
+  path: string
+  op: 'created' | 'modified'
+}
+
 export interface PresenceSession {
   session_id: string
   label?: string
@@ -6,7 +11,8 @@ export interface PresenceSession {
   status_text?: string
   last_narrative?: string
   last_narrative_at?: string
-  modified_files?: string[]
+  modified_files?: (string | FileChange)[]
+  last_user_prompt?: string
   last_command?: string
   last_command_exit?: number | null
   activity_buckets?: number[]

--- a/frontend/src/types/status.ts
+++ b/frontend/src/types/status.ts
@@ -1,0 +1,4 @@
+export interface SystemStatusResponse {
+  claude_code_version: string | null
+  active_sessions: number
+}


### PR DESCRIPTION
## Summary

- **Presence Dashboard**: New top-level page (`/presence`) that receives webhook events from Claude Code HTTP hooks and displays live session cards updated in real-time via WebSocket
- **HTTP Hook Support**: Extended the existing hooks system to support `type: "http"` hooks with `url`, `headers`, and `allowedEnvVars` fields (fixes validation bug that only allowed "command"/"prompt")
- **ConnectDialog**: Auto-setup mode creates HTTP hooks via the existing hooks API; manual mode shows a copy-paste JSON snippet for `~/.claude/settings.json`

### Architecture
```
CC Session → POST /api/v1/presence/events → Store in DB + Broadcast via WS
Browser    ← WS /api/v1/presence/ws       ← Real-time session card updates
```

### New files (9)
| File | Purpose |
|------|---------|
| `backend/app/api/v1/presence.py` | Webhook receiver + REST + WebSocket endpoints |
| `backend/app/services/presence_service.py` | Event processing, session aggregation, ConnectionManager |
| `frontend/src/types/presence.ts` | TypeScript interfaces |
| `frontend/src/features/presence/api.ts` | REST + WebSocket URL helpers |
| `frontend/src/hooks/usePresenceWebSocket.ts` | WebSocket hook with auto-reconnect |
| `frontend/src/features/presence/PresencePage.tsx` | Main page with stats + session grid |
| `frontend/src/features/presence/PresenceCard.tsx` | Session card (status, narrative, files, commands, sparkline) |
| `frontend/src/features/presence/ActivitySparkline.tsx` | Mini recharts bar chart |
| `frontend/src/features/presence/ConnectDialog.tsx` | Setup dialog (auto + manual modes) |

### Modified files (9)
| File | Changes |
|------|---------|
| `backend/app/models/database.py` | Add PresenceEvent + PresenceSession ORM models |
| `backend/app/models/schemas.py` | Add presence Pydantic schemas + HTTP hook fields |
| `backend/app/api/v1/router.py` | Register presence router |
| `backend/app/api/v1/hooks.py` | Fix type validation (add "agent", "http") + HTTP validation |
| `backend/app/services/hook_service.py` | Read/write url, headers, allowedEnvVars for HTTP hooks |
| `frontend/src/types/hooks.ts` | Add "http" HookType + HTTP fields + Presence template |
| `frontend/src/App.tsx` | Add `/presence` route |
| `frontend/src/components/layout/Sidebar.tsx` | Add Presence nav entry |
| `frontend/eslint.config.js` | Downgrade set-state-in-effect to warning |

## Test plan

- [ ] Backend: POST test events to `/api/v1/presence/events`, verify sessions appear via GET `/api/v1/presence/sessions`
- [ ] Frontend: Navigate to `/presence`, verify empty state with "Connect to Deck" CTA
- [ ] ConnectDialog: Click "Connect to Deck", verify auto-setup creates HTTP hooks
- [ ] Live updates: POST events while on `/presence`, verify cards update in real-time via WebSocket
- [ ] Session cards: Verify status dots, narratives, file badges, commands, and sparklines render correctly
- [ ] Existing features: Verify `/hooks`, `/sessions`, `/cc-bridge` still work correctly