### PR TITLE
feat(settings): close settings editor gaps vs latest docs

### DIFF
--- a/frontend/src/features/config/settings/SettingsEditor.tsx
+++ b/frontend/src/features/config/settings/SettingsEditor.tsx
@@ -32,6 +32,9 @@ import { EnvVarsCard } from './cards/EnvVarsCard'
 import { HooksSecurityCard } from './cards/HooksSecurityCard'
 import { HookEventEditorCard } from './cards/HookEventEditorCard'
 import { AdvancedCard } from './cards/AdvancedCard'
+import { IdeCard } from './cards/IdeCard'
+import { WorktreeCard } from './cards/WorktreeCard'
+import { ManagedPolicyCard } from './cards/ManagedPolicyCard'
 
 interface SettingsEditorProps {
   onSave?: () => void
@@ -219,22 +222,27 @@ export function SettingsEditor({ onSave }: SettingsEditorProps) {
         </div>
       )}
 
-      <div className="grid gap-6">
-        <AuthenticationCard {...cardProps} />
-        <GeneralCard {...cardProps} />
-        <MemoryCard {...cardProps} />
-        <SandboxCard {...cardProps} />
-        <PermissionsCard {...cardProps} />
-        <AutoModeCard {...cardProps} />
-        <McpServersCard {...cardProps} />
-        <PluginManagementCard {...cardProps} />
-        <AttributionCard {...cardProps} />
-        <UiCard {...cardProps} />
-        <EnvVarsCard {...cardProps} />
-        <HookEventEditorCard {...cardProps} />
-        <HooksSecurityCard {...cardProps} />
-        <AdvancedCard {...cardProps} />
-      </div>
+      <fieldset disabled={isManaged} className="contents">
+        <div className="grid gap-6">
+          <AuthenticationCard {...cardProps} />
+          <GeneralCard {...cardProps} />
+          <IdeCard {...cardProps} />
+          <MemoryCard {...cardProps} />
+          <SandboxCard {...cardProps} />
+          <PermissionsCard {...cardProps} />
+          <AutoModeCard {...cardProps} />
+          <McpServersCard {...cardProps} />
+          <PluginManagementCard {...cardProps} />
+          <AttributionCard {...cardProps} />
+          <UiCard {...cardProps} />
+          <EnvVarsCard {...cardProps} />
+          <HookEventEditorCard {...cardProps} />
+          <HooksSecurityCard {...cardProps} />
+          <WorktreeCard {...cardProps} />
+          <AdvancedCard {...cardProps} />
+          <ManagedPolicyCard {...cardProps} />
+        </div>
+      </fieldset>
 
       {/* Pattern Fix Confirmation Dialog */}
       <AlertDialog open={showFixDialog} onOpenChange={setShowFixDialog}>

--- a/frontend/src/features/config/settings/cards/AdvancedCard.tsx
+++ b/frontend/src/features/config/settings/cards/AdvancedCard.tsx
@@ -1,7 +1,7 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
 import { TextSetting, NumberSetting, SelectSetting, SwitchSetting, ListEditor } from '../field-components'
