### PR TITLE
fix(cc-bridge): stop Resume mode overflowing the New Session dialog

### DIFF
--- a/frontend/src/features/cc-bridge/NewSessionDialog.tsx
+++ b/frontend/src/features/cc-bridge/NewSessionDialog.tsx
@@ -117,7 +117,7 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned }: NewSessionDi
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4">
+        <div className="space-y-4 min-w-0">
           {/* Mode selector */}
           <div className="space-y-1.5">
             <Label>Mode</Label>
@@ -200,21 +200,21 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned }: NewSessionDi
                   No recent sessions found.
                 </div>
               ) : (
-                <div className="max-h-48 overflow-y-auto rounded-md border">
+                <div className="max-h-48 w-full overflow-y-auto rounded-md border">
                   {recentSessions.map((session) => (
                     <button
                       key={session.id}
                       type="button"
                       className={cn(
-                        'w-full text-left px-3 py-2 border-b last:border-b-0 transition-colors',
+                        'block w-full min-w-0 text-left px-3 py-2 border-b last:border-b-0 transition-colors',
                         selectedSession?.id === session.id
                           ? 'border-l-2 border-l-primary bg-primary/5'
                           : 'hover:bg-muted/50'
                       )}
                       onClick={() => setSelectedSession(session)}
                     >
-                      <div className="flex items-center justify-between gap-2">
-                        <span className="text-sm font-medium truncate">
+                      <div className="flex items-center justify-between gap-2 min-w-0">
+                        <span className="text-sm font-medium truncate min-w-0">
                           {session.project_name}
                         </span>
                         <span className="text-xs text-muted-foreground shrink-0">


### PR DESCRIPTION
Closes #116.

## Root cause

The dialog root is rendered as a CSS grid (\`display: grid\`). Grid items default to \`minmax(auto, 1fr)\`, which lets them grow to fit their widest child rather than shrink to the track. With 20 recent sessions and long summaries, the dialog content wrapper grew to **1466px inside a 768px dialog**, pushing the modal off the right edge of the viewport.

## Fix

- \`min-w-0\` on the \`.space-y-4\` content wrapper so the grid item can shrink below intrinsic content width.
- \`min-w-0\` on the inner flex row and truncating span so \`truncate\` actually clamps long strings (flexbox quirk — needs the min-w-0 escape hatch on every ancestor).
- \`block w-full min-w-0\` on the session button.
- \`w-full\` on the list container.

## Verified in the browser

Before the fix (DOM measurement):
- dialog clientWidth: 766, scrollWidth: 1490
- content div: 1466px

After the fix:
- dialog: 766 / 766 (no overflow)
- content div: 718px
- session list: 701px
- full-viewport screenshot shows the dialog centered with ellipsis on long summaries

## Test plan
- [x] Frontend lint clean
- [x] Open dialog → Resume → dialog stays contained at its normal width
- [x] Long summaries ellipsis instead of overflow
- [x] Vertical scroll still works inside the list