### PR TITLE
fix(context): 1M window for Opus 4.7 + align categories with CC /context

### DIFF
--- a/backend/app/services/context_service.py
+++ b/backend/app/services/context_service.py
@@ -25,33 +25,56 @@ from app.models.schemas import (
 from app.utils.path_utils import get_claude_projects_dir, get_project_display_name
 
 
-# Model context window limits (input tokens)
+# Model context window limits (input tokens). Keys are normalized
+# substrings — `_normalize_model` strips dated suffixes before lookup.
 MODEL_CONTEXT_LIMITS: dict[str, int] = {
-    "claude-sonnet-4-5-20250929": 200_000,
+    # Claude 4.7 — 1M window
+    "claude-opus-4-7": 1_000_000,
+    # Claude 4.6
     "claude-opus-4-6": 200_000,
-    "claude-haiku-4-5-20251001": 200_000,
-    "claude-sonnet-4-20250514": 200_000,
-    "claude-opus-4-20250514": 200_000,
-    # Older models
-    "claude-3-5-sonnet-20241022": 200_000,
-    "claude-3-5-haiku-20241022": 200_000,
-    "claude-3-opus-20240229": 200_000,
+    "claude-sonnet-4-6": 1_000_000,  # 1M beta context enabled by default in CC
+    "claude-haiku-4-5": 200_000,
+    # Claude 4.5 and older 4.x
+    "claude-sonnet-4-5": 200_000,
+    "claude-sonnet-4": 200_000,
+    "claude-opus-4": 200_000,
+    # Claude 3.x
+    "claude-3-5-sonnet": 200_000,
+    "claude-3-5-haiku": 200_000,
+    "claude-3-opus": 200_000,
 }
 DEFAULT_CONTEXT_LIMIT = 200_000
 ACTIVE_SESSION_THRESHOLD_SECONDS = 600  # 10 minutes
 CHARS_PER_TOKEN_ESTIMATE = 4
 
+# CC's built-in tool definitions add a roughly constant overhead. Calibrated
+# against `/context` output (≈8.2k on a standard session). Used to split
+# System prompt from System tools in the composition breakdown.
+SYSTEM_TOOLS_ESTIMATE = 8_200
+
+
+def _normalize_model(model: str) -> str:
+    """Strip trailing YYYYMMDD date suffix (e.g. claude-opus-4-6-20260101 → claude-opus-4-6)."""
+    if not model:
+        return model
+    parts = model.rsplit("-", 1)
+    if len(parts) == 2 and parts[1].isdigit() and len(parts[1]) == 8:
+        return parts[0]
+    return model
+
 
 def get_context_limit(model: str) -> int:
-    """Get context window limit for a model."""
-    # Try exact match first
-    if model in MODEL_CONTEXT_LIMITS:
-        return MODEL_CONTEXT_LIMITS[model]
-    # Try prefix match
+    """Get context window limit for a model, preferring the longest matching key."""
+    normalized = _normalize_model(model)
+    # Exact match first
+    if normalized in MODEL_CONTEXT_LIMITS:
+        return MODEL_CONTEXT_LIMITS[normalized]
+    # Longest-prefix match so claude-opus-4-7 picks the 4-7 entry over 4 entry
+    best: tuple[int, int] = (-1, DEFAULT_CONTEXT_LIMIT)
     for key, limit in MODEL_CONTEXT_LIMITS.items():
-        if model.startswith(key.rsplit("-", 1)[0]):
-            return limit
-    return DEFAULT_CONTEXT_LIMIT
+        if normalized.startswith(key) and len(key) > best[0]:
+            best = (len(key), limit)
+    return best[1]
 
 
 def get_context_zone(percentage: float) -> str:
@@ -318,11 +341,17 @@ class ContextService:
         # --- Messages (estimated from JSONL content) ---
         messages_tokens = message_chars // CHARS_PER_TOKEN_ESTIMATE
 
-        # --- System & Tools (derived as residual) ---
-        system_and_tools_tokens = max(
+        # --- System prompt + System tools ---
+        # Total non-message, non-addon context is the residual. CC /context
+        # splits this into "System prompt" (fairly small) and "System tools"
+        # (large constant from built-in tool definitions). We subtract a
+        # calibrated constant for system tools; the remainder is system prompt.
+        system_total = max(
             0,
             current_context_tokens - messages_tokens - mcp_total - agent_total - memory_total - skill_total,
         )
+        system_tools_tokens = min(system_total, SYSTEM_TOOLS_ESTIMATE)
+        system_prompt_tokens = system_total - system_tools_tokens
 
         # --- Free Space ---
         free_space = max(0, context_limit - current_context_tokens - autocompact_buffer)
@@ -341,14 +370,15 @@ class ContextService:
                     items=items if items else None,
                 ))
 
-        _add("System & Tools", system_and_tools_tokens, "#888888")
-        _add("MCP Tools", mcp_total, "#0891b2", mcp_items)
-        _add("Custom Agents", agent_total, "#b1b9f9", agent_items)
-        _add("Memory Files", memory_total, "#d77757", memory_items)
+        _add("System prompt", system_prompt_tokens, "#6b7280")
+        _add("System tools", system_tools_tokens, "#9ca3af")
+        _add("MCP tools", mcp_total, "#0891b2", mcp_items)
+        _add("Custom agents", agent_total, "#b1b9f9", agent_items)
+        _add("Memory files", memory_total, "#d77757", memory_items)
         _add("Skills", skill_total, "#ffc107", skill_items)
         _add("Messages", messages_tokens, "#9333ea")