-import { TEAMMATE_MODE_OPTIONS } from '../constants'
+import { SPINNER_VERBS_MODE_OPTIONS, TEAMMATE_MODE_OPTIONS } from '../constants'
 import type { SettingsCardProps } from '../types'
 
 export function AdvancedCard({ getSetting, updateSetting }: SettingsCardProps) {
@@ -92,6 +92,66 @@ export function AdvancedCard({ getSetting, updateSetting }: SettingsCardProps) {
           onChange={(v) => updateSetting('agent', v)}
           placeholder="e.g., my-custom-agent"
         />
+
+        <TextSetting
+          id="minimumVersion"
+          label="Minimum Version"
+          description="Refuse to run if the Claude Code binary is older than this semver."
+          value={getSetting<string>('minimumVersion', '')}
+          onChange={(v) => updateSetting('minimumVersion', v)}
+          placeholder="e.g., 1.5.0"
+        />
+
+        <SwitchSetting
+          label="Disable Deep Link Registration"
+          description="Skip registering the claude:// URL scheme handler"
+          checked={getSetting<boolean>('disableDeepLinkRegistration', false)}
+          onCheckedChange={(v) => updateSetting('disableDeepLinkRegistration', v)}
+        />
+
+        <div className="grid gap-2 rounded border p-3">
+          <Label>Spinner Tips Override</Label>
+          <p className="text-sm text-muted-foreground">
+            Replace or extend the default loading-spinner tips.
+          </p>
+          <SwitchSetting
+            label="Exclude Default Tips"
+            description="Only show the tips listed below"
+            checked={getSetting<boolean>('spinnerTipsOverride.excludeDefault', false)}
+            onCheckedChange={(v) => updateSetting('spinnerTipsOverride.excludeDefault', v)}
+          />
+          <div className="grid gap-2">
+            <Label>Custom Tips</Label>
+            <ListEditor
+              value={getSetting<string[]>('spinnerTipsOverride.tips', [])}
+              onChange={(v) => updateSetting('spinnerTipsOverride.tips', v)}
+              placeholder="Add a tip..."
+            />
+          </div>
+        </div>
+
+        <div className="grid gap-2 rounded border p-3">
+          <Label>Spinner Verbs</Label>
+          <p className="text-sm text-muted-foreground">
+            Customize the verbs shown next to the spinner (e.g., "Thinking...", "Cooking...").
+          </p>
+          <SelectSetting
+            id="spinnerVerbsMode"
+            label="Mode"
+            value={getSetting<string>('spinnerVerbs.mode', '')}
+            onValueChange={(v) => updateSetting('spinnerVerbs.mode', v)}
+            placeholder="Default"
+            options={SPINNER_VERBS_MODE_OPTIONS}
+          />
+          <div className="grid gap-2">
+            <Label>Verbs</Label>
+            <ListEditor
+              value={getSetting<string[]>('spinnerVerbs.verbs', [])}
+              onChange={(v) => updateSetting('spinnerVerbs.verbs', v)}
+              placeholder="e.g., Pondering"
+            />
+          </div>
+        </div>
       </CardContent>
     </Card>
   )

--- a/frontend/src/features/config/settings/cards/AuthenticationCard.tsx
+++ b/frontend/src/features/config/settings/cards/AuthenticationCard.tsx
@@ -4,31 +4,64 @@ import { LOGIN_METHOD_OPTIONS } from '../constants'
 import type { SettingsCardProps } from '../types'
 
 export function AuthenticationCard({ getSetting, updateSetting, scope }: SettingsCardProps) {
-  if (scope !== 'managed') return null
+  const isManaged = scope === 'managed'
 
   return (
     <Card>
       <CardHeader>
         <CardTitle>Authentication</CardTitle>
-        <CardDescription>Restrict login method and organization (managed settings only)</CardDescription>
+        <CardDescription>
+          Login restrictions (managed) and AWS/OTel credential helpers (Bedrock)
+        </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <SelectSetting
-          id="forceLoginMethod"
-          label="Force Login Method"
-          description="Restrict which authentication method users must use."
-          value={getSetting<string>('forceLoginMethod', '')}
-          onValueChange={(v) => updateSetting('forceLoginMethod', v)}
-          placeholder="Select login method"
-          options={LOGIN_METHOD_OPTIONS}
-        />
+        {isManaged && (
+          <>
+            <SelectSetting
+              id="forceLoginMethod"
+              label="Force Login Method"
+              description="Restrict which authentication method users must use."
+              value={getSetting<string>('forceLoginMethod', '')}
+              onValueChange={(v) => updateSetting('forceLoginMethod', v)}
+              placeholder="Select login method"
+              options={LOGIN_METHOD_OPTIONS}
+            />
+            <TextSetting
+              id="forceLoginOrgUUID"
+              label="Force Login Org UUID"
+              description="Restrict login to a specific organization UUID."
+              value={getSetting<string>('forceLoginOrgUUID', '')}
+              onChange={(v) => updateSetting('forceLoginOrgUUID', v)}
+              placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+            />
+          </>
+        )}
+
         <TextSetting
-          id="forceLoginOrgUUID"
-          label="Force Login Org UUID"
-          description="Restrict login to a specific organization UUID."
-          value={getSetting<string>('forceLoginOrgUUID', '')}
-          onChange={(v) => updateSetting('forceLoginOrgUUID', v)}
-          placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+          id="awsAuthRefresh"
+          label="AWS Auth Refresh Script"
+          description="Script (via /bin/sh) that refreshes AWS credentials before each request. Used for Bedrock."
+          value={getSetting<string>('awsAuthRefresh', '')}
+          onChange={(v) => updateSetting('awsAuthRefresh', v)}
+          placeholder="/bin/refresh-aws-auth.sh"
+        />
+
+        <TextSetting
+          id="awsCredentialExport"
+          label="AWS Credential Export Script"
+          description="Script that prints AWS credentials as JSON to stdout (for SSO/federation flows)."
+          value={getSetting<string>('awsCredentialExport', '')}
+          onChange={(v) => updateSetting('awsCredentialExport', v)}
+          placeholder="/bin/aws-credentials.sh"
+        />
+
+        <TextSetting
+          id="otelHeadersHelper"
+          label="OTel Headers Helper"
+          description="Script that prints headers for OpenTelemetry exporters as JSON."
+          value={getSetting<string>('otelHeadersHelper', '')}
+          onChange={(v) => updateSetting('otelHeadersHelper', v)}
+          placeholder="/bin/otel-headers.sh"
         />
       </CardContent>
     </Card>

--- a/frontend/src/features/config/settings/cards/IdeCard.tsx
+++ b/frontend/src/features/config/settings/cards/IdeCard.tsx
@@ -1,0 +1,54 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { SelectSetting, SwitchSetting } from '../field-components'
+import { EDITOR_MODE_OPTIONS } from '../constants'
+import type { SettingsCardProps } from '../types'
+
+export function IdeCard({ getSetting, updateSetting }: SettingsCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>IDE & Editor</CardTitle>
+        <CardDescription>Editor input mode and IDE extension preferences</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <SelectSetting
+          id="editorMode"
+          label="Editor Mode"
+          description="Input handling in the prompt editor — normal or vim motions."
+          value={getSetting<string>('editorMode', '')}
+          onValueChange={(v) => updateSetting('editorMode', v)}
+          placeholder="Normal"
+          options={EDITOR_MODE_OPTIONS}
+        />
+
+        <SwitchSetting
+          label="Auto Connect IDE"
+          description="Automatically connect to a running IDE when Claude Code starts"
+          checked={getSetting<boolean>('autoConnectIde', false)}
+          onCheckedChange={(v) => updateSetting('autoConnectIde', v)}
+        />
+
+        <SwitchSetting
+          label="Auto Install IDE Extension"
+          description="Install the Claude Code IDE extension on first launch"
+          checked={getSetting<boolean>('autoInstallIdeExtension', true)}
+          onCheckedChange={(v) => updateSetting('autoInstallIdeExtension', v)}
+        />
+
+        <SwitchSetting
+          label="Auto Scroll"
+          description="Automatically scroll to new output as it streams"
+          checked={getSetting<boolean>('autoScrollEnabled', true)}
+          onCheckedChange={(v) => updateSetting('autoScrollEnabled', v)}
+        />
+
+        <SwitchSetting
+          label="External Editor Context"
+          description="Include the active IDE file as context when opening an external editor"
+          checked={getSetting<boolean>('externalEditorContext', false)}
+          onCheckedChange={(v) => updateSetting('externalEditorContext', v)}
+        />
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/features/config/settings/cards/ManagedPolicyCard.tsx
+++ b/frontend/src/features/config/settings/cards/ManagedPolicyCard.tsx
@@ -1,0 +1,109 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Label } from '@/components/ui/label'
+import { ListEditor, SwitchSetting } from '../field-components'
+import type { SettingsCardProps } from '../types'
+
+/**
+ * Managed-only policy controls. Only rendered when viewing the managed scope —
+ * the editor wraps the whole grid in a disabled fieldset, so fields surface as
+ * read-only. Claude Deck is not a policy authoring tool; this card exists so
+ * users can see what policy their org has pushed.
+ */
+export function ManagedPolicyCard({ getSetting, scope }: SettingsCardProps) {
+  if (scope !== 'managed') return null
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Managed Policy</CardTitle>
+        <CardDescription>
+          Controls set by your organization's managed settings. Displayed here for visibility.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <SwitchSetting
+          label="Allow Managed Hooks Only"
+          description="Reject user/project hooks — only hooks defined in managed settings run."
+          checked={getSetting<boolean>('allowManagedHooksOnly', false)}
+          onCheckedChange={() => {}}
+        />
+
+        <SwitchSetting
+          label="Allow Managed MCP Servers Only"
+          description="Reject MCP servers that aren't declared in managed settings."
+          checked={getSetting<boolean>('allowManagedMcpServersOnly', false)}
+          onCheckedChange={() => {}}
+        />
+
+        <SwitchSetting
+          label="Allow Managed Permission Rules Only"
+          description="Reject user/project permission rules outside of the managed allow/deny/ask lists."
+          checked={getSetting<boolean>('allowManagedPermissionRulesOnly', false)}
+          onCheckedChange={() => {}}
+        />
+
+        <SwitchSetting
+          label="Disable Skill Shell Execution"
+          description="Block skills from running shell commands."
+          checked={getSetting<boolean>('disableSkillShellExecution', false)}
+          onCheckedChange={() => {}}
+        />
+
+        <SwitchSetting
+          label="Force Remote Settings Refresh"
+          description="Force the client to refresh managed settings from the remote source on every launch."
+          checked={getSetting<boolean>('forceRemoteSettingsRefresh', false)}
+          onCheckedChange={() => {}}
+        />
+
+        <SwitchSetting
+          label="Channels Enabled"
+          description="Enable the channels feature for this deployment."
+          checked={getSetting<boolean>('channelsEnabled', false)}
+          onCheckedChange={() => {}}
+        />
+
+        <div className="grid gap-2">
+          <Label>Allowed Channel Plugins</Label>
+          <p className="text-sm text-muted-foreground">
+            Plugins that may be installed from channels.
+          </p>
+          <ListEditor
+            value={getSetting<string[]>('allowedChannelPlugins', [])}
+            onChange={() => {}}
+          />
+        </div>
+
+        <div className="grid gap-2">
+          <Label>Allowed MCP Servers (managed)</Label>
+          <ListEditor
+            value={getSetting<string[]>('allowedMcpServers', [])}
+            onChange={() => {}}
+          />
+        </div>
+
+        <div className="grid gap-2">
+          <Label>Denied MCP Servers (managed)</Label>
+          <ListEditor
+            value={getSetting<string[]>('deniedMcpServers', [])}
+            onChange={() => {}}
+          />
+        </div>
+
+        <SwitchSetting
+          label="Allow Managed Read Paths Only"
+          description="Sandbox: only allow filesystem read paths defined in managed settings."
+          checked={getSetting<boolean>('sandbox.filesystem.allowManagedReadPathsOnly', false)}
+          onCheckedChange={() => {}}
+        />
+
+        <SwitchSetting
+          label="Allow Managed Domains Only"
+          description="Sandbox: only allow network domains defined in managed settings."
+          checked={getSetting<boolean>('sandbox.network.allowManagedDomainsOnly', false)}
+          onCheckedChange={() => {}}
+        />
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/features/config/settings/cards/PermissionsCard.tsx
+++ b/frontend/src/features/config/settings/cards/PermissionsCard.tsx
@@ -28,6 +28,13 @@ export function PermissionsCard({ getSetting, updateSetting }: SettingsCardProps
           onCheckedChange={(v) => updateSetting('permissions.disableBypassPermissionsMode', v ? 'disable' : '')}
         />
 
+        <SwitchSetting
+          label="Skip Dangerous Mode Permission Prompt"
+          description="Don't prompt when entering bypassPermissions/dangerous mode. Use with caution."
+          checked={getSetting<boolean>('permissions.skipDangerousModePermissionPrompt', false)}
+          onCheckedChange={(v) => updateSetting('permissions.skipDangerousModePermissionPrompt', v)}
+        />
+
         <div className="grid gap-2">
           <Label>Additional Directories</Label>
           <p className="text-sm text-muted-foreground">

--- a/frontend/src/features/config/settings/cards/SandboxCard.tsx
+++ b/frontend/src/features/config/settings/cards/SandboxCard.tsx
@@ -3,7 +3,7 @@ import { Label } from '@/components/ui/label'
 import { SwitchSetting, NumberSetting, ListEditor } from '../field-components'
 import type { SettingsCardProps } from '../types'
 
-export function SandboxCard({ getSetting, updateSetting, scope }: SettingsCardProps) {
+export function SandboxCard({ getSetting, updateSetting }: SettingsCardProps) {
   return (
     <Card>
       <CardHeader>
@@ -16,6 +16,13 @@ export function SandboxCard({ getSetting, updateSetting, scope }: SettingsCardPr
           description="Run commands in an isolated environment"
           checked={getSetting<boolean>('sandbox.enabled', false)}
           onCheckedChange={(v) => updateSetting('sandbox.enabled', v)}
+        />
+
+        <SwitchSetting
+          label="Fail If Unavailable"
+          description="Refuse to run commands when the sandbox is enabled but unavailable on this platform"
+          checked={getSetting<boolean>('sandbox.failIfUnavailable', false)}
+          onCheckedChange={(v) => updateSetting('sandbox.failIfUnavailable', v)}
         />
 
         <SwitchSetting
@@ -39,6 +46,13 @@ export function SandboxCard({ getSetting, updateSetting, scope }: SettingsCardPr
           onCheckedChange={(v) => updateSetting('sandbox.enableWeakerNestedSandbox', v)}
         />
 
+        <SwitchSetting
+          label="Weaker Network Isolation (macOS)"
+          description="Use a looser network isolation policy — needed on some macOS versions where strict isolation breaks DNS."
+          checked={getSetting<boolean>('sandbox.enableWeakerNetworkIsolation', false)}
+          onCheckedChange={(v) => updateSetting('sandbox.enableWeakerNetworkIsolation', v)}
+        />
+
         <div className="grid gap-2">
           <Label>Excluded Commands</Label>
           <p className="text-sm text-muted-foreground">
@@ -59,6 +73,18 @@ export function SandboxCard({ getSetting, updateSetting, scope }: SettingsCardPr
           <ListEditor
             value={getSetting<string[]>('sandbox.network.allowedDomains', [])}
             onChange={(v) => updateSetting('sandbox.network.allowedDomains', v)}
+            placeholder="Add domain..."
+          />
+        </div>
+
+        <div className="grid gap-2">
+          <Label>Denied Domains</Label>
+          <p className="text-sm text-muted-foreground">
+            Network domains explicitly blocked from the sandbox (overrides allowed list)
+          </p>
+          <ListEditor
+            value={getSetting<string[]>('sandbox.network.deniedDomains', [])}
+            onChange={(v) => updateSetting('sandbox.network.deniedDomains', v)}
             placeholder="Add domain..."
           />
         </div>
@@ -87,6 +113,13 @@ export function SandboxCard({ getSetting, updateSetting, scope }: SettingsCardPr
           description="Allow localhost binding in sandbox (macOS only)"
           checked={getSetting<boolean>('sandbox.network.allowLocalBinding', false)}
           onCheckedChange={(v) => updateSetting('sandbox.network.allowLocalBinding', v)}
+        />
+
+        <SwitchSetting
+          label="Allow Mach Lookup (macOS)"
+          description="Allow mach-bootstrap service lookups from inside the sandbox."
+          checked={getSetting<boolean>('sandbox.network.allowMachLookup', false)}
+          onCheckedChange={(v) => updateSetting('sandbox.network.allowMachLookup', v)}
         />
 
         <div className="grid grid-cols-2 gap-4">
@@ -131,22 +164,29 @@ export function SandboxCard({ getSetting, updateSetting, scope }: SettingsCardPr
           />
         </div>
 
-        {scope === 'managed' && (
-          <>
-            <SwitchSetting
-              label="Allow Managed Read Paths Only"
-              description="Only allow filesystem read paths defined in managed settings"
-              checked={getSetting<boolean>('sandbox.filesystem.allowManagedReadPathsOnly', false)}
-              onCheckedChange={(v) => updateSetting('sandbox.filesystem.allowManagedReadPathsOnly', v)}
-            />
-            <SwitchSetting
-              label="Allow Managed Domains Only"
-              description="Only allow network domains defined in managed settings"
-              checked={getSetting<boolean>('sandbox.network.allowManagedDomainsOnly', false)}
-              onCheckedChange={(v) => updateSetting('sandbox.network.allowManagedDomainsOnly', v)}
-            />
-          </>
-        )}
+        <div className="grid gap-2">
+          <Label>Allowed Write Paths</Label>
+          <p className="text-sm text-muted-foreground">
+            Gitignore-style patterns for allowed filesystem write paths
+          </p>
+          <ListEditor
+            value={getSetting<string[]>('sandbox.filesystem.allowWrite', [])}
+            onChange={(v) => updateSetting('sandbox.filesystem.allowWrite', v)}
+            placeholder="e.g., /tmp/**, ./build/**"
+          />
+        </div>
+
+        <div className="grid gap-2">
+          <Label>Denied Write Paths</Label>
+          <p className="text-sm text-muted-foreground">
+            Gitignore-style patterns for blocked filesystem write paths
+          </p>
+          <ListEditor
+            value={getSetting<string[]>('sandbox.filesystem.denyWrite', [])}
+            onChange={(v) => updateSetting('sandbox.filesystem.denyWrite', v)}
+            placeholder="e.g., ~/.ssh/**, /etc/**"
+          />
+        </div>
       </CardContent>
     </Card>
   )

--- a/frontend/src/features/config/settings/cards/UiCard.tsx
+++ b/frontend/src/features/config/settings/cards/UiCard.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { SwitchSetting, TextSetting } from '../field-components'
+import { SelectSetting, SwitchSetting, TextSetting } from '../field-components'
+import { SHELL_OPTIONS, TUI_OPTIONS, VIEW_MODE_OPTIONS } from '../constants'
 import type { SettingsCardProps } from '../types'
 
 export function UiCard({ getSetting, updateSetting }: SettingsCardProps) {
@@ -10,11 +11,83 @@ export function UiCard({ getSetting, updateSetting }: SettingsCardProps) {
         <CardDescription>User interface preferences</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
+        <SelectSetting
+          id="tui"
+          label="Terminal UI Mode"
+          description="Fullscreen takes over the terminal; default inlines with your scrollback."
+          value={getSetting<string>('tui', '')}
+          onValueChange={(v) => updateSetting('tui', v)}
+          placeholder="Default"
+          options={TUI_OPTIONS}
+        />
+
+        <SelectSetting
+          id="viewMode"
+          label="View Mode"
+          description="Verbose shows full tool output; focus hides ambient UI."
+          value={getSetting<string>('viewMode', '')}
+          onValueChange={(v) => updateSetting('viewMode', v)}
+          placeholder="Default"
+          options={VIEW_MODE_OPTIONS}
+        />
+
+        <SelectSetting
+          id="defaultShell"
+          label="Default Shell"
+          description="Shell used for Bash tool invocations."
+          value={getSetting<string>('defaultShell', '')}
+          onValueChange={(v) => updateSetting('defaultShell', v)}
+          placeholder="Auto"
+          options={SHELL_OPTIONS}
+        />
+
         <SwitchSetting
           label="Always Thinking Enabled"
           description="Always show thinking process in responses"
           checked={getSetting<boolean>('alwaysThinkingEnabled', false)}
           onCheckedChange={(v) => updateSetting('alwaysThinkingEnabled', v)}
+        />
+
+        <SwitchSetting
+          label="Show Thinking Summaries"
+          description="Display short summaries of thinking blocks as they stream"
+          checked={getSetting<boolean>('showThinkingSummaries', true)}
+          onCheckedChange={(v) => updateSetting('showThinkingSummaries', v)}
+        />
+
+        <SwitchSetting
+          label="Away Summary"
+          description="Surface a summary when you return to an idle session"
+          checked={getSetting<boolean>('awaySummaryEnabled', false)}
+          onCheckedChange={(v) => updateSetting('awaySummaryEnabled', v)}
+        />
+
+        <SwitchSetting
+          label="Show Clear-Context Prompt on Plan Accept"
+          description="After accepting a plan, prompt to clear conversation context before execution"
+          checked={getSetting<boolean>('showClearContextOnPlanAccept', false)}
+          onCheckedChange={(v) => updateSetting('showClearContextOnPlanAccept', v)}
+        />
+
+        <SwitchSetting
+          label="Use Auto Mode During Plan"
+          description="Allow auto mode to run while planning"
+          checked={getSetting<boolean>('useAutoModeDuringPlan', false)}
+          onCheckedChange={(v) => updateSetting('useAutoModeDuringPlan', v)}
+        />
+
+        <SwitchSetting
+          label="Fast Mode Per-Session Opt-In"
+          description="Require opting into fast mode per session rather than using the last-selected value"
+          checked={getSetting<boolean>('fastModePerSessionOptIn', false)}
+          onCheckedChange={(v) => updateSetting('fastModePerSessionOptIn', v)}
+        />
+
+        <SwitchSetting
+          label="Voice Enabled"
+          description="Enable voice input/output features"
+          checked={getSetting<boolean>('voiceEnabled', false)}
+          onCheckedChange={(v) => updateSetting('voiceEnabled', v)}
         />
 
         <SwitchSetting
@@ -50,6 +123,22 @@ export function UiCard({ getSetting, updateSetting }: SettingsCardProps) {
           description="Reduce UI animations for accessibility"
           checked={getSetting<boolean>('prefersReducedMotion', false)}
           onCheckedChange={(v) => updateSetting('prefersReducedMotion', v)}
+        />
+
+        <TextSetting
+          id="feedbackSurveyRate"
+          label="Feedback Survey Rate"
+          description="Fraction of sessions (0 to 1) that see the feedback survey. 0 disables it."
+          value={String(getSetting<string | number>('feedbackSurveyRate', ''))}
+          onChange={(v) => {
+            if (v === '') {
+              updateSetting('feedbackSurveyRate', null)
+              return
+            }
+            const num = parseFloat(v)
+            updateSetting('feedbackSurveyRate', Number.isFinite(num) ? num : v)
+          }}
+          placeholder="0"
         />
 
         <TextSetting

--- a/frontend/src/features/config/settings/cards/WorktreeCard.tsx
+++ b/frontend/src/features/config/settings/cards/WorktreeCard.tsx
@@ -1,0 +1,35 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Label } from '@/components/ui/label'
+import { ListEditor, SwitchSetting } from '../field-components'
+import type { SettingsCardProps } from '../types'
+
+export function WorktreeCard({ getSetting, updateSetting }: SettingsCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Worktrees</CardTitle>
+        <CardDescription>Behavior when creating git worktrees from Claude Code</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <SwitchSetting
+          label="Symlink Directories"
+          description="Symlink ignored/untracked directories (e.g., node_modules, venv) into new worktrees to save time and disk."
+          checked={getSetting<boolean>('worktree.symlinkDirectories', false)}
+          onCheckedChange={(v) => updateSetting('worktree.symlinkDirectories', v)}
+        />
+
+        <div className="grid gap-2">
+          <Label>Sparse Paths</Label>
+          <p className="text-sm text-muted-foreground">
+            Gitignore-style patterns for paths to check out via sparse-checkout in new worktrees.
+          </p>
+          <ListEditor
+            value={getSetting<string[]>('worktree.sparsePaths', [])}
+            onChange={(v) => updateSetting('worktree.sparsePaths', v)}
+            placeholder="e.g., src/**, docs/**"
+          />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/features/config/settings/constants.ts
+++ b/frontend/src/features/config/settings/constants.ts
@@ -1,4 +1,5 @@
 export const MODEL_OPTIONS = [
+  { value: 'claude-opus-4-7', label: 'Claude Opus 4.7' },
   { value: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
   { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
   { value: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
@@ -56,6 +57,28 @@ export const HOOK_MODEL_OPTIONS = [
   { value: 'haiku', label: 'Haiku' },
   { value: 'sonnet', label: 'Sonnet' },
   { value: 'opus', label: 'Opus' },
+]
+
+export const TUI_OPTIONS = [
+  { value: 'default', label: 'Default' },
+  { value: 'fullscreen', label: 'Fullscreen' },
+]
+
+export const VIEW_MODE_OPTIONS = [
+  { value: 'default', label: 'Default' },
+  { value: 'verbose', label: 'Verbose' },
+  { value: 'focus', label: 'Focus' },
+]
+
+export const EDITOR_MODE_OPTIONS = [
+  { value: 'normal', label: 'Normal' },
+  { value: 'vim', label: 'Vim' },
+]
+
+export const SPINNER_VERBS_MODE_OPTIONS = [
+  { value: 'default', label: 'Default' },
+  { value: 'append', label: 'Append to defaults' },
+  { value: 'replace', label: 'Replace defaults' },
 ]
 
 export const HOOK_EVENT_GROUPS = [


### PR DESCRIPTION
## Summary

Closes #106. Adds UI coverage for ~30 settings keys documented at https://code.claude.com/docs/en/settings that Claude Deck's settings editor was missing, plus a few drift fixes.

**New cards**
- `IdeCard` — `editorMode`, `autoConnectIde`, `autoInstallIdeExtension`, `autoScrollEnabled`, `externalEditorContext`
- `WorktreeCard` — `worktree.symlinkDirectories`, `worktree.sparsePaths`
- `ManagedPolicyCard` — surfaces managed-only policy keys (`allowManagedHooksOnly`, `forceRemoteSettingsRefresh`, `disableSkillShellExecution`, `allowedChannelPlugins`, `channelsEnabled`, `allowedMcpServers`/`deniedMcpServers`, `sandbox.filesystem.allowManagedReadPathsOnly`, `sandbox.network.allowManagedDomainsOnly`, etc.) read-only when viewing the `managed` scope

**Extended cards**
- `UiCard` — `tui`, `viewMode`, `defaultShell`, `showThinkingSummaries`, `awaySummaryEnabled`, `showClearContextOnPlanAccept`, `useAutoModeDuringPlan`, `fastModePerSessionOptIn`, `voiceEnabled`, `feedbackSurveyRate`
- `AdvancedCard` — `minimumVersion`, `disableDeepLinkRegistration`, `spinnerTipsOverride.tips/excludeDefault`, `spinnerVerbs.mode/verbs`
- `AuthenticationCard` — AWS/OTel helpers (`awsAuthRefresh`, `awsCredentialExport`, `otelHeadersHelper`); card now visible at all scopes (managed-only login restrictions still conditional)
- `PermissionsCard` — `permissions.skipDangerousModePermissionPrompt`
- `SandboxCard` — `sandbox.failIfUnavailable`, `sandbox.enableWeakerNetworkIsolation`, `sandbox.network.allowMachLookup`, `sandbox.network.deniedDomains`, `sandbox.filesystem.allowWrite`, `sandbox.filesystem.denyWrite`

**Drift fixes**
- Add `claude-opus-4-7` as the new flagship option in `MODEL_OPTIONS`

**Managed-scope UX**
- The settings grid is now wrapped in `<fieldset disabled={isManaged}>`, so every control under `managed` scope renders visibly but is read-only (inherited HTML semantics — no per-field prop threading). The existing "Read-only" banner is preserved.

## Test plan

- [x] `npm run build` clean
- [x] Verified User scope renders all new fields
- [x] Verified Managed scope renders everything disabled (via a11y snapshot — every input has `disabled` attribute) and shows the new `Managed Policy` card with managed-only keys
- [x] No new console errors on `/config`