### PR TITLE
fix(context): Custom agents category over-counts vs CC /context

### DIFF
--- a/backend/app/services/context_service.py
+++ b/backend/app/services/context_service.py
@@ -57,6 +57,13 @@ SYSTEM_TOOLS_ESTIMATE = 8_200
 # with 80 skills showing 9.3k total.
 SKILL_OVERHEAD_TOKENS = 50
 
+# CC caps per-agent context at roughly this many tokens — it loads an
+# abridged representation (description + truncated prompt) rather than
+# the full system prompt. Observed in /context output where per-agent
+# token counts clustered in the 200–510 range regardless of prompt size.
+# Calibrated so sum matches CC's reported 9k on a 17-agent session.
+AGENT_MAX_TOKENS_PER_ITEM = 550
+
 
 def _normalize_model(model: str) -> str:
     """Strip trailing YYYYMMDD date suffix (e.g. claude-opus-4-6-20260101 → claude-opus-4-6)."""
@@ -295,12 +302,17 @@ class ContextService:
             pass
 
         # --- Custom Agents ---
+        # CC doesn't inject each agent's full system prompt at session start.
+        # Per-agent numbers in /context cluster in the 200–510 range even
+        # when the actual prompt is 6k+ tokens, so CC is loading a summary
+        # or truncated representation. Cap per-agent at AGENT_MAX_TOKENS_PER_ITEM.
         agent_items: List[ContextCategoryItem] = []
         agent_total = 0
         try:
             agents = AgentService.list_agents(project_path)
             for agent in agents:
-                tokens = len(agent.prompt) // CHARS_PER_TOKEN_ESTIMATE
+                full_tokens = len(agent.prompt or "") // CHARS_PER_TOKEN_ESTIMATE
+                tokens = min(full_tokens, AGENT_MAX_TOKENS_PER_ITEM)
                 agent_items.append(ContextCategoryItem(name=agent.name, estimated_tokens=tokens))
                 agent_total += tokens
         except Exception:


### PR DESCRIPTION
Closes #122. Follow-up to #120.

## Summary

Cap per-agent estimated tokens at a calibrated maximum (\`AGENT_MAX_TOKENS_PER_ITEM = 550\`) instead of counting the full system prompt. CC doesn't inject full agent prompts at session start — observed per-agent numbers in \`/context\` cluster in the 200–510 range even when actual prompts are 6k+ tokens.

## Calibration data

Against a 17-agent local install:

| Formula | Total | vs CC's 9k |
|---|---|---|
| Full prompts (current) | 26,498 | 3× over |
| Metadata only | 1,569 | 85% short |
| cap=400 | 6,800 | 25% short |
| cap=500 | 8,383 | close |
| **cap=550** | **9,083** | **~1% over** ✅ |
| cap=600 | 9,783 | 8% over |

## Verified

Same Opus 4.7 session as #120:

\`\`\`
  System prompt               56,520    5.7%
  System tools                 8,200    0.8%
  Custom agents                9,083    0.9%   ← was 26,498
  Skills                       8,860    0.9%
  Messages                    27,736    2.8%
  Autocompact buffer         165,000   16.5%
  Free space                 724,601   72.5%
\`\`\`

All categories we can cross-check against CC's \`/context\` now line up within tolerance:
- Custom agents: 9,083 vs CC 9k ✅
- Skills: 8,860 vs CC 9.3k ✅
- System tools: 8,200 vs CC 8.2k ✅

## Test plan
- [x] Backend imports cleanly
- [x] Real session composition totals match CC \`/context\`
- [x] Agents with small prompts not under-counted (cap is a ceiling, not a floor)