### PR TITLE
feat(cc-bridge): suggest configured projects in New Session dialog

### DIFF
--- a/frontend/src/features/cc-bridge/NewSessionDialog.tsx
+++ b/frontend/src/features/cc-bridge/NewSessionDialog.tsx
@@ -16,6 +16,7 @@ import { cn } from '@/lib/utils'
 import { formatTimestamp } from '@/features/usage/utils'
 import { spawnSession } from './api'
 import { useSessionsApi } from '@/hooks/useSessionsApi'
+import { useProjectContext } from '@/contexts/ProjectContext'
 import type { SpawnSessionRequest } from './types'
 import type { SessionSummary } from '@/types/sessions'
 
@@ -46,6 +47,7 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned }: NewSessionDi
   const [loadingSessions, setLoadingSessions] = useState(false)
 
   const { listSessions } = useSessionsApi()
+  const { projects } = useProjectContext()
 
   // Fetch sessions when switching to resume mode
   useEffect(() => {
@@ -148,10 +150,24 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned }: NewSessionDi
               <Label htmlFor="session-directory">Project Directory</Label>
               <Input
                 id="session-directory"
+                list="session-directory-projects"
                 value={directory}
                 onChange={(e) => setDirectory(e.target.value)}
                 placeholder="/home/user/project"
+                autoComplete="off"
               />
+              {projects.length > 0 && (
+                <>
+                  <datalist id="session-directory-projects">
+                    {projects.map((p) => (
+                      <option key={p.id} value={p.path} label={p.name} />
+                    ))}
+                  </datalist>
+                  <p className="text-xs text-muted-foreground">
+                    Pick from configured projects or type any path.
+                  </p>
+                </>
+              )}
             </div>
           )}
 


### PR DESCRIPTION
Closes #114.

## Summary

Back the Project Directory input in \`NewSessionDialog\` with a native \`<datalist>\` populated from \`useProjectContext()\`. Users get project suggestions (path as value, project name as label) in Plain and Worktree modes while freeform typing still works. When no projects are configured, the field behaves identically to before — no datalist, no helper text.

Zero new dependencies — just an \`<input list>\` / \`<datalist>\` pair.

## Smoke test

Against a real instance (dev server, 4 projects configured):

- Dialog opened in Plain mode → Project Directory rendered as an autocomplete combobox with a dropdown arrow.
- \`document.getElementById('session-directory-projects').options\` returned all 4 project paths with the expected labels.
- Typed freeform \`/home/juan\` → Launch button became enabled (free typing submits).
- Switched to Worktree mode → field retained value and still presents suggestions.
- No console errors, no lint errors.

## Test plan
- [x] Frontend lint clean
- [x] Datalist options match configured projects
- [x] Freeform typing still submits
- [x] Both Plain and Worktree modes show the suggestions
- [x] Resume mode unchanged