-        _add("Autocompact Buffer", autocompact_buffer, "#555555")
-        _add("Free Space", free_space, "#333333")
+        _add("Autocompact buffer", autocompact_buffer, "#555555")
+        _add("Free space", free_space, "#333333")
 
         total_tokens = sum(c.estimated_tokens for c in categories)
 

--- a/frontend/src/features/context/ContextCompositionChart.tsx
+++ b/frontend/src/features/context/ContextCompositionChart.tsx
@@ -106,9 +106,9 @@ export function ContextCompositionChart({ composition, showHelp }: ContextCompos
     return null
   }
 
-  // Filter out categories with 0 tokens except Free Space
+  // Filter out categories with 0 tokens except Free space
   const visibleCategories = composition.categories.filter(
-    (c) => c.estimated_tokens > 0 || c.category === 'Free Space'
+    (c) => c.estimated_tokens > 0 || c.category === 'Free space'
   )
 
   return (
@@ -158,14 +158,15 @@ export function ContextCompositionChart({ composition, showHelp }: ContextCompos
               <Info className="h-3.5 w-3.5" />
               Category Glossary
             </p>
-            <p><span className="font-medium">System & Tools</span> — Claude's base instructions, personality, and built-in tool definitions (Read, Write, Bash, etc.). Derived as the residual after subtracting measurable categories.</p>
-            <p><span className="font-medium">MCP Tools</span> — tools from connected MCP servers.</p>
-            <p><span className="font-medium">Agents</span> — custom agent definitions loaded for this project.</p>
-            <p><span className="font-medium">Memory</span> — CLAUDE.md files and project memory loaded at startup.</p>
+            <p><span className="font-medium">System prompt</span> — Claude's base instructions and personality. Derived as the residual after subtracting system tools and other measurable categories.</p>
+            <p><span className="font-medium">System tools</span> — built-in tool definitions (Read, Write, Bash, etc.). Approximated at a calibrated constant that matches CC's /context output.</p>
+            <p><span className="font-medium">MCP tools</span> — tools from connected MCP servers.</p>
+            <p><span className="font-medium">Custom agents</span> — custom agent definitions loaded for this project.</p>
+            <p><span className="font-medium">Memory files</span> — CLAUDE.md files and project memory loaded at startup.</p>
             <p><span className="font-medium">Skills</span> — skill definitions available in this session.</p>
             <p><span className="font-medium">Messages</span> — the actual conversation (prompts, responses, tool results).</p>
-            <p><span className="font-medium">Autocompact Buffer</span> — space reserved for auto-compaction.</p>
-            <p><span className="font-medium">Free Space</span> — remaining capacity for more conversation.</p>
+            <p><span className="font-medium">Autocompact buffer</span> — space reserved for auto-compaction.</p>
+            <p><span className="font-medium">Free space</span> — remaining capacity for more conversation.</p>
           </div>
         )}
       </CardContent>


### PR DESCRIPTION
Closes #118. Two related fixes surfaced by comparing the Context page to CC's \`/context\` output on an Opus 4.7 session.

## 1. Correct context budget for Opus 4.7

**Before:** CC showed \`320.5k/1m (32%)\`; Claude Deck showed \`320.5k/200k (160% → capped)\`.

\`MODEL_CONTEXT_LIMITS\` had no entry for \`claude-opus-4-7\` and fell through to \`DEFAULT_CONTEXT_LIMIT\`. The prefix-match fallback was also wrong: \`"claude-opus-4-6".rsplit("-", 1)[0]\` = \`"claude-opus-4"\`, which prefix-matches \`claude-opus-4-7\` and would bind it to 200K regardless.

**Fix:**
- Add \`claude-opus-4-7\` → \`1_000_000\` and \`claude-sonnet-4-6\` → \`1_000_000\`.
- Normalize model IDs by stripping trailing \`YYYYMMDD\` date suffix before lookup.
- Replace the buggy prefix fallback with a **longest-prefix** match over the normalized ID. Smoke-tested all observed model strings from my local JSONLs.

## 2. Category parity with CC /context

CC's \`/context\` shows **9** categories; Claude Deck shipped **8** because it merged "System prompt" and "System tools" into one "System & Tools" residual.

**Fix:** split the residual into \`System prompt\` + \`System tools\`. \`System tools\` is approximated at a calibrated constant (\`SYSTEM_TOOLS_ESTIMATE = 8_200\`, matching \`/context\`'s 8.2k on standard sessions); the remainder of the residual becomes \`System prompt\`.

Renamed the category labels to match CC's lowercase-after-first-word convention (\`MCP tools\`, \`Custom agents\`, \`Memory files\`, \`Free space\`, etc.). Frontend glossary and the one hardcoded filter updated accordingly.

## Verified

\`\`\`
session=1ccc7949 model=claude-opus-4-7
tokens=110,399 / 1,000,000 (11.0%)
\`\`\`

Previously this showed up as \`110,399 / 200,000\`.

## Not in scope

While testing I noticed the Skills category over-counts — it totals to more than any session's actual budget, which means it's probably summing *all installed skills* rather than only those loaded in the session. Pre-existing bug, not touched here. Happy to file a separate issue.

## Test plan
- [x] Backend imports cleanly
- [x] \`get_context_limit\` returns correct values for \`claude-opus-4-7\`, \`claude-opus-4-7-20260401\`, \`claude-sonnet-4-6\`, \`claude-haiku-4-5-20251001\`, unknown models (fall through to 200K)
- [x] Composition analysis runs against a real Opus 4.7 session and reports 1M budget
- [x] Frontend lint clean