### PR TITLE
fix(context): Skills category over-counts by ~20x vs CC /context

### DIFF
--- a/backend/app/services/context_service.py
+++ b/backend/app/services/context_service.py
@@ -52,6 +52,11 @@ CHARS_PER_TOKEN_ESTIMATE = 4
 # System prompt from System tools in the composition breakdown.
 SYSTEM_TOOLS_ESTIMATE = 8_200
 
+# Per-skill overhead in the system prompt (structural/envelope tokens
+# around each skill's metadata). Calibrated against /context on a session
+# with 80 skills showing 9.3k total.
+SKILL_OVERHEAD_TOKENS = 50
+
 
 def _normalize_model(model: str) -> str:
     """Strip trailing YYYYMMDD date suffix (e.g. claude-opus-4-6-20260101 → claude-opus-4-6)."""
@@ -325,16 +330,26 @@ class ContextService:
             pass
 
         # --- Skills ---
+        # CC only loads skill metadata (name + description) into the system
+        # prompt at startup. Full bodies are pulled only when a skill is
+        # invoked. Counting every installed skill's full content over-counts
+        # this category by ~20x on a session with many skills installed.
         skill_items: List[ContextCategoryItem] = []
         skill_total = 0
         try:
             skills = AgentService.list_skills(project_path)
             for skill in skills:
                 detail = AgentService.get_skill(skill.name, skill.location, project_path)
-                if detail and detail.content:
-                    tokens = len(detail.content) // CHARS_PER_TOKEN_ESTIMATE
-                    skill_items.append(ContextCategoryItem(name=skill.name, estimated_tokens=tokens))
-                    skill_total += tokens
+                description = ""
+                if detail:
+                    if detail.frontmatter and detail.frontmatter.description:
+                        description = detail.frontmatter.description
+                    elif detail.description:
+                        description = detail.description
+                metadata_chars = len(skill.name) + len(description)
+                tokens = metadata_chars // CHARS_PER_TOKEN_ESTIMATE + SKILL_OVERHEAD_TOKENS
+                skill_items.append(ContextCategoryItem(name=skill.name, estimated_tokens=tokens))
+                skill_total += tokens
         except Exception:
             pass
 


### PR DESCRIPTION
Closes #120. Follow-up to #118/#119.

## Root cause

\`ContextService.get_context_composition\` was summing every installed skill's **full content body**. CC's \`/context\` only includes skill metadata (name + description) in the system prompt at startup — the full body is only loaded when a skill is invoked.

## Measured

- 80 skills installed locally.
- Full-body sum: 749,021 chars → **187,255 tokens**.
- CC \`/context\` reported **9.3k**.
- Over-count factor: **~20x**.

## Fix

Switch from \`len(detail.content) / 4\` to \`(name + description) / 4 + 50 token overhead\`. The 50-token overhead accounts for structural/envelope tokens CC adds around each skill entry in the system prompt. Calibrated against CC's 9.3k for 80 skills.

## Verified

Against the same Opus 4.7 session from #119:

\`\`\`
session=1ccc7949 model=claude-opus-4-7
tokens=110,399 / 1,000,000 (11.0%)
  System prompt               39,105    3.9%
  System tools                 8,200    0.8%
  Custom agents               26,498    2.6%
  Skills                       8,860    0.9%   ← was 187,228
  Messages                    27,736    2.8%
  Autocompact buffer         165,000   16.5%
  Free space                 724,601   72.5%
  sum: 1,000,000
\`\`\`

Skills now reads **8,860** (CC shows 9.3k — within tolerance). Sum exactly equals the 1M budget.

**Bonus:** System prompt and System tools now populate. Previously they were clamped to 0 because Skills was consuming the entire residual. This closes the issue I flagged in #119.

## Still pending

Custom agents shows 26,498 on this session while CC's equivalent line shows 9k — same pattern (counting full agent prompts instead of a metadata summary). Separate issue territory; not in this PR.

## Test plan
- [x] Backend imports cleanly
- [x] Composition analysis produces sensible numbers on a real session
- [x] Sum of categories equals model budget
- [x] Skills value roughly matches \`/context\` (8.9k vs 9.3k)