### PR TITLE
perf(db): enable SQLite WAL mode

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,4 +1,5 @@
 """Database setup with SQLAlchemy async."""
+from sqlalchemy import event
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
 from sqlalchemy.orm import DeclarativeBase
 
@@ -16,6 +17,21 @@ engine = create_async_engine(
     echo=settings.debug,
     future=True,
 )
+
+
+# For SQLite: enable WAL so readers don't block writers (and vice versa).
+# Without this, any write (usage ingest, presence event, etc.) stalls
+# concurrent chart/page reads and can surface "database is locked" under
+# load. WAL is a one-time pragma that persists in the DB header.
+if settings.database_url.startswith("sqlite"):
+    @event.listens_for(engine.sync_engine, "connect")
+    def _set_sqlite_pragma(dbapi_conn, _):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA journal_mode=WAL")
+        cur.execute("PRAGMA synchronous=NORMAL")
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.execute("PRAGMA busy_timeout=5000")
+        cur.close()
 
 # Create async session factory
 AsyncSessionLocal = async_sessionmaker(


### PR DESCRIPTION
Closes #124.

## Summary

Enable WAL on SQLite connect so readers don't block writers (and vice versa) under concurrent load — usage ingest, presence events, and chart queries all hit the same DB.

Pragmas set:
- \`journal_mode=WAL\` — the main change; persists in the DB header.
- \`synchronous=NORMAL\` — safe to pair with WAL; better throughput than \`FULL\`.
- \`busy_timeout=5000\` — retry rather than fail on any remaining contention (e.g. schema ops).
- \`foreign_keys=ON\` — SQLite's default-off is a foot-gun.

Guarded behind \`settings.database_url.startswith("sqlite")\` so it's a no-op if the DB ever changes.

## Verified

\`\`\`
journal_mode=wal  synchronous=1  busy_timeout=5000  foreign_keys=1
\`\`\`

First write creates \`.db-wal\` and \`.db-shm\` as expected.

## Test plan
- [x] Pragmas applied on connect
- [x] WAL/SHM files materialize on first write
- [ ] Stress test usage ingest + chart reads simultaneously (not trivially reproducible, but contention should no longer block)