### PR TITLE
fix(dev.sh): clean up orphans on Ctrl-C and add --host flag

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -7,6 +7,45 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
+HOST=""
+
+usage() {
+    cat <<EOF
+Usage: $0 [--host <host>]
+
+Options:
+  --host <host>   Bind both backend and frontend to the given host (e.g. 0.0.0.0)
+  -h, --help      Show this help message
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --host)
+            if [ -z "${2:-}" ]; then
+                echo "Error: --host requires a value."
+                usage
+                exit 1
+            fi
+            HOST="$2"
+            shift 2
+            ;;
+        --host=*)
+            HOST="${1#*=}"
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
 echo "Starting Claude Deck development servers..."
 
 # Check if backend venv exists
@@ -23,37 +62,74 @@ if [ ! -d "$PROJECT_ROOT/frontend/node_modules" ]; then
     exit 1
 fi
 
-# Function to cleanup on exit
-cleanup() {
-    echo ""
-    echo "Shutting down servers..."
-    kill $BACKEND_PID 2>/dev/null || true
-    kill $FRONTEND_PID 2>/dev/null || true
-    exit 0
+BACKEND_PID=""
+FRONTEND_PID=""
+CLEANED_UP=0
+
+# Kill a process and its entire descendant tree
+kill_tree() {
+    local pid="$1"
+    [ -z "$pid" ] && return 0
+    # Collect descendants (children, grandchildren, ...)
+    local pids="$pid"
+    local frontier="$pid"
+    while [ -n "$frontier" ]; do
+        local next
+        next="$(pgrep -P $frontier 2>/dev/null | tr '\n' ' ')"
+        [ -z "$next" ] && break
+        pids="$pids $next"
+        frontier="$next"
+    done
+    kill -TERM $pids 2>/dev/null || true
+    # Give them a moment, then force-kill anything left
+    sleep 1
+    kill -KILL $pids 2>/dev/null || true
 }
 
-trap cleanup SIGINT SIGTERM
+cleanup() {
+    [ "$CLEANED_UP" -eq 1 ] && return
+    CLEANED_UP=1
+    echo ""
+    echo "Shutting down servers..."
+    kill_tree "$BACKEND_PID"
+    kill_tree "$FRONTEND_PID"
+    wait 2>/dev/null || true
+}
+
+trap 'cleanup; exit 130' SIGINT
+trap 'cleanup; exit 143' SIGTERM
+trap cleanup EXIT
+
+BACKEND_HOST_ARGS=()
+FRONTEND_HOST_ARGS=()
+if [ -n "$HOST" ]; then
+    BACKEND_HOST_ARGS=(--host "$HOST")
+    FRONTEND_HOST_ARGS=(-- --host "$HOST")
+    echo "Binding servers to host: $HOST"
+fi
 
 # Start backend
-echo "Starting backend server on http://localhost:8000..."
+BACKEND_DISPLAY_HOST="${HOST:-localhost}"
+echo "Starting backend server on http://${BACKEND_DISPLAY_HOST}:8000..."
 cd "$PROJECT_ROOT/backend"
 source venv/bin/activate
-uvicorn app.main:app --reload --port 8000 &
+uvicorn app.main:app --reload --port 8000 "${BACKEND_HOST_ARGS[@]}" &
 BACKEND_PID=$!
 
 # Start frontend
-echo "Starting frontend server on http://localhost:5173..."
+echo "Starting frontend server on http://${BACKEND_DISPLAY_HOST}:5173..."
 cd "$PROJECT_ROOT/frontend"
-npm run dev &
+npm run dev "${FRONTEND_HOST_ARGS[@]}" &
 FRONTEND_PID=$!
 
 echo ""
 echo "Development servers started!"
-echo "  - Backend:  http://localhost:8000"
-echo "  - Frontend: http://localhost:5173"
-echo "  - API Docs: http://localhost:8000/docs"
+echo "  - Backend:  http://${BACKEND_DISPLAY_HOST}:8000"
+echo "  - Frontend: http://${BACKEND_DISPLAY_HOST}:5173"
+echo "  - API Docs: http://${BACKEND_DISPLAY_HOST}:8000/docs"
 echo ""
 echo "Press Ctrl+C to stop all servers."
 
-# Wait for both processes
-wait
+# Wait for either process to exit, then clean up the other
+wait -n 2>/dev/null || true
+cleanup


### PR DESCRIPTION
Closes #102

## Summary
- Kill the full descendant tree on SIGINT/SIGTERM/EXIT (TERM → 1s grace → KILL). Previously `kill $BACKEND_PID $FRONTEND_PID` missed uvicorn's reloader worker and vite, leaving orphans bound to 8000/5173.
- Tear down the surviving server if either process exits, and guard cleanup against running twice.
- Accept `--host <addr>` (or `--host=<addr>`) and forward it to both `uvicorn --host` and `vite -- --host`, so the dev environment can be reached from another machine on the LAN/tailnet.

## Test plan
- [x] `./scripts/dev.sh`, Ctrl-C → `lsof -i :8000 -i :5173` shows both ports free, no leftover `uvicorn`/`vite`/`npm` processes.
- [x] `./scripts/dev.sh --host 0.0.0.0` binds both servers to all interfaces; reachable from another host in the network.
- [x] `./scripts/dev.sh --help` prints usage; unknown flag exits non-zero.
- [x] Killing the backend manually causes the frontend to be cleaned up (and vice versa).