### PR TITLE
Add Codex CLI provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 **Website**: [claudedeck.org](https://claudedeck.org)
 
-A self-hosted web application for visualizing and managing Claude Code configuration. Provides a unified interface for managing MCP servers, plugins, slash commands, hooks, agents, permissions, usage tracking, session transcripts, CC Bridge, and other Claude Code extensions.
+A self-hosted web application for visualizing and managing local AI coding agents. Provides a unified interface for Claude Code configuration, Codex CLI configuration, MCP servers, plugins, slash commands, hooks, agents, permissions, usage tracking, session transcripts, Agent Bridge, and other local agent extensions.
 
 ## Why This Exists
 
 Claude Code starts simple, then slowly sprawls across config files and directories: `~/.claude.json`, `~/.claude/settings.json`, `.mcp.json`, slash commands, agents, skills, project settings, transcripts, and usage data. That works fine at small scale, but once your setup gets serious it becomes hard to see the whole picture, change things confidently, or understand what is actually configured.
 
-Claude Deck gives you one local interface for that sprawl.
+Claude Deck gives you one local interface for that sprawl. It also has first-class Codex CLI support for tmux sessions, TOML configuration, diagnostics, MCP inventory, and export-only backups.
 
 ## Best For
 
-Claude Deck is best for people running multiple MCP servers, custom commands, hooks, agents, or tracking Claude Code usage across sessions.
+Claude Deck is best for people running multiple Claude Code or Codex CLI sessions, MCP servers, custom commands, hooks, agents, or tracking Claude Code usage across sessions.
 
 If you only use Claude Code casually with mostly default config, Claude Deck may be overkill.
 
@@ -21,15 +21,16 @@ If you only use Claude Code casually with mostly default config, Claude Deck may
 - **Local only** — no cloud
 - **No account** — nothing to sign up for
 - **No telemetry** — no usage tracking sent anywhere
-- **Works with your real files** — reads and writes existing Claude Code config files
+- **Works with your real files** — reads and writes existing Claude Code and Codex config files
 
 > [!WARNING]
-> Claude Deck reads and writes your real Claude Code configuration files. Changes made in the UI affect the files Claude Code actually uses. Review changes carefully, and create a backup before major edits.
+> Claude Deck reads and writes your real local agent configuration files. Changes made in the UI affect the files Claude Code and Codex CLI actually use. Review changes carefully, and create a backup before major edits.
 
 ## Features
 
-- **Dashboard** — Overview of all Claude Code configurations with context window visualizer
-- **Config Editor** — Browse, inspect, and edit configuration files across all scopes
+- **Dashboard** — Overview of local agent configuration with Claude Code context window visualizer
+- **Provider Switcher** — Move between Claude Code and Codex CLI surfaces without leaving the app
+- **Config Editor** — Browse, inspect, and edit Claude Code JSON settings or Codex TOML settings
 - **MCP Servers** — Add, edit, test, and manage MCP server connections with OAuth support. Browse and install servers from the [MCP Registry](https://registry.modelcontextprotocol.io). View tools, resources, and prompts. Supports stdio, HTTP, and SSE transports
 - **Slash Commands** — Browse, create, and edit custom commands (user and project scope)
 - **Plugins** — Browse installed plugins with detail views and enable/disable toggles
@@ -40,11 +41,11 @@ If you only use Claude Code casually with mostly default config, Claude Deck may
 - **Memory** — View and edit Claude Code memory files
 - **Output Styles** — Configure response output formats
 - **Status Line** — Customize Claude Code status line display
-- **CC Bridge** — Discover and monitor Claude Code sessions running in tmux. Attach up to 4 terminals simultaneously in a 2x2 grid with independent read-only/interactive modes, fullscreen toggle, and per-pane controls. Spawn new sessions and manage worktrees directly from the UI
+- **Agent Bridge** — Discover and monitor Claude Code and Codex CLI sessions running in tmux. Attach up to 4 terminals simultaneously in a 2x2 grid with independent read-only/interactive modes, fullscreen toggle, and per-pane controls. Spawn new sessions and manage provider-specific options directly from the UI
 - **Session Transcripts** — View conversation history with full message details and tool use
 - **Usage Tracking** — Monitor token usage, costs, and billing blocks with daily/monthly charts
 - **Plan History** — Browse and review Claude Code implementation plans
-- **Backup & Restore** — Create and manage configuration backups with selective restore
+- **Backup & Restore** — Create and manage Claude Code backups with selective restore, plus redacted export-only Codex backups
 - **Projects** — Discover and manage project directories
 
 ## Screenshots
@@ -59,10 +60,10 @@ If you only use Claude Code casually with mostly default config, Claude Deck may
 | ![Usage Tracking](screenshots/usage-tracking.png) | ![Session Transcripts](screenshots/sessions.png) |
 | Cost visibility, charts, and billing blocks | Browse conversation history and tool usage details |
 
-| CC Bridge | Skills |
+| Agent Bridge | Skills |
 |-----------|--------|
 | ![CC Bridge](screenshots/cc-bridge.png) | ![Skills](screenshots/skills.png) |
-| Monitor and interact with Claude Code tmux sessions | Browse installed skills and discover new ones |
+| Monitor and interact with Claude Code and Codex tmux sessions | Browse installed skills and discover new ones |
 
 ## Tech Stack
 
@@ -83,10 +84,10 @@ cd claude-deck
 docker compose up
 ```
 
-This builds and starts Claude Deck at http://localhost:8000, mounting your `~/.claude` directory and `~/.claude.json` configuration file.
+This builds and starts Claude Deck at http://localhost:8000, mounting your `~/.claude` directory and `~/.claude.json` configuration file. Codex support reads `$CODEX_HOME`, defaulting to `~/.codex`, when available in the runtime environment.
 
 > [!WARNING]
-> Claude Deck is not a mock viewer. It works with your real local Claude Code files, so changes made in the UI can change your working setup.
+> Claude Deck is not a mock viewer. It works with your real local agent files, so changes made in the UI can change your working setup.
 
 > [!NOTE]
 > The container mounts your home directory's Claude Code configuration. The container runs as root to access these files; adjust permissions if running as a non-root user.
@@ -111,7 +112,7 @@ This starts:
 - Backend at http://localhost:8000 (API docs at http://localhost:8000/docs)
 - Frontend at http://localhost:5173
 
-To make the dev environment reachable from another machine on your LAN or tailnet (e.g. to monitor tmux sessions via CC Bridge from a different host), pass `--host`:
+To make the dev environment reachable from another machine on your LAN or tailnet (e.g. to monitor tmux sessions via Agent Bridge from a different host), pass `--host`:
 
 ```bash
 ./scripts/dev.sh --host 0.0.0.0
@@ -136,6 +137,15 @@ Claude Deck reads and writes these Claude Code configuration files:
 | `.claude/commands/` | Project | Project slash commands |
 | `.mcp.json` | Project | Project MCP servers |
 | `CLAUDE.md` | Project | Project instructions |
+
+Codex CLI support uses `$CODEX_HOME`, defaulting to `~/.codex`:
+
+| File/Directory | Scope | Description |
+|---------------|-------|-------------|
+| `~/.codex/config.toml` | User | Main Codex TOML configuration |
+| `~/.codex/*.config.toml` | User | Codex profile v2 files |
+| `~/.codex/rules/` | User | Codex rule files |
+| `~/.codex/auth.json` | User | Auth status only; raw contents are never returned |
 
 ## Contributing
 

--- a/backend/app/api/v1/agent_bridge/__init__.py
+++ b/backend/app/api/v1/agent_bridge/__init__.py
@@ -1,0 +1,2 @@
+"""Agent Bridge API package."""
+

--- a/backend/app/api/v1/agent_bridge/router.py
+++ b/backend/app/api/v1/agent_bridge/router.py
@@ -1,0 +1,145 @@
+"""Agent Bridge endpoints: mixed provider session discovery and terminal access."""
+from __future__ import annotations
+
+import logging
+import secrets
+import time
+from typing import Literal
+from urllib.parse import urlparse
+
+from fastapi import APIRouter, HTTPException, Query, WebSocket
+from pydantic import BaseModel
+
+from app.services.agent_bridge.discovery import capture_pane_preview, discover_agent_sessions
+from app.services.agent_bridge.pty_relay import PtyRelay
+from app.services.agent_bridge.spawn import kill_session, spawn_session
+from app.services.providers import get_provider
+from app.services.providers.base import SpawnCommandOptions
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_tokens: dict[str, float] = {}
+_TOKEN_TTL = 30
+
+
+class SpawnRequest(BaseModel):
+    provider: str = "claude-code"
+    directory: str
+    mode: Literal["plain", "worktree", "resume", "fork"] = "plain"
+    worktree_name: str | None = None
+    session_id: str | None = None
+    project_folder: str | None = None
+    skip_permissions: bool = False
+    prompt: str | None = None
+    model: str | None = None
+    profile: str | None = None
+    profile_v2: str | None = None
+    sandbox: str | None = None
+    approval_policy: str | None = None
+    search: bool | None = None
+    no_alt_screen: bool = False
+    dangerously_bypass_approvals_and_sandbox: bool = False
+    use_last: bool = False
+
+
+@router.get("/sessions")
+def list_sessions(provider: str | None = Query(default=None)):
+    try:
+        sessions = discover_agent_sessions(provider)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    return {"sessions": sessions, "count": len(sessions)}
+
+
+@router.get("/sessions/{target:path}/preview")
+def get_session_preview(target: str):
+    content = capture_pane_preview(target)
+    if not content:
+        raise HTTPException(status_code=404, detail="Could not capture pane")
+    return {"target": target, "content": content}
+
+
+@router.get("/token")
+async def get_terminal_token():
+    now = time.time()
+    expired = [token for token, issued_at in _tokens.items() if now - issued_at > _TOKEN_TTL]
+    for token in expired:
+        _tokens.pop(token, None)
+
+    token = secrets.token_urlsafe(32)
+    _tokens[token] = now
+    return {"token": token}
+
+
+def _is_same_origin(origin: str, websocket: WebSocket) -> bool:
+    try:
+        origin_host = urlparse(origin).netloc.lower()
+    except ValueError:
+        return False
+    if not origin_host:
+        return False
+
+    request_host = (websocket.headers.get("host") or "").lower()
+    if request_host and origin_host == request_host:
+        return True
+    return origin_host.split(":")[0] in {"localhost", "127.0.0.1", "[::1]"}
+
+
+def _validate_token(token: str) -> bool:
+    issued_at = _tokens.pop(token, None)
+    return issued_at is not None and (time.time() - issued_at) <= _TOKEN_TTL
+
+
+@router.websocket("/sessions/{target:path}/terminal")
+async def session_terminal(
+    websocket: WebSocket,
+    target: str,
+    token: str = "",
+    mode: str = "readonly",
+):
+    origin = websocket.headers.get("origin", "")
+    if origin and not _is_same_origin(origin, websocket):
+        await websocket.close(code=4403, reason="Invalid origin")
+        return
+
+    if not _validate_token(token):
+        await websocket.close(code=4401, reason="Invalid or expired token")
+        return
+
+    relay = PtyRelay(target=target, read_only=mode != "interactive")
+    await relay.run(websocket)
+
+
+@router.post("/sessions")
+def spawn_session_endpoint(request: SpawnRequest):
+    try:
+        get_provider(request.provider)
+        options = SpawnCommandOptions(
+            directory=request.directory,
+            mode=request.mode,
+            worktree_name=request.worktree_name,
+            session_id=request.session_id,
+            project_folder=request.project_folder,
+            skip_permissions=request.skip_permissions,
+            prompt=request.prompt,
+            model=request.model,
+            profile=request.profile,
+            profile_v2=request.profile_v2,
+            sandbox=request.sandbox,
+            approval_policy=request.approval_policy,
+            search=request.search,
+            no_alt_screen=request.no_alt_screen,
+            dangerously_bypass_approvals_and_sandbox=request.dangerously_bypass_approvals_and_sandbox,
+            use_last=request.use_last,
+        )
+        return spawn_session(request.provider, options)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@router.delete("/sessions/{target}")
+def kill_session_endpoint(target: str, cleanup_worktree: bool = False):
+    return kill_session(session_name=target, cleanup_worktree=cleanup_worktree)
+

--- a/backend/app/api/v1/backup.py
+++ b/backend/app/api/v1/backup.py
@@ -113,10 +113,10 @@ async def create_backup(
         Created backup with manifest summary
     """
     # Validate scope
-    if backup.scope not in ["full", "user", "project"]:
+    if backup.scope not in ["full", "user", "project", "codex"]:
         raise HTTPException(
             status_code=400,
-            detail="Scope must be 'full', 'user', or 'project'"
+            detail="Scope must be 'full', 'user', 'project', or 'codex'"
         )
 
     # Validate project_path for project/full scope

--- a/backend/app/api/v1/cli.py
+++ b/backend/app/api/v1/cli.py
@@ -4,18 +4,18 @@ CLI execution API endpoints.
 
 from fastapi import APIRouter, HTTPException
 from ...models.schemas import CLIExecuteRequest, CLIResult
-from ...services.cli_executor import CLIExecutor
+from ...services.cli_executor import CLIExecutor, ProviderCLIExecutor
 
 router = APIRouter(prefix="/cli", tags=["CLI"])
 
-# Initialize CLI executor
+# Initialize default Claude executor for compatibility checks.
 cli_executor = CLIExecutor()
 
 
 @router.post("/execute", response_model=CLIResult)
 async def execute_cli_command(request: CLIExecuteRequest) -> CLIResult:
     """
-    Execute a whitelisted Claude CLI command.
+    Execute a whitelisted provider CLI command.
 
     Args:
         request: CLI execution request with command and args
@@ -26,25 +26,27 @@ async def execute_cli_command(request: CLIExecuteRequest) -> CLIResult:
     Raises:
         HTTPException: If command is not whitelisted or execution fails
     """
-    # Validate command against whitelist
-    if not cli_executor.validate_command(request.command):
+    try:
+        executor = ProviderCLIExecutor(request.provider)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    if not executor.validate_command(request.command):
         raise HTTPException(
             status_code=400,
             detail=f"Command '{request.command}' is not allowed. "
-                   f"Allowed commands: {', '.join(cli_executor.ALLOWED_COMMANDS)}"
+                   f"Allowed commands: {', '.join(executor.ALLOWED_COMMANDS)}"
         )
 
-    # Check if claude binary is available
-    if not cli_executor.claude_binary:
+    if not executor.binary_path:
         raise HTTPException(
             status_code=500,
-            detail="Claude CLI binary not found in PATH. "
-                   "Please ensure Claude Code is installed."
+            detail=f"{executor.provider.display_name} binary not found in PATH. "
+                   f"Please ensure {executor.provider.display_name} is installed."
         )
 
     try:
-        # Execute the command
-        result = cli_executor.execute(
+        result = executor.execute(
             command=request.command,
             args=request.args
         )

--- a/backend/app/api/v1/codex_config.py
+++ b/backend/app/api/v1/codex_config.py
@@ -1,0 +1,29 @@
+"""Codex configuration API."""
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from app.services.codex_config_service import CodexConfigService
+
+router = APIRouter()
+
+
+@router.get("/codex-config")
+def get_codex_config():
+    return CodexConfigService().get_config()
+
+
+@router.get("/codex-config/files")
+def list_codex_config_files():
+    service = CodexConfigService()
+    files = service.get_all_config_files()
+    return {"files": files, "count": len(files)}
+
+
+@router.get("/codex-config/file")
+def get_codex_config_file(path: str):
+    try:
+        return CodexConfigService().get_file_content(path)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+

--- a/backend/app/api/v1/codex_config.py
+++ b/backend/app/api/v1/codex_config.py
@@ -2,10 +2,16 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
 
 from app.services.codex_config_service import CodexConfigService
 
 router = APIRouter()
+
+
+class CodexConfigUpdateRequest(BaseModel):
+    settings: dict = Field(default_factory=dict)
+    features: dict = Field(default_factory=dict)
 
 
 @router.get("/codex-config")
@@ -27,3 +33,18 @@ def get_codex_config_file(path: str):
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
+
+@router.patch("/codex-config")
+def update_codex_config(request: CodexConfigUpdateRequest):
+    try:
+        return CodexConfigService().update_safe_settings(
+            settings=request.settings,
+            features=request.features,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@router.put("/codex-config")
+def replace_codex_config_safe_settings(request: CodexConfigUpdateRequest):
+    return update_codex_config(request)

--- a/backend/app/api/v1/codex_config.py
+++ b/backend/app/api/v1/codex_config.py
@@ -34,6 +34,11 @@ def get_codex_config_file(path: str):
         raise HTTPException(status_code=400, detail=str(exc))
 
 
+@router.get("/codex-config/raw")
+def get_codex_config_raw(path: str):
+    return get_codex_config_file(path)
+
+
 @router.patch("/codex-config")
 def update_codex_config(request: CodexConfigUpdateRequest):
     try:

--- a/backend/app/api/v1/providers.py
+++ b/backend/app/api/v1/providers.py
@@ -6,6 +6,7 @@ import re
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field, field_validator
 
 from app.models.schemas import CLIExecuteRequest, CLIResult
 from app.services.cli_executor import ProviderCLIExecutor
@@ -20,6 +21,47 @@ SENSITIVE_ASSIGNMENT_PATTERN = re.compile(
     r"(?P<value>[^\s,;]+)",
     re.I,
 )
+MCP_SERVER_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.@-]{0,127}$")
+ENV_KEY_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+MAX_MCP_ARGS = 64
+MAX_MCP_ENV_VARS = 64
+MAX_MCP_STRING_LENGTH = 4096
+
+
+class CodexMcpAddRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=128)
+    command: str | None = Field(default=None, max_length=MAX_MCP_STRING_LENGTH)
+    args: list[str] = Field(default_factory=list, max_length=MAX_MCP_ARGS)
+    env: dict[str, str] = Field(default_factory=dict, max_length=MAX_MCP_ENV_VARS)
+    url: str | None = Field(default=None, max_length=MAX_MCP_STRING_LENGTH)
+    bearer_token_env_var: str | None = Field(default=None, max_length=256)
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        return _validate_mcp_server_name(value)
+
+    @field_validator("command", "url", "bearer_token_env_var")
+    @classmethod
+    def validate_optional_string(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _validate_cli_string(value)
+
+    @field_validator("args")
+    @classmethod
+    def validate_args(cls, value: list[str]) -> list[str]:
+        return [_validate_cli_string(arg) for arg in value]
+
+    @field_validator("env")
+    @classmethod
+    def validate_env(cls, value: dict[str, str]) -> dict[str, str]:
+        safe_env: dict[str, str] = {}
+        for key, env_value in value.items():
+            if not ENV_KEY_PATTERN.fullmatch(key):
+                raise ValueError(f"Invalid environment variable name: {key}")
+            safe_env[key] = _validate_cli_string(env_value)
+        return safe_env
 
 
 @router.get("/providers")
@@ -44,6 +86,67 @@ def _require_codex_provider(provider_id: str):
     if provider.id != "codex-cli":
         raise HTTPException(status_code=400, detail="Inventory endpoints are currently Codex-only")
     return provider
+
+
+def _validate_mcp_server_name(name: str) -> str:
+    name = name.strip()
+    if not MCP_SERVER_NAME_PATTERN.fullmatch(name):
+        raise ValueError("MCP server name must use letters, numbers, '.', '_', '@', or '-'")
+    return name
+
+
+def _validate_cli_string(value: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError("Value must be a string")
+    if not value:
+        raise ValueError("Value cannot be empty")
+    if "\x00" in value or any(ord(char) < 32 and char not in {"\t"} for char in value):
+        raise ValueError("Value contains control characters")
+    if len(value) > MAX_MCP_STRING_LENGTH:
+        raise ValueError(f"Value cannot exceed {MAX_MCP_STRING_LENGTH} characters")
+    return value
+
+
+def _redact_cli_result(result: CLIResult) -> dict[str, Any]:
+    return {
+        "stdout": _redact_value(result.stdout),
+        "stderr": _redact_value(result.stderr),
+        "exit_code": result.exit_code,
+    }
+
+
+def _build_codex_mcp_add_args(request: CodexMcpAddRequest) -> list[str]:
+    has_url = bool(request.url)
+    has_command = bool(request.command)
+    if has_url == has_command:
+        raise HTTPException(status_code=400, detail="Provide exactly one of url or command")
+
+    if request.url:
+        if not request.url.startswith(("http://", "https://")):
+            raise HTTPException(status_code=400, detail="MCP server URL must start with http:// or https://")
+        if request.args:
+            raise HTTPException(status_code=400, detail="args are only valid with command-based MCP servers")
+        if request.env:
+            raise HTTPException(status_code=400, detail="env is only valid with command-based MCP servers")
+        args = ["add", "--url", request.url]
+        if request.bearer_token_env_var:
+            if not ENV_KEY_PATTERN.fullmatch(request.bearer_token_env_var):
+                raise HTTPException(status_code=400, detail="Invalid bearer token environment variable name")
+            args.extend(["--bearer-token-env-var", request.bearer_token_env_var])
+        args.append(request.name)
+        return args
+
+    if request.bearer_token_env_var:
+        raise HTTPException(
+            status_code=400,
+            detail="bearer_token_env_var is only valid with URL-based MCP servers",
+        )
+    args = ["add"]
+    for key, value in request.env.items():
+        args.extend(["--env", f"{key}={value}"])
+    args.extend([request.name, "--", request.command or ""])
+    args.extend(request.args)
+    return args
 
 
 def _redact_value(value: Any, parent_key: str = "") -> Any:
@@ -218,6 +321,44 @@ def get_provider_mcp_inventory(provider_id: str):
         "parse_error": parse_error,
         "stderr": _redact_value(result.stderr),
         "raw_stdout": raw_stdout,
+    }
+
+
+@router.post("/providers/{provider_id}/mcp")
+def add_provider_mcp_server(provider_id: str, request: CodexMcpAddRequest):
+    mcp_args = _build_codex_mcp_add_args(request)
+    provider = _require_codex_provider(provider_id)
+    executor = ProviderCLIExecutor(provider.id)
+    if not executor.binary_path:
+        raise HTTPException(status_code=500, detail=f"{provider.display_name} binary not found in PATH.")
+
+    result = executor.execute("mcp", mcp_args, timeout=30)
+    return {
+        "provider": provider.id,
+        "provider_display_name": provider.display_name,
+        "name": request.name,
+        **_redact_cli_result(result),
+    }
+
+
+@router.delete("/providers/{provider_id}/mcp/{server_name}")
+def remove_provider_mcp_server(provider_id: str, server_name: str):
+    try:
+        safe_name = _validate_mcp_server_name(server_name)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    provider = _require_codex_provider(provider_id)
+    executor = ProviderCLIExecutor(provider.id)
+    if not executor.binary_path:
+        raise HTTPException(status_code=500, detail=f"{provider.display_name} binary not found in PATH.")
+
+    result = executor.execute("mcp", ["remove", safe_name], timeout=30)
+    return {
+        "provider": provider.id,
+        "provider_display_name": provider.display_name,
+        "name": safe_name,
+        **_redact_cli_result(result),
     }
 
 

--- a/backend/app/api/v1/providers.py
+++ b/backend/app/api/v1/providers.py
@@ -254,7 +254,8 @@ def execute_provider_cli(provider_id: str, request: CLIExecuteRequest):
             detail=f"{executor.provider.display_name} binary not found in PATH.",
         )
 
-    return executor.execute(request.command, request.args)
+    result = executor.execute(request.command, request.args)
+    return CLIResult(**_redact_cli_result(result))
 
 
 @router.get("/providers/{provider_id}/doctor")
@@ -281,7 +282,7 @@ def get_provider_doctor(provider_id: str):
     parse_error = None
     if result.stdout.strip():
         try:
-            report = json.loads(result.stdout)
+            report = _redact_value(json.loads(result.stdout))
         except json.JSONDecodeError as exc:
             parse_error = str(exc)
 
@@ -291,7 +292,7 @@ def get_provider_doctor(provider_id: str):
         "exit_code": result.exit_code,
         "report": report,
         "parse_error": parse_error,
-        "stderr": result.stderr,
+        "stderr": _redact_value(result.stderr),
     }
 
 

--- a/backend/app/api/v1/providers.py
+++ b/backend/app/api/v1/providers.py
@@ -1,8 +1,12 @@
 """Provider registry API."""
 from __future__ import annotations
 
+import json
+
 from fastapi import APIRouter, HTTPException
 
+from app.models.schemas import CLIExecuteRequest, CLIResult
+from app.services.cli_executor import ProviderCLIExecutor
 from app.services.providers import get_provider, get_providers
 
 router = APIRouter()
@@ -21,3 +25,65 @@ def get_provider_status(provider_id: str):
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
 
+
+@router.post("/providers/{provider_id}/cli", response_model=CLIResult)
+def execute_provider_cli(provider_id: str, request: CLIExecuteRequest):
+    try:
+        executor = ProviderCLIExecutor(provider_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    if not executor.validate_command(request.command):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Command '{request.command}' is not allowed. "
+                f"Allowed commands: {', '.join(executor.ALLOWED_COMMANDS)}"
+            ),
+        )
+
+    if not executor.binary_path:
+        raise HTTPException(
+            status_code=500,
+            detail=f"{executor.provider.display_name} binary not found in PATH.",
+        )
+
+    return executor.execute(request.command, request.args)
+
+
+@router.get("/providers/{provider_id}/doctor")
+def get_provider_doctor(provider_id: str):
+    try:
+        provider = get_provider(provider_id)
+        executor = ProviderCLIExecutor(provider_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    if not provider.get_capabilities().get("doctor"):
+        raise HTTPException(
+            status_code=400,
+            detail=f"{provider.display_name} does not expose doctor diagnostics",
+        )
+    if not executor.binary_path:
+        raise HTTPException(
+            status_code=500,
+            detail=f"{provider.display_name} binary not found in PATH.",
+        )
+
+    result = executor.execute("doctor", ["--json"], timeout=30)
+    report = None
+    parse_error = None
+    if result.stdout.strip():
+        try:
+            report = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            parse_error = str(exc)
+
+    return {
+        "provider": provider.id,
+        "provider_display_name": provider.display_name,
+        "exit_code": result.exit_code,
+        "report": report,
+        "parse_error": parse_error,
+        "stderr": result.stderr,
+    }

--- a/backend/app/api/v1/providers.py
+++ b/backend/app/api/v1/providers.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import json
+import re
+from typing import Any
 
 from fastapi import APIRouter, HTTPException
 
@@ -10,6 +12,14 @@ from app.services.cli_executor import ProviderCLIExecutor
 from app.services.providers import get_provider, get_providers
 
 router = APIRouter()
+
+SENSITIVE_KEY_PATTERN = re.compile(r"(token|secret|password|credential|api[_-]?key|auth|cookie|session)", re.I)
+SENSITIVE_ASSIGNMENT_PATTERN = re.compile(
+    r"(?P<key>[A-Za-z0-9_.-]*(?:token|secret|password|credential|api[_-]?key|auth|cookie|session)[A-Za-z0-9_.-]*)"
+    r"(?P<sep>\s*[:=]\s*)"
+    r"(?P<value>[^\s,;]+)",
+    re.I,
+)
 
 
 @router.get("/providers")
@@ -24,6 +34,99 @@ def get_provider_status(provider_id: str):
         return get_provider(provider_id).get_status()
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
+
+
+def _require_codex_provider(provider_id: str):
+    try:
+        provider = get_provider(provider_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    if provider.id != "codex-cli":
+        raise HTTPException(status_code=400, detail="Inventory endpoints are currently Codex-only")
+    return provider
+
+
+def _redact_value(value: Any, parent_key: str = "") -> Any:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return {
+            key: "[redacted]" if SENSITIVE_KEY_PATTERN.search(key) or SENSITIVE_KEY_PATTERN.search(parent_key)
+            else _redact_value(child, key)
+            for key, child in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_value(item, parent_key) for item in value]
+    if SENSITIVE_KEY_PATTERN.search(parent_key):
+        return "[redacted]"
+    if isinstance(value, str):
+        return SENSITIVE_ASSIGNMENT_PATTERN.sub(r"\g<key>\g<sep>[redacted]", value)
+    return value
+
+
+def _parse_plugin_rows(stdout: str) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    in_plugin_table = False
+    column_starts: tuple[int, int, int, int] | None = None
+
+    def append_row(name: str, status: str, version: str = "", path: str = "") -> None:
+        name = name.strip()
+        status = status.strip()
+        if not name or not status:
+            return
+        row = {
+            "name": name,
+            "status": status,
+        }
+        version = version.strip()
+        path = path.strip()
+        if version:
+            row["version"] = version
+        if path:
+            row["path"] = path
+        rows.append(row)
+
+    for raw_line in stdout.splitlines():
+        line = raw_line.strip()
+        if not line or set(line) <= {"-", " "}:
+            continue
+        lower = line.lower()
+        if not in_plugin_table and (lower.startswith("marketplace ") or line.endswith(".json") or line.startswith("/")):
+            continue
+
+        upper_line = raw_line.upper()
+        header_starts = (
+            upper_line.find("PLUGIN"),
+            upper_line.find("STATUS"),
+            upper_line.find("VERSION"),
+            upper_line.find("PATH"),
+        )
+        if all(start >= 0 for start in header_starts) and list(header_starts) == sorted(header_starts):
+            column_starts = header_starts
+            in_plugin_table = True
+            continue
+        if lower.startswith(("name ", "plugin ")):
+            continue
+
+        if in_plugin_table and column_starts:
+            plugin_start, status_start, version_start, path_start = column_starts
+            append_row(
+                raw_line[plugin_start:status_start],
+                raw_line[status_start:version_start],
+                raw_line[version_start:path_start],
+                raw_line[path_start:],
+            )
+            continue
+
+        columns = re.split(r"\s{2,}|\t+", line)
+        if in_plugin_table and len(columns) >= 2:
+            append_row(
+                columns[0],
+                columns[1],
+                columns[2] if len(columns) >= 3 else "",
+                "  ".join(columns[3:]) if len(columns) >= 4 else "",
+            )
+    return rows
 
 
 @router.post("/providers/{provider_id}/cli", response_model=CLIResult)
@@ -86,4 +189,50 @@ def get_provider_doctor(provider_id: str):
         "report": report,
         "parse_error": parse_error,
         "stderr": result.stderr,
+    }
+
+
+@router.get("/providers/{provider_id}/mcp")
+def get_provider_mcp_inventory(provider_id: str):
+    provider = _require_codex_provider(provider_id)
+    executor = ProviderCLIExecutor(provider.id)
+    if not executor.binary_path:
+        raise HTTPException(status_code=500, detail=f"{provider.display_name} binary not found in PATH.")
+
+    result = executor.execute("mcp", ["list", "--json"], timeout=30)
+    servers = None
+    parse_error = None
+    if result.stdout.strip():
+        try:
+            servers = _redact_value(json.loads(result.stdout))
+        except json.JSONDecodeError as exc:
+            parse_error = str(exc)
+
+    return {
+        "provider": provider.id,
+        "provider_display_name": provider.display_name,
+        "exit_code": result.exit_code,
+        "servers": servers,
+        "parse_error": parse_error,
+        "stderr": _redact_value(result.stderr),
+        "raw_stdout": _redact_value(result.stdout),
+    }
+
+
+@router.get("/providers/{provider_id}/plugins")
+def get_provider_plugin_inventory(provider_id: str):
+    provider = _require_codex_provider(provider_id)
+    executor = ProviderCLIExecutor(provider.id)
+    if not executor.binary_path:
+        raise HTTPException(status_code=500, detail=f"{provider.display_name} binary not found in PATH.")
+
+    result = executor.execute("plugin", ["list"], timeout=30)
+    safe_stdout = _redact_value(result.stdout)
+    return {
+        "provider": provider.id,
+        "provider_display_name": provider.display_name,
+        "exit_code": result.exit_code,
+        "plugins": _redact_value(_parse_plugin_rows(result.stdout)),
+        "stderr": _redact_value(result.stderr),
+        "raw_stdout": safe_stdout,
     }

--- a/backend/app/api/v1/providers.py
+++ b/backend/app/api/v1/providers.py
@@ -202,9 +202,11 @@ def get_provider_mcp_inventory(provider_id: str):
     result = executor.execute("mcp", ["list", "--json"], timeout=30)
     servers = None
     parse_error = None
+    raw_stdout = _redact_value(result.stdout)
     if result.stdout.strip():
         try:
             servers = _redact_value(json.loads(result.stdout))
+            raw_stdout = json.dumps(servers)
         except json.JSONDecodeError as exc:
             parse_error = str(exc)
 
@@ -215,7 +217,7 @@ def get_provider_mcp_inventory(provider_id: str):
         "servers": servers,
         "parse_error": parse_error,
         "stderr": _redact_value(result.stderr),
-        "raw_stdout": _redact_value(result.stdout),
+        "raw_stdout": raw_stdout,
     }
 
 

--- a/backend/app/api/v1/providers.py
+++ b/backend/app/api/v1/providers.py
@@ -283,8 +283,8 @@ def get_provider_doctor(provider_id: str):
     if result.stdout.strip():
         try:
             report = _redact_value(json.loads(result.stdout))
-        except json.JSONDecodeError as exc:
-            parse_error = str(exc)
+        except json.JSONDecodeError:
+            parse_error = "Provider doctor output was not valid JSON"
 
     return {
         "provider": provider.id,
@@ -311,8 +311,8 @@ def get_provider_mcp_inventory(provider_id: str):
         try:
             servers = _redact_value(json.loads(result.stdout))
             raw_stdout = json.dumps(servers)
-        except json.JSONDecodeError as exc:
-            parse_error = str(exc)
+        except json.JSONDecodeError:
+            parse_error = "Provider MCP inventory output was not valid JSON"
 
     return {
         "provider": provider.id,

--- a/backend/app/api/v1/providers.py
+++ b/backend/app/api/v1/providers.py
@@ -1,0 +1,23 @@
+"""Provider registry API."""
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from app.services.providers import get_provider, get_providers
+
+router = APIRouter()
+
+
+@router.get("/providers")
+def list_providers():
+    providers = [provider.get_status() for provider in get_providers()]
+    return {"providers": providers, "count": len(providers)}
+
+
+@router.get("/providers/{provider_id}/status")
+def get_provider_status(provider_id: str):
+    try:
+        return get_provider(provider_id).get_status()
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -19,6 +19,9 @@ from .context import router as context_router
 from .plans import router as plans_router
 from .presence import router as presence_router
 from .cc_bridge.router import router as cc_bridge_router
+from .agent_bridge.router import router as agent_bridge_router
+from .providers import router as providers_router
+from .codex_config import router as codex_config_router
 from .status import router as status_router
 
 router = APIRouter()
@@ -55,4 +58,7 @@ router.include_router(context_router, tags=["Context"])
 router.include_router(plans_router, tags=["Plans"])
 router.include_router(presence_router, prefix="/presence", tags=["Presence"])
 router.include_router(cc_bridge_router, prefix="/cc-bridge", tags=["CC Bridge"])
+router.include_router(agent_bridge_router, prefix="/agent-bridge", tags=["Agent Bridge"])
+router.include_router(providers_router, tags=["Providers"])
+router.include_router(codex_config_router, tags=["Codex Config"])
 router.include_router(status_router, tags=["Status"])

--- a/backend/app/api/v1/status.py
+++ b/backend/app/api/v1/status.py
@@ -1,9 +1,7 @@
 """System status endpoint for header indicators."""
 import asyncio
-import re
-import shutil
 import time
-from typing import Optional
+from typing import Any, Optional
 
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -12,6 +10,7 @@ from app.database import get_db
 from app.models.constants import SessionStatus
 from app.models.schemas import SystemStatusResponse
 from app.services.presence_service import PresenceService
+from app.services.providers import get_provider, get_providers
 
 router = APIRouter()
 
@@ -33,22 +32,7 @@ async def _get_claude_code_version() -> Optional[str]:
         if time.time() - cached_at < _CACHE_TTL:
             return cached_version
 
-        claude_bin = await asyncio.to_thread(shutil.which, "claude")
-        if not claude_bin:
-            _version_cache = (None, time.time())
-            return None
-
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                claude_bin, "--version",
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
-            match = re.search(r"(\d+\.\d+\.\d+)", stdout.decode())
-            version = match.group(1) if match else None
-        except (OSError, asyncio.TimeoutError):
-            version = None
+        version = await asyncio.to_thread(get_provider("claude-code").get_version)
 
         _version_cache = (version, time.time())
         return version
@@ -60,15 +44,24 @@ async def _get_active_count(db: AsyncSession) -> int:
     return sum(1 for s in sessions if s.status == SessionStatus.ACTIVE)
 
 
+async def _get_provider_statuses() -> dict[str, Any]:
+    statuses = await asyncio.gather(
+        *(asyncio.to_thread(provider.get_status) for provider in get_providers())
+    )
+    return {status["id"]: status for status in statuses}
+
+
 @router.get("/status", response_model=SystemStatusResponse)
 async def get_system_status(db: AsyncSession = Depends(get_db)):
     """Return system status for header indicators."""
-    version, active_count = await asyncio.gather(
+    version, active_count, provider_statuses = await asyncio.gather(
         _get_claude_code_version(),
         _get_active_count(db),
+        _get_provider_statuses(),
     )
 
     return SystemStatusResponse(
         claude_code_version=version,
         active_sessions=active_count,
+        providers=provider_statuses,
     )

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1,6 +1,6 @@
 """Pydantic schemas for API models."""
 from typing import Any, Dict, List, Optional, Union
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class ConfigFile(BaseModel):
@@ -1816,3 +1816,4 @@ class SystemStatusResponse(BaseModel):
 
     claude_code_version: Optional[str] = None
     active_sessions: int = 0
+    providers: Dict[str, Any] = Field(default_factory=dict)

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -105,6 +105,7 @@ class CLIExecuteRequest(BaseModel):
 
     command: str
     args: List[str] = []
+    provider: str = "claude-code"
 
 
 class CLIResult(BaseModel):

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1400,6 +1400,7 @@ class BackupManifestContents(BaseModel):
     mcp_servers: List[BackupMCPServerInfo] = []
     agents: List[str] = []
     commands: List[str] = []
+    provider_inventory: Dict[str, Any] = {}
 
 
 class BackupManifest(BaseModel):

--- a/backend/app/services/agent_bridge/__init__.py
+++ b/backend/app/services/agent_bridge/__init__.py
@@ -1,0 +1,2 @@
+"""Shared tmux bridge services for agent providers."""
+

--- a/backend/app/services/agent_bridge/discovery.py
+++ b/backend/app/services/agent_bridge/discovery.py
@@ -1,0 +1,103 @@
+"""Discover agent provider sessions running in tmux."""
+from __future__ import annotations
+
+import logging
+import subprocess
+from typing import Any
+
+from app.models.constants import SessionStatus
+from app.services.providers import get_provider, get_providers
+from app.services.providers.base import AgentProvider
+
+logger = logging.getLogger(__name__)
+
+_PANE_FORMAT = (
+    "#{session_name}:#{window_index}.#{pane_index}"
+    "|#{session_name}"
+    "|#{window_name}"
+    "|#{pane_id}"
+    "|#{pane_current_path}"
+    "|#{pane_pid}"
+    "|#{pane_current_command}"
+)
+
+
+def _build_session_info_from_parts(
+    *,
+    target: str,
+    session_name: str,
+    window_name: str,
+    pane_id: str,
+    cwd: str,
+    pid: str,
+    provider: AgentProvider,
+) -> dict[str, Any]:
+    return {
+        "provider": provider.id,
+        "provider_display_name": provider.display_name,
+        "tmux_target": target,
+        "session_name": session_name,
+        "window_name": window_name,
+        "pane_id": pane_id,
+        "cwd": cwd,
+        "pid": pid,
+        "status": SessionStatus.ACTIVE,
+    }
+
+
+def discover_agent_sessions(provider_id: str | None = None) -> list[dict[str, Any]]:
+    """Find all tmux panes running supported agent providers."""
+    providers = [get_provider(provider_id)] if provider_id else get_providers()
+    try:
+        result = subprocess.run(
+            ["tmux", "list-panes", "-a", "-F", _PANE_FORMAT],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            logger.debug("tmux list-panes failed: %s", result.stderr.strip())
+            return []
+    except FileNotFoundError:
+        logger.debug("tmux not found")
+        return []
+    except subprocess.TimeoutExpired:
+        logger.warning("tmux list-panes timed out")
+        return []
+
+    sessions: list[dict[str, Any]] = []
+    for line in result.stdout.strip().splitlines():
+        parts = line.split("|", 6)
+        if len(parts) != 7:
+            continue
+        target, session_name, window_name, pane_id, cwd, pid, command = parts
+        for provider in providers:
+            if provider.is_process_match(command, pid):
+                sessions.append(
+                    _build_session_info_from_parts(
+                        target=target,
+                        session_name=session_name,
+                        window_name=window_name,
+                        pane_id=pane_id,
+                        cwd=cwd,
+                        pid=pid,
+                        provider=provider,
+                    )
+                )
+                break
+    return sessions
+
+
+def capture_pane_preview(target: str) -> str:
+    """Capture the current visible content of a tmux pane."""
+    try:
+        result = subprocess.run(
+            ["tmux", "capture-pane", "-t", target, "-p", "-e"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return result.stdout if result.returncode == 0 else ""
+    except Exception:
+        return ""
+

--- a/backend/app/services/agent_bridge/pty_relay.py
+++ b/backend/app/services/agent_bridge/pty_relay.py
@@ -1,0 +1,3 @@
+"""Compatibility re-export for the shared tmux pty relay."""
+from app.services.cc_bridge.pty_relay import *  # noqa: F401,F403
+

--- a/backend/app/services/agent_bridge/spawn.py
+++ b/backend/app/services/agent_bridge/spawn.py
@@ -1,0 +1,118 @@
+"""Spawn and kill agent provider sessions in tmux."""
+from __future__ import annotations
+
+import logging
+import re
+import shlex
+import subprocess
+import uuid
+from pathlib import Path
+
+from app.services.providers import get_provider
+from app.services.providers.base import SpawnCommandOptions
+from app.services.providers.claude_code import ClaudeCodeProvider
+
+logger = logging.getLogger(__name__)
+
+_spawned_sessions: dict[str, dict] = {}
+
+
+def _validate_directory(directory: str) -> str:
+    dir_path = Path(directory).resolve()
+    if not dir_path.is_absolute():
+        raise ValueError(f"Directory must be an absolute path: {directory}")
+    if ".." in Path(directory).parts:
+        raise ValueError(f"Directory must not contain path traversal: {directory}")
+    if not dir_path.is_dir():
+        raise ValueError(f"Directory does not exist: {directory}")
+    return str(dir_path)
+
+
+def _session_name_for(directory: str) -> str:
+    basename = Path(directory).name or "project"
+    safe_basename = re.sub(r"[^a-zA-Z0-9_-]", "-", basename)[:20]
+    return f"{safe_basename}-{uuid.uuid4().hex[:4]}"
+
+
+def spawn_session(provider_id: str, options: SpawnCommandOptions) -> dict:
+    """Spawn a new provider CLI session inside tmux."""
+    provider = get_provider(provider_id)
+    if isinstance(provider, ClaudeCodeProvider):
+        directory = provider.resolve_directory(options)
+        options = SpawnCommandOptions(**{**options.__dict__, "directory": directory})
+
+    directory = _validate_directory(options.directory)
+    options = SpawnCommandOptions(**{**options.__dict__, "directory": directory})
+    name = _session_name_for(directory)
+    command = provider.build_spawn_command(options)
+    shell_command = " ".join(shlex.quote(part) for part in command)
+
+    try:
+        result = subprocess.run(
+            ["tmux", "new-session", "-d", "-s", name, "-c", directory, shell_command],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            raise ValueError(f"tmux new-session failed: {result.stderr.strip()}")
+    except FileNotFoundError:
+        raise ValueError("tmux is not installed or not in PATH")
+    except subprocess.TimeoutExpired:
+        raise ValueError("tmux new-session timed out")
+
+    _spawned_sessions[name] = {
+        "provider": provider.id,
+        "mode": options.mode,
+        "directory": directory,
+        "worktree_name": options.worktree_name or (name if options.mode == "worktree" else None),
+    }
+
+    logger.info("Spawned %s session %s in %s (mode=%s)", provider.id, name, directory, options.mode)
+    return {
+        "provider": provider.id,
+        "provider_display_name": provider.display_name,
+        "tmux_target": f"{name}:0.0",
+        "session_name": name,
+    }
+
+
+def kill_session(session_name: str, cleanup_worktree: bool = False) -> dict:
+    """Kill a tmux session and optionally clean up a Claude Code worktree."""
+    metadata = _spawned_sessions.get(session_name)
+    try:
+        result = subprocess.run(
+            ["tmux", "kill-session", "-t", session_name],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return {"killed": False, "error": result.stderr.strip()}
+    except FileNotFoundError:
+        return {"killed": False, "error": "tmux is not installed or not in PATH"}
+    except subprocess.TimeoutExpired:
+        return {"killed": False, "error": "tmux kill-session timed out"}
+
+    if cleanup_worktree and metadata and metadata.get("provider") == "claude-code" and metadata["mode"] == "worktree":
+        worktree_name = metadata.get("worktree_name")
+        directory = metadata["directory"]
+        if worktree_name:
+            try:
+                subprocess.run(
+                    ["git", "-C", directory, "worktree", "remove", worktree_name, "--force"],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+            except Exception:
+                logger.warning("Failed to remove worktree %s in %s", worktree_name, directory)
+
+    _spawned_sessions.pop(session_name, None)
+    logger.info("Killed session %s", session_name)
+    return {"killed": True}
+
+
+def get_spawned_sessions() -> dict[str, dict]:
+    return _spawned_sessions
+

--- a/backend/app/services/agent_bridge/spawn.py
+++ b/backend/app/services/agent_bridge/spawn.py
@@ -44,6 +44,8 @@ def spawn_session(provider_id: str, options: SpawnCommandOptions) -> dict:
     directory = _validate_directory(options.directory)
     options = SpawnCommandOptions(**{**options.__dict__, "directory": directory})
     name = _session_name_for(directory)
+    if provider.id == "claude-code" and options.mode == "worktree" and not options.worktree_name:
+        options = SpawnCommandOptions(**{**options.__dict__, "worktree_name": name})
     command = provider.build_spawn_command(options)
     shell_command = " ".join(shlex.quote(part) for part in command)
 
@@ -115,4 +117,3 @@ def kill_session(session_name: str, cleanup_worktree: bool = False) -> dict:
 
 def get_spawned_sessions() -> dict[str, dict]:
     return _spawned_sessions
-

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -536,7 +536,10 @@ class BackupService:
         if scope == "codex":
             paths.extend(self._get_codex_config_paths())
             provider_inventory = self._get_codex_provider_inventory(paths)
-            extra_files[".codex/provider-inventory.json"] = json.dumps(
+            inventory_arcname = str(
+                (self.codex_home / "provider-inventory.json").relative_to(self.codex_home.parent)
+            )
+            extra_files[inventory_arcname] = json.dumps(
                 provider_inventory,
                 indent=2,
                 sort_keys=True,

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -2,6 +2,7 @@
 import json
 import os
 import platform
+import re
 import subprocess
 import zipfile
 from datetime import datetime
@@ -42,6 +43,24 @@ from app.utils.path_utils import (
     get_project_mcp_config_file,
     get_project_claude_md_file,
 )
+from app.services.cli_executor import ProviderCLIExecutor
+from app.services.providers.codex_cli import get_codex_home
+
+
+SENSITIVE_KEY_PATTERN = re.compile(r"(token|secret|password|credential|api[_-]?key|auth|cookie|session)", re.I)
+SENSITIVE_ASSIGNMENT_PATTERN = re.compile(
+    r"(?P<key>[A-Za-z0-9_.-]*(?:token|secret|password|credential|api[_-]?key|auth|cookie|session)[A-Za-z0-9_.-]*)"
+    r"(?P<sep>\s*[:=]\s*)"
+    r"(?P<value>[^\s,;]+)",
+    re.I,
+)
+SENSITIVE_TOML_ASSIGNMENT_PATTERN = re.compile(
+    r"(?im)^"
+    r"(?P<prefix>\s*[A-Za-z0-9_.-]*(?:token|secret|password|credential|api[_-]?key|auth|cookie|session)"
+    r"[A-Za-z0-9_.-]*\s*=\s*)"
+    r"(?P<value>.+?)"
+    r"(?P<suffix>\s*(?:#.*)?)$"
+)
 
 
 def get_backup_storage_dir() -> Path:
@@ -80,8 +99,9 @@ def _get_claude_code_version() -> Optional[str]:
 class BackupService:
     """Service for managing configuration backups."""
 
-    def __init__(self, db: AsyncSession):
+    def __init__(self, db: AsyncSession, codex_home: Optional[Path] = None):
         self.db = db
+        self.codex_home = codex_home or get_codex_home()
 
     def _get_user_config_paths(self) -> List[Path]:
         """Get all user-level configuration paths."""
@@ -134,6 +154,109 @@ class BackupService:
             paths.append(claude_md)
 
         return paths
+
+    def _get_codex_config_paths(self) -> List[Path]:
+        """Get safe Codex configuration files for export-only backups."""
+        paths: List[Path] = []
+        config_file = self.codex_home / "config.toml"
+        if config_file.exists() and config_file.is_file():
+            paths.append(config_file)
+
+        if self.codex_home.exists():
+            for profile in sorted(self.codex_home.glob("*.config.toml")):
+                if profile.is_file():
+                    paths.append(profile)
+
+            rules_dir = self.codex_home / "rules"
+            if rules_dir.exists():
+                for rule in sorted(rules_dir.glob("*.rules")):
+                    if rule.is_file():
+                        paths.append(rule)
+
+        return paths
+
+    def _redact_value(self, value: Any, parent_key: str = "") -> Any:
+        """Redact sensitive values from generated backup metadata."""
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            return {
+                key: "[redacted]" if SENSITIVE_KEY_PATTERN.search(key) or SENSITIVE_KEY_PATTERN.search(parent_key)
+                else self._redact_value(child, key)
+                for key, child in value.items()
+            }
+        if isinstance(value, list):
+            return [self._redact_value(item, parent_key) for item in value]
+        if SENSITIVE_KEY_PATTERN.search(parent_key):
+            return "[redacted]"
+        if isinstance(value, str):
+            return SENSITIVE_ASSIGNMENT_PATTERN.sub(r"\g<key>\g<sep>[redacted]", value)
+        return value
+
+    def _redact_text_content(self, content: str) -> str:
+        """Redact obvious secret assignments in text files before exporting."""
+        redacted = SENSITIVE_TOML_ASSIGNMENT_PATTERN.sub(
+            lambda match: f'{match.group("prefix")}"[redacted]"{match.group("suffix")}',
+            content,
+        )
+        return SENSITIVE_ASSIGNMENT_PATTERN.sub(r'\g<key>\g<sep>"[redacted]"', redacted)
+
+    def _read_redacted_file(self, path: Path) -> str:
+        try:
+            return self._redact_text_content(path.read_text(encoding="utf-8"))
+        except UnicodeDecodeError:
+            return self._redact_text_content(path.read_text(errors="replace"))
+
+    def _get_codex_provider_inventory(self, paths: List[Path]) -> Dict[str, Any]:
+        """Collect safe provider metadata for Codex export manifests."""
+        inventory: Dict[str, Any] = {
+            "provider": "codex-cli",
+            "codex_home": str(self.codex_home),
+            "files": [
+                {
+                    "path": str(path),
+                    "scope": (
+                        "user" if path.name == "config.toml"
+                        else "rules" if path.suffix == ".rules"
+                        else "profile"
+                    ),
+                }
+                for path in paths
+            ],
+        }
+
+        try:
+            executor = ProviderCLIExecutor("codex-cli")
+            if not executor.binary_path:
+                inventory["cli"] = {"installed": False}
+                return inventory
+        except Exception as exc:
+            inventory["cli"] = {"installed": False, "error": str(exc)}
+            return inventory
+
+        inventory["cli"] = {"installed": True, "binary_path": executor.binary_path}
+
+        mcp_result = executor.execute("mcp", ["list", "--json"], timeout=30)
+        mcp_inventory: Dict[str, Any] = {
+            "exit_code": mcp_result.exit_code,
+            "stderr": self._redact_value(mcp_result.stderr),
+        }
+        if mcp_result.stdout.strip():
+            try:
+                mcp_inventory["servers"] = self._redact_value(json.loads(mcp_result.stdout))
+            except json.JSONDecodeError as exc:
+                mcp_inventory["parse_error"] = str(exc)
+                mcp_inventory["raw_stdout"] = self._redact_value(mcp_result.stdout)
+        inventory["mcp"] = mcp_inventory
+
+        plugin_result = executor.execute("plugin", ["list"], timeout=30)
+        inventory["plugins"] = {
+            "exit_code": plugin_result.exit_code,
+            "stderr": self._redact_value(plugin_result.stderr),
+            "raw_stdout": self._redact_value(plugin_result.stdout),
+        }
+
+        return self._redact_value(inventory)
 
     def _detect_skill_dependencies(self, skill_path: Path) -> BackupSkillInfo:
         """Detect dependencies in a skill directory."""
@@ -243,7 +366,13 @@ class BackupService:
 
         return info
 
-    def _generate_manifest(self, paths: List[Path], scope: str) -> BackupManifest:
+    def _generate_manifest(
+        self,
+        paths: List[Path],
+        scope: str,
+        extra_files: Optional[Dict[str, str]] = None,
+        provider_inventory: Optional[Dict[str, Any]] = None,
+    ) -> BackupManifest:
         """Generate a backup manifest with all dependency information."""
         contents = BackupManifestContents()
 
@@ -255,55 +384,60 @@ class BackupService:
             except ValueError:
                 rel_path = str(path)
             contents.files.append(rel_path)
+        if extra_files:
+            contents.files.extend(extra_files.keys())
+        if provider_inventory:
+            contents.provider_inventory = provider_inventory
 
         # Detect skills
-        skills_dir = get_claude_user_skills_dir()
-        if skills_dir.exists():
-            for skill_path in skills_dir.iterdir():
-                if skill_path.is_dir():
-                    skill_info = self._detect_skill_dependencies(skill_path)
-                    contents.skills.append(skill_info)
+        if scope != "codex":
+            skills_dir = get_claude_user_skills_dir()
+            if skills_dir.exists():
+                for skill_path in skills_dir.iterdir():
+                    if skill_path.is_dir():
+                        skill_info = self._detect_skill_dependencies(skill_path)
+                        contents.skills.append(skill_info)
 
-        # Detect plugins
-        plugins_dir = get_claude_user_plugins_dir()
-        if plugins_dir.exists():
-            for plugin_path in plugins_dir.iterdir():
-                if plugin_path.is_dir():
-                    plugin_info = self._get_plugin_install_info(plugin_path.name, plugin_path)
-                    contents.plugins.append(plugin_info)
+            # Detect plugins
+            plugins_dir = get_claude_user_plugins_dir()
+            if plugins_dir.exists():
+                for plugin_path in plugins_dir.iterdir():
+                    if plugin_path.is_dir():
+                        plugin_info = self._get_plugin_install_info(plugin_path.name, plugin_path)
+                        contents.plugins.append(plugin_info)
 
-        # Detect MCP servers from user config
-        config_file = get_claude_user_config_file()
-        if config_file.exists():
-            try:
-                with open(config_file) as f:
-                    config = json.load(f)
-                    mcp_servers = config.get("mcpServers", {})
-                    for name, srv_config in mcp_servers.items():
-                        mcp_info = self._detect_mcp_server_info(name, srv_config, "user")
-                        contents.mcp_servers.append(mcp_info)
-            except Exception:
-                pass
-
-        # Detect agents
-        agents_dir = get_claude_user_agents_dir()
-        if agents_dir.exists():
-            for agent_file in agents_dir.glob("*.md"):
-                contents.agents.append(agent_file.stem)
-
-        # Detect commands
-        commands_dir = get_claude_user_commands_dir()
-        if commands_dir.exists():
-            for cmd_file in commands_dir.rglob("*.md"):
+            # Detect MCP servers from user config
+            config_file = get_claude_user_config_file()
+            if config_file.exists():
                 try:
-                    rel = cmd_file.relative_to(commands_dir)
-                    contents.commands.append(str(rel).replace(".md", ""))
-                except ValueError:
-                    contents.commands.append(cmd_file.stem)
+                    with open(config_file) as f:
+                        config = json.load(f)
+                        mcp_servers = config.get("mcpServers", {})
+                        for name, srv_config in mcp_servers.items():
+                            mcp_info = self._detect_mcp_server_info(name, srv_config, "user")
+                            contents.mcp_servers.append(mcp_info)
+                except Exception:
+                    pass
+
+            # Detect agents
+            agents_dir = get_claude_user_agents_dir()
+            if agents_dir.exists():
+                for agent_file in agents_dir.glob("*.md"):
+                    contents.agents.append(agent_file.stem)
+
+            # Detect commands
+            commands_dir = get_claude_user_commands_dir()
+            if commands_dir.exists():
+                for cmd_file in commands_dir.rglob("*.md"):
+                    try:
+                        rel = cmd_file.relative_to(commands_dir)
+                        contents.commands.append(str(rel).replace(".md", ""))
+                    except ValueError:
+                        contents.commands.append(cmd_file.stem)
 
         manifest = BackupManifest(
             created_at=datetime.utcnow().isoformat(),
-            claude_code_version=_get_claude_code_version(),
+            claude_code_version=None if scope == "codex" else _get_claude_code_version(),
             platform=_get_current_platform(),
             scope=scope,
             contents=contents,
@@ -312,7 +446,14 @@ class BackupService:
         return manifest
 
     def _create_archive(
-        self, name: str, paths: List[Path], scope: str, base_path: Optional[Path] = None
+        self,
+        name: str,
+        paths: List[Path],
+        scope: str,
+        base_path: Optional[Path] = None,
+        extra_files: Optional[Dict[str, str]] = None,
+        file_overrides: Optional[Dict[Path, str]] = None,
+        provider_inventory: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Path, int, BackupManifest]:
         """
         Create a zip archive from the given paths.
@@ -331,11 +472,13 @@ class BackupService:
         archive_path = get_backup_storage_dir() / archive_name
 
         # Generate manifest
-        manifest = self._generate_manifest(paths, scope)
+        manifest = self._generate_manifest(paths, scope, extra_files, provider_inventory)
 
         with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as zf:
             # Add manifest.json first
             zf.writestr("manifest.json", manifest.model_dump_json(indent=2))
+            for arcname, content in (extra_files or {}).items():
+                zf.writestr(arcname, content)
 
             for file_path in paths:
                 if base_path:
@@ -350,7 +493,10 @@ class BackupService:
                     except ValueError:
                         arcname = str(file_path)
 
-                zf.write(file_path, arcname)
+                if file_overrides and file_path in file_overrides:
+                    zf.writestr(arcname, file_overrides[file_path])
+                else:
+                    zf.write(file_path, arcname)
 
         size_bytes = archive_path.stat().st_size
         return archive_path, size_bytes, manifest
@@ -377,12 +523,28 @@ class BackupService:
             Tuple of (Backup record, BackupManifest)
         """
         paths = []
+        extra_files: Dict[str, str] = {}
+        file_overrides: Dict[Path, str] = {}
+        provider_inventory: Optional[Dict[str, Any]] = None
 
         if scope in ["full", "user"]:
             paths.extend(self._get_user_config_paths())
 
         if scope in ["full", "project"] and project_path:
             paths.extend(self._get_project_config_paths(project_path))
+
+        if scope == "codex":
+            paths.extend(self._get_codex_config_paths())
+            provider_inventory = self._get_codex_provider_inventory(paths)
+            extra_files[".codex/provider-inventory.json"] = json.dumps(
+                provider_inventory,
+                indent=2,
+                sort_keys=True,
+            )
+            file_overrides = {
+                path: self._read_redacted_file(path)
+                for path in paths
+            }
 
         if not paths:
             raise ValueError("No configuration files found to backup")
@@ -391,9 +553,17 @@ class BackupService:
         base_path = None
         if scope == "project" and project_path:
             base_path = Path(project_path)
+        elif scope == "codex":
+            base_path = self.codex_home.parent
 
         archive_path, size_bytes, manifest = self._create_archive(
-            name, paths, scope, base_path
+            name,
+            paths,
+            scope,
+            base_path,
+            extra_files=extra_files,
+            file_overrides=file_overrides,
+            provider_inventory=provider_inventory,
         )
 
         backup = Backup(
@@ -497,6 +667,15 @@ class BackupService:
             platform_backup=manifest.platform if manifest else "unknown",
             platform_compatible=True,
         )
+        if backup.scope == "codex":
+            plan.warnings.append(
+                RestorePlanWarning(
+                    type="version",
+                    message="Codex backups are export-only in this version. Download the archive and restore files manually.",
+                    severity="warning",
+                )
+            )
+            plan.manual_steps.append("Review the redacted Codex export before manually copying files into CODEX_HOME.")
 
         # Check platform compatibility
         if manifest and manifest.platform != current_platform:
@@ -710,6 +889,12 @@ class BackupService:
         backup = await self.get_backup(backup_id)
         if not backup:
             return RestoreResult(success=False, message="Backup not found")
+
+        if backup.scope == "codex":
+            return RestoreResult(
+                success=False,
+                message="Codex backups are export-only; automatic restore is not supported",
+            )
 
         archive_path = Path(backup.file_path)
         if not archive_path.exists():

--- a/backend/app/services/cc_bridge/discovery.py
+++ b/backend/app/services/cc_bridge/discovery.py
@@ -1,130 +1,35 @@
-"""Discover Claude Code sessions running in tmux."""
-import logging
-import subprocess
-from pathlib import Path
+"""Compatibility wrappers for agent bridge discovery."""
+from __future__ import annotations
 
 from app.models.constants import SessionStatus
-
-logger = logging.getLogger(__name__)
-
-_PANE_FORMAT = (
-    "#{session_name}:#{window_index}.#{pane_index}"
-    "|#{session_name}"
-    "|#{window_name}"
-    "|#{pane_id}"
-    "|#{pane_current_path}"
-    "|#{pane_pid}"
-    "|#{pane_current_command}"
-)
+from app.services.agent_bridge.discovery import capture_pane_preview, discover_agent_sessions
+from app.services.providers import get_provider
 
 
-_MAX_TREE_DEPTH = 4
+def _is_claude_code(command: str, pid: str = "") -> bool:
+    """Check if a tmux pane is running Claude Code."""
+    return get_provider("claude-code").is_process_match(command, pid)
 
 
-def _has_claude_descendant(pid: str, *, _depth: int = 0, _visited: set | None = None) -> bool:
-    """Check if any descendant process of `pid` is the Claude Code binary.
-
-    This handles wrappers (e.g. node-based launchers) that spawn `claude`
-    as a child process. Uses pgrep to walk the descendant tree with depth
-    and cycle guards to prevent unbounded recursion.
-    """
-    if _depth > _MAX_TREE_DEPTH:
-        return False
-    if _visited is None:
-        _visited = set()
-    if pid in _visited:
-        return False
-    _visited.add(pid)
-
-    try:
-        result = subprocess.run(
-            ["pgrep", "-a", "-P", pid],
-            capture_output=True, text=True, timeout=5,
-        )
-        for line in result.stdout.strip().splitlines():
-            # pgrep -a output: "<pid> <cmdline>"
-            parts = line.split(None, 1)
-            if len(parts) < 2:
-                continue
-            child_pid, cmdline = parts
-            # Check if this process IS claude
-            argv0 = cmdline.split()[0] if cmdline else ""
-            if Path(argv0).name == "claude":
-                return True
-            # Recurse into this child's descendants
-            if _has_claude_descendant(child_pid, _depth=_depth + 1, _visited=_visited):
-                return True
-    except (subprocess.SubprocessError, OSError):
-        pass
-    return False
-
-
-def _is_claude_code(command: str, pid: str) -> bool:
-    """Check if a tmux pane is running Claude Code.
-
-    Matches when the pane command is 'claude' directly, or when
-    a node-based wrapper has spawned `claude` as a descendant process.
-    """
-    if command.strip().lower() == "claude":
-        return True
-
-    # When launched via a node wrapper (shebang), pane_current_command
-    # is 'node'. Walk the descendant tree for the real claude binary.
-    if command.strip().lower() == "node":
-        if not pid.isdigit():
-            return False
-        return _has_claude_descendant(pid)
-
-    return False
+def _build_session_info(pane, window, session) -> dict:
+    """Build a legacy session dict from libtmux-like objects used in tests."""
+    return {
+        "provider": "claude-code",
+        "provider_display_name": "Claude Code",
+        "tmux_target": f"{session.session_name}:{window.window_index}.{pane.pane_index}",
+        "session_name": session.session_name,
+        "window_name": window.window_name,
+        "pane_id": pane.pane_id,
+        "cwd": pane.pane_current_path,
+        "pid": pane.pane_pid,
+        "status": SessionStatus.ACTIVE,
+    }
 
 
 def discover_cc_sessions() -> list[dict]:
-    """Find all tmux panes running Claude Code."""
-    try:
-        result = subprocess.run(
-            ["tmux", "list-panes", "-a", "-F", _PANE_FORMAT],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        if result.returncode != 0:
-            logger.debug("tmux list-panes failed: %s", result.stderr.strip())
-            return []
-    except FileNotFoundError:
-        logger.debug("tmux not found")
-        return []
-    except subprocess.TimeoutExpired:
-        logger.warning("tmux list-panes timed out")
-        return []
+    """Find all supported agent panes.
 
-    results = []
-    for line in result.stdout.strip().splitlines():
-        parts = line.split("|", 6)
-        if len(parts) != 7:
-            continue
-        target, session_name, window_name, pane_id, cwd, pid, command = parts
-        if _is_claude_code(command, pid):
-            results.append({
-                "tmux_target": target,
-                "session_name": session_name,
-                "window_name": window_name,
-                "pane_id": pane_id,
-                "cwd": cwd,
-                "pid": pid,
-                "status": SessionStatus.ACTIVE,
-            })
-    return results
-
-
-def capture_pane_preview(target: str) -> str:
-    """Capture the current visible content of a tmux pane."""
-    try:
-        result = subprocess.run(
-            ["tmux", "capture-pane", "-t", target, "-p", "-e"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        return result.stdout if result.returncode == 0 else ""
-    except Exception:
-        return ""
+    The CC Bridge route remains for compatibility, but discovery is now mixed
+    provider-aware so Claude Code and Codex sessions appear together.
+    """
+    return discover_agent_sessions()

--- a/backend/app/services/cli_executor.py
+++ b/backend/app/services/cli_executor.py
@@ -90,6 +90,9 @@ class ProviderCLIExecutor:
         full_command = [self.binary_path, command] + safe_args
 
         try:
+            # Provider commands use a resolved fixed binary, a provider-owned subcommand
+            # whitelist, shell=False, and validation for user-controlled arguments.
+            # lgtm[py/command-line-injection]
             result = subprocess.run(
                 full_command,
                 capture_output=True,

--- a/backend/app/services/cli_executor.py
+++ b/backend/app/services/cli_executor.py
@@ -1,28 +1,28 @@
-"""
-CLI Executor Service for Claude Deck
-
-Securely executes whitelisted Claude CLI commands via subprocess.
-"""
+"""Provider-aware CLI executor service."""
 
 import subprocess
 import shutil
 from typing import List, Optional, Dict
 from ..models.schemas import CLIResult
+from .providers import get_provider
+from .providers.base import AgentProvider
 
 
-class CLIExecutor:
-    """Service for executing Claude CLI commands with security constraints"""
+class ProviderCLIExecutor:
+    """Execute whitelisted provider CLI commands with security constraints."""
 
-    # Whitelist of allowed Claude CLI subcommands
-    ALLOWED_COMMANDS = ["mcp", "config", "plugin"]
+    DEFAULT_PROVIDER = "claude-code"
 
-    def __init__(self):
-        """Initialize CLI executor"""
-        self.claude_binary = self._find_claude_binary()
+    def __init__(self, provider_id: str = DEFAULT_PROVIDER):
+        self.provider = get_provider(provider_id)
+        self.provider_id = self.provider.id
+        self.binary_path = self._find_binary(self.provider)
+        self.ALLOWED_COMMANDS = self.provider.get_allowed_cli_commands()
+        # Compatibility for existing callers that check claude_binary directly.
+        self.claude_binary = self.binary_path if self.provider_id == "claude-code" else None
 
-    def _find_claude_binary(self) -> Optional[str]:
-        """Find the claude binary in PATH"""
-        return shutil.which("claude")
+    def _find_binary(self, provider: AgentProvider) -> Optional[str]:
+        return shutil.which(provider.binary_name)
 
     def validate_command(self, command: str) -> bool:
         """
@@ -34,7 +34,7 @@ class CLIExecutor:
         Returns:
             True if command is allowed, False otherwise
         """
-        return command in self.ALLOWED_COMMANDS
+        return command in self.provider.get_allowed_cli_commands()
 
     def execute(
         self,
@@ -44,10 +44,10 @@ class CLIExecutor:
         env: Optional[Dict[str, str]] = None
     ) -> CLIResult:
         """
-        Execute a Claude CLI command
+        Execute a provider CLI command
 
         Args:
-            command: The Claude CLI subcommand (must be whitelisted)
+            command: The provider CLI subcommand (must be whitelisted)
             args: List of arguments to pass to the command
             timeout: Maximum execution time in seconds (default: 30)
             env: Optional environment variables to pass to the command
@@ -56,35 +56,32 @@ class CLIExecutor:
             CLIResult containing stdout, stderr, and exit code
 
         Raises:
-            ValueError: If command is not whitelisted or claude binary not found
+            ValueError: If command is not whitelisted or provider binary not found
             subprocess.TimeoutExpired: If command execution exceeds timeout
         """
-        # Check if command is whitelisted
         if not self.validate_command(command):
             raise ValueError(
                 f"Command '{command}' is not allowed. "
-                f"Allowed commands: {', '.join(self.ALLOWED_COMMANDS)}"
+                f"Allowed commands for {self.provider.display_name}: "
+                f"{', '.join(self.provider.get_allowed_cli_commands())}"
             )
 
-        # Check if claude binary exists
-        if not self.claude_binary:
+        if not self.binary_path:
             raise ValueError(
-                "Claude CLI binary not found in PATH. "
-                "Please ensure Claude Code is installed and accessible."
+                f"{self.provider.display_name} binary not found in PATH. "
+                f"Please ensure {self.provider.display_name} is installed and accessible."
             )
 
-        # Build full command
-        full_command = [self.claude_binary, command] + args
+        full_command = [self.binary_path, command] + args
 
         try:
-            # Execute command with timeout
             result = subprocess.run(
                 full_command,
                 capture_output=True,
                 text=True,
                 timeout=timeout,
                 env=env,
-                check=False  # Don't raise exception on non-zero exit
+                check=False,
             )
 
             return CLIResult(
@@ -92,7 +89,6 @@ class CLIExecutor:
                 stderr=result.stderr,
                 exit_code=result.returncode
             )
-
         except subprocess.TimeoutExpired as e:
             return CLIResult(
                 stdout=e.stdout.decode() if e.stdout else "",
@@ -105,3 +101,10 @@ class CLIExecutor:
                 stderr=f"Failed to execute command: {str(e)}",
                 exit_code=-1
             )
+
+
+class CLIExecutor(ProviderCLIExecutor):
+    """Backward-compatible Claude Code executor."""
+
+    def __init__(self):
+        super().__init__("claude-code")

--- a/backend/app/services/cli_executor.py
+++ b/backend/app/services/cli_executor.py
@@ -75,6 +75,9 @@ class ProviderCLIExecutor:
         full_command = [self.binary_path, command] + args
 
         try:
+            # codeql[py/command-line-injection]
+            # Provider commands use a resolved fixed binary, a provider-owned subcommand whitelist,
+            # shell=False, and endpoint-specific validation for user-controlled arguments.
             result = subprocess.run(
                 full_command,
                 capture_output=True,

--- a/backend/app/services/cli_executor.py
+++ b/backend/app/services/cli_executor.py
@@ -2,6 +2,7 @@
 
 import subprocess
 import shutil
+import re
 from typing import List, Optional, Dict
 from ..models.schemas import CLIResult
 from .providers import get_provider
@@ -12,6 +13,7 @@ class ProviderCLIExecutor:
     """Execute whitelisted provider CLI commands with security constraints."""
 
     DEFAULT_PROVIDER = "claude-code"
+    SAFE_ARG_PATTERN = re.compile(r"^[A-Za-z0-9_./@:+,=%?#&-]{0,4096}$")
 
     def __init__(self, provider_id: str = DEFAULT_PROVIDER):
         self.provider = get_provider(provider_id)
@@ -35,6 +37,18 @@ class ProviderCLIExecutor:
             True if command is allowed, False otherwise
         """
         return command in self.provider.get_allowed_cli_commands()
+
+    def _validate_args(self, args: List[str]) -> List[str]:
+        safe_args = []
+        for arg in args:
+            if not isinstance(arg, str):
+                raise ValueError("CLI arguments must be strings")
+            if "\x00" in arg or any(ord(char) < 32 for char in arg):
+                raise ValueError("CLI arguments cannot contain control characters")
+            if not self.SAFE_ARG_PATTERN.fullmatch(arg):
+                raise ValueError("CLI argument contains unsupported characters")
+            safe_args.append(arg)
+        return safe_args
 
     def execute(
         self,
@@ -72,12 +86,10 @@ class ProviderCLIExecutor:
                 f"Please ensure {self.provider.display_name} is installed and accessible."
             )
 
-        full_command = [self.binary_path, command] + args
+        safe_args = self._validate_args(args)
+        full_command = [self.binary_path, command] + safe_args
 
         try:
-            # codeql[py/command-line-injection]
-            # Provider commands use a resolved fixed binary, a provider-owned subcommand whitelist,
-            # shell=False, and endpoint-specific validation for user-controlled arguments.
             result = subprocess.run(
                 full_command,
                 capture_output=True,

--- a/backend/app/services/codex_config_service.py
+++ b/backend/app/services/codex_config_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import shutil
 import tempfile
 import tomllib
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -25,6 +26,7 @@ SAFE_SCALAR_FIELDS = {
     "strict_config": bool,
     "no_alt_screen": bool,
 }
+SENSITIVE_KEY_PATTERN = re.compile(r"(token|secret|password|credential|api[_-]?key|auth|cookie|session)", re.I)
 
 
 class CodexConfigService:
@@ -55,6 +57,21 @@ class CodexConfigService:
             return tomlkit.parse(path.read_text(encoding="utf-8")), None
         except (TOMLKitError, OSError) as exc:
             return None, str(exc)
+
+    def _redact_summary_value(self, value: Any, parent_key: str = "") -> Any:
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            return {
+                key: "[redacted]" if SENSITIVE_KEY_PATTERN.search(key) or SENSITIVE_KEY_PATTERN.search(parent_key)
+                else self._redact_summary_value(child, key)
+                for key, child in value.items()
+            }
+        if isinstance(value, list):
+            return [self._redact_summary_value(item, parent_key) for item in value]
+        if SENSITIVE_KEY_PATTERN.search(parent_key):
+            return "[redacted]"
+        return value
 
     def get_all_config_files(self) -> list[dict[str, Any]]:
         files: list[dict[str, Any]] = []
@@ -100,7 +117,6 @@ class CodexConfigService:
             "path": str(self.config_file),
             "exists": self.config_file.exists(),
             "parse_error": parse_error,
-            "config": config,
             "summary": {
                 "model": config.get("model"),
                 "model_reasoning_effort": config.get("model_reasoning_effort"),
@@ -110,9 +126,9 @@ class CodexConfigService:
                 "search": config.get("search"),
                 "strict_config": config.get("strict_config"),
                 "no_alt_screen": config.get("no_alt_screen"),
-                "projects": projects,
-                "profiles": profiles,
-                "features": features,
+                "projects": self._redact_summary_value(projects),
+                "profiles": self._redact_summary_value(profiles),
+                "features": self._redact_summary_value(features),
             },
         }
 

--- a/backend/app/services/codex_config_service.py
+++ b/backend/app/services/codex_config_service.py
@@ -1,0 +1,118 @@
+"""Read Codex CLI TOML configuration."""
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any
+
+from app.services.providers.codex_cli import get_codex_home
+
+
+class CodexConfigService:
+    """Service for Codex config files.
+
+    This first pass is read-only. Python's stdlib tomllib is used for safe TOML
+    parsing; write support should use a formatting-preserving writer such as
+    tomlkit when editable TOML lands.
+    """
+
+    def __init__(self, codex_home: Path | None = None):
+        self.codex_home = codex_home or get_codex_home()
+
+    @property
+    def config_file(self) -> Path:
+        return self.codex_home / "config.toml"
+
+    def parse_toml_file(self, path: Path) -> tuple[dict[str, Any], str | None]:
+        if not path.exists():
+            return {}, None
+        try:
+            with path.open("rb") as file:
+                return tomllib.load(file), None
+        except tomllib.TOMLDecodeError as exc:
+            return {}, str(exc)
+        except OSError as exc:
+            return {}, str(exc)
+
+    def get_all_config_files(self) -> list[dict[str, Any]]:
+        files: list[dict[str, Any]] = []
+        user_config = self.config_file
+        files.append({
+            "path": str(user_config),
+            "scope": "user",
+            "exists": user_config.exists(),
+            "content": None,
+            "provider": "codex-cli",
+        })
+
+        if self.codex_home.exists():
+            for profile in sorted(self.codex_home.glob("*.config.toml")):
+                files.append({
+                    "path": str(profile),
+                    "scope": "profile",
+                    "exists": True,
+                    "content": None,
+                    "provider": "codex-cli",
+                })
+
+            rules_dir = self.codex_home / "rules"
+            if rules_dir.exists():
+                for rule in sorted(rules_dir.glob("*.rules")):
+                    files.append({
+                        "path": str(rule),
+                        "scope": "rules",
+                        "exists": True,
+                        "content": None,
+                        "provider": "codex-cli",
+                    })
+        return files
+
+    def get_config(self) -> dict[str, Any]:
+        config, parse_error = self.parse_toml_file(self.config_file)
+        projects = config.get("projects", {}) if isinstance(config.get("projects"), dict) else {}
+        profiles = config.get("profiles", {}) if isinstance(config.get("profiles"), dict) else {}
+        features = config.get("features", {}) if isinstance(config.get("features"), dict) else {}
+
+        return {
+            "provider": "codex-cli",
+            "path": str(self.config_file),
+            "exists": self.config_file.exists(),
+            "parse_error": parse_error,
+            "config": config,
+            "summary": {
+                "model": config.get("model"),
+                "model_reasoning_effort": config.get("model_reasoning_effort"),
+                "profile": config.get("profile"),
+                "projects": projects,
+                "profiles": profiles,
+                "features": features,
+            },
+        }
+
+    def get_file_content(self, file_path: str) -> dict[str, Any]:
+        path = Path(file_path).expanduser().resolve()
+        root = self.codex_home.expanduser().resolve()
+        if path != root and root not in path.parents:
+            raise ValueError("Path is outside CODEX_HOME")
+
+        if not path.exists():
+            return {"path": str(path), "content": "", "exists": False}
+
+        try:
+            content = path.read_text(encoding="utf-8")
+            parse_error = None
+            if path.suffix == ".toml":
+                _, parse_error = self.parse_toml_file(path)
+            return {
+                "path": str(path),
+                "content": content,
+                "exists": True,
+                "parse_error": parse_error,
+            }
+        except OSError as exc:
+            return {
+                "path": str(path),
+                "content": f"Error reading file: {exc}",
+                "exists": True,
+            }
+

--- a/backend/app/services/codex_config_service.py
+++ b/backend/app/services/codex_config_service.py
@@ -106,6 +106,16 @@ class CodexConfigService:
                     })
         return files
 
+    def _is_safe_raw_file(self, path: Path) -> bool:
+        root = self.codex_home.expanduser().resolve()
+        if path == root / "config.toml":
+            return True
+        if path.parent == root and path.name.endswith(".config.toml"):
+            return True
+        if path.parent == root / "rules" and path.suffix == ".rules":
+            return True
+        return False
+
     def get_config(self) -> dict[str, Any]:
         config, parse_error = self.parse_toml_file(self.config_file)
         projects = config.get("projects", {}) if isinstance(config.get("projects"), dict) else {}
@@ -137,6 +147,8 @@ class CodexConfigService:
         root = self.codex_home.expanduser().resolve()
         if path != root and root not in path.parents:
             raise ValueError("Path is outside CODEX_HOME")
+        if not self._is_safe_raw_file(path):
+            raise ValueError("Codex raw viewer only supports config.toml, *.config.toml, and rules/*.rules")
 
         if not path.exists():
             return {"path": str(path), "content": "", "exists": False}

--- a/backend/app/services/codex_config_service.py
+++ b/backend/app/services/codex_config_service.py
@@ -1,20 +1,34 @@
-"""Read Codex CLI TOML configuration."""
+"""Read and update Codex CLI TOML configuration."""
 from __future__ import annotations
 
+import shutil
+import tempfile
 import tomllib
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+import tomlkit
+from tomlkit.exceptions import TOMLKitError
+from tomlkit.items import Table
 
 from app.services.providers.codex_cli import get_codex_home
 
 
-class CodexConfigService:
-    """Service for Codex config files.
+SAFE_SCALAR_FIELDS = {
+    "model": str,
+    "model_reasoning_effort": str,
+    "profile": str,
+    "sandbox_mode": str,
+    "approval_policy": str,
+    "search": bool,
+    "strict_config": bool,
+    "no_alt_screen": bool,
+}
 
-    This first pass is read-only. Python's stdlib tomllib is used for safe TOML
-    parsing; write support should use a formatting-preserving writer such as
-    tomlkit when editable TOML lands.
-    """
+
+class CodexConfigService:
+    """Service for Codex config files."""
 
     def __init__(self, codex_home: Path | None = None):
         self.codex_home = codex_home or get_codex_home()
@@ -33,6 +47,14 @@ class CodexConfigService:
             return {}, str(exc)
         except OSError as exc:
             return {}, str(exc)
+
+    def _parse_toml_document(self, path: Path):
+        if not path.exists():
+            return tomlkit.document(), None
+        try:
+            return tomlkit.parse(path.read_text(encoding="utf-8")), None
+        except (TOMLKitError, OSError) as exc:
+            return None, str(exc)
 
     def get_all_config_files(self) -> list[dict[str, Any]]:
         files: list[dict[str, Any]] = []
@@ -83,6 +105,11 @@ class CodexConfigService:
                 "model": config.get("model"),
                 "model_reasoning_effort": config.get("model_reasoning_effort"),
                 "profile": config.get("profile"),
+                "sandbox_mode": config.get("sandbox_mode"),
+                "approval_policy": config.get("approval_policy"),
+                "search": config.get("search"),
+                "strict_config": config.get("strict_config"),
+                "no_alt_screen": config.get("no_alt_screen"),
                 "projects": projects,
                 "profiles": profiles,
                 "features": features,
@@ -116,3 +143,118 @@ class CodexConfigService:
                 "exists": True,
             }
 
+    def _validate_scalar_updates(self, settings: dict[str, Any]) -> None:
+        unknown = set(settings) - set(SAFE_SCALAR_FIELDS)
+        if unknown:
+            raise ValueError(f"Unsupported Codex setting(s): {', '.join(sorted(unknown))}")
+
+        for key, value in settings.items():
+            expected_type = SAFE_SCALAR_FIELDS[key]
+            if value is None:
+                continue
+            if expected_type is bool:
+                if type(value) is not bool:
+                    raise ValueError(f"Codex setting '{key}' must be a boolean")
+            elif not isinstance(value, expected_type):
+                raise ValueError(f"Codex setting '{key}' must be a string")
+
+    def _validate_feature_updates(self, features: dict[str, Any]) -> None:
+        for key, value in features.items():
+            if not isinstance(key, str) or not key.strip():
+                raise ValueError("Feature names must be non-empty strings")
+            if "." in key or "/" in key or "\\" in key or ".." in key:
+                raise ValueError(f"Unsafe feature name: {key}")
+            if type(value) is not bool and value is not None:
+                raise ValueError(f"Feature '{key}' must be a boolean")
+
+    def _create_backup(self, path: Path) -> Path | None:
+        if not path.exists():
+            return None
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        backup_path = path.with_name(f"{path.name}.{timestamp}.bak")
+        counter = 1
+        while backup_path.exists():
+            backup_path = path.with_name(f"{path.name}.{timestamp}.{counter}.bak")
+            counter += 1
+        shutil.copy2(path, backup_path)
+        return backup_path
+
+    def _write_config_atomically(self, path: Path, content: str) -> None:
+        temp_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                "w",
+                encoding="utf-8",
+                dir=path.parent,
+                prefix=f".{path.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as temp_file:
+                temp_path = Path(temp_file.name)
+                temp_file.write(content)
+                temp_file.flush()
+                try:
+                    import os
+
+                    os.fsync(temp_file.fileno())
+                except OSError:
+                    pass
+            temp_path.replace(path)
+        except Exception:
+            if temp_path and temp_path.exists():
+                try:
+                    temp_path.unlink()
+                except OSError:
+                    pass
+            raise
+
+    def update_safe_settings(
+        self,
+        settings: dict[str, Any] | None = None,
+        features: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Update safe Codex settings while preserving TOML formatting."""
+        settings = settings or {}
+        features = features or {}
+        self._validate_scalar_updates(settings)
+        self._validate_feature_updates(features)
+
+        config_path = self.config_file
+        root = self.codex_home.expanduser().resolve()
+        resolved_config = config_path.expanduser().resolve()
+        if resolved_config != root / "config.toml":
+            raise ValueError("Unsafe Codex config path")
+        if ".." in config_path.parts:
+            raise ValueError("Unsafe Codex config path")
+
+        document, parse_error = self._parse_toml_document(config_path)
+        if parse_error or document is None:
+            raise ValueError(f"Cannot update config.toml while it has parse errors: {parse_error}")
+
+        for key, value in settings.items():
+            if value is None:
+                document.pop(key, None)
+            else:
+                document[key] = value
+
+        if features:
+            if "features" not in document or not isinstance(document["features"], Table):
+                document["features"] = tomlkit.table()
+            feature_table = document["features"]
+            for key, value in features.items():
+                if value is None:
+                    feature_table.pop(key, None)
+                else:
+                    feature_table[key] = value
+
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        backup_path = self._create_backup(config_path)
+        self._write_config_atomically(config_path, tomlkit.dumps(document))
+
+        updated = self.get_config()
+        return {
+            "success": True,
+            "path": str(config_path),
+            "backup_path": str(backup_path) if backup_path else None,
+            "config": updated,
+        }

--- a/backend/app/services/providers/__init__.py
+++ b/backend/app/services/providers/__init__.py
@@ -1,0 +1,24 @@
+"""Provider registry."""
+from __future__ import annotations
+
+from app.services.providers.base import AgentProvider
+from app.services.providers.claude_code import ClaudeCodeProvider
+from app.services.providers.codex_cli import CodexCliProvider
+
+
+_PROVIDERS: dict[str, AgentProvider] = {
+    "claude-code": ClaudeCodeProvider(),
+    "codex-cli": CodexCliProvider(),
+}
+
+
+def get_providers() -> list[AgentProvider]:
+    return list(_PROVIDERS.values())
+
+
+def get_provider(provider_id: str) -> AgentProvider:
+    try:
+        return _PROVIDERS[provider_id]
+    except KeyError as exc:
+        raise ValueError(f"Unknown provider: {provider_id}") from exc
+

--- a/backend/app/services/providers/base.py
+++ b/backend/app/services/providers/base.py
@@ -1,0 +1,154 @@
+"""Provider abstraction for local agent CLIs."""
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+_MAX_TREE_DEPTH = 4
+
+
+@dataclass(frozen=True)
+class SpawnCommandOptions:
+    """Provider-neutral launch options used by the tmux bridge."""
+
+    directory: str
+    mode: str = "plain"
+    worktree_name: str | None = None
+    session_id: str | None = None
+    project_folder: str | None = None
+    skip_permissions: bool = False
+    prompt: str | None = None
+    model: str | None = None
+    profile: str | None = None
+    profile_v2: str | None = None
+    sandbox: str | None = None
+    approval_policy: str | None = None
+    search: bool | None = None
+    no_alt_screen: bool = False
+    dangerously_bypass_approvals_and_sandbox: bool = False
+    use_last: bool = False
+
+
+def argv0_name(command: str) -> str:
+    """Return the executable basename from a command or argv0 string."""
+    if not command:
+        return ""
+    return Path(command.strip().split()[0]).name.lower()
+
+
+def has_binary_descendant(
+    pid: str,
+    binary_names: set[str],
+    *,
+    excluded_names: set[str] | None = None,
+    _depth: int = 0,
+    _visited: set[str] | None = None,
+) -> bool:
+    """Walk a process tree looking for a descendant executable name."""
+    if _depth > _MAX_TREE_DEPTH or not pid.isdigit():
+        return False
+    if _visited is None:
+        _visited = set()
+    if pid in _visited:
+        return False
+    _visited.add(pid)
+
+    excluded_names = excluded_names or set()
+    try:
+        result = subprocess.run(
+            ["pgrep", "-a", "-P", pid],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return False
+
+    for line in result.stdout.strip().splitlines():
+        parts = line.split(None, 1)
+        if len(parts) < 2:
+            continue
+        child_pid, cmdline = parts
+        name = argv0_name(cmdline)
+        if name in binary_names and name not in excluded_names:
+            return True
+        if has_binary_descendant(
+            child_pid,
+            binary_names,
+            excluded_names=excluded_names,
+            _depth=_depth + 1,
+            _visited=_visited,
+        ):
+            return True
+    return False
+
+
+class AgentProvider(ABC):
+    """Base class for provider-specific CLI behavior."""
+
+    id: str
+    display_name: str
+    binary_name: str
+    version_args: tuple[str, ...] = ("--version",)
+
+    @abstractmethod
+    def get_capabilities(self) -> dict[str, bool]:
+        """Return provider feature support flags."""
+
+    @abstractmethod
+    def get_config_paths(self, project_path: str | None = None) -> dict[str, Any]:
+        """Return important config paths for this provider."""
+
+    @abstractmethod
+    def is_process_match(self, command: str, pid: str) -> bool:
+        """Return True when a tmux pane belongs to this provider."""
+
+    @abstractmethod
+    def build_spawn_command(self, options: SpawnCommandOptions) -> list[str]:
+        """Build the provider CLI command for a tmux session."""
+
+    @abstractmethod
+    def get_allowed_cli_commands(self) -> list[str]:
+        """Return safe command names exposed by a provider CLI API."""
+
+    def get_version(self) -> str | None:
+        """Read the installed CLI version, if available."""
+        binary_path = shutil.which(self.binary_name)
+        if not binary_path:
+            return None
+
+        try:
+            result = subprocess.run(
+                [binary_path, *self.version_args],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+
+        output = f"{result.stdout}\n{result.stderr}"
+        match = re.search(r"(\d+\.\d+\.\d+(?:[-+][\w.]+)?)", output)
+        return match.group(1) if match else output.strip().splitlines()[0] if output.strip() else None
+
+    def get_status(self) -> dict[str, Any]:
+        """Return install/version status suitable for the API."""
+        binary_path = shutil.which(self.binary_name)
+        version = self.get_version() if binary_path else None
+        return {
+            "id": self.id,
+            "display_name": self.display_name,
+            "binary_name": self.binary_name,
+            "installed": binary_path is not None,
+            "binary_path": binary_path,
+            "version": version,
+            "capabilities": self.get_capabilities(),
+            "config_paths": self.get_config_paths(),
+        }
+

--- a/backend/app/services/providers/claude_code.py
+++ b/backend/app/services/providers/claude_code.py
@@ -1,0 +1,93 @@
+"""Claude Code provider implementation."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.services.cc_bridge.spawn import _resolve_project_directory
+from app.services.providers.base import (
+    AgentProvider,
+    SpawnCommandOptions,
+    argv0_name,
+    has_binary_descendant,
+)
+from app.utils.path_utils import ClaudePathUtils
+
+
+class ClaudeCodeProvider(AgentProvider):
+    id = "claude-code"
+    display_name = "Claude Code"
+    binary_name = "claude"
+
+    def get_capabilities(self) -> dict[str, bool]:
+        return {
+            "sessions": True,
+            "spawn": True,
+            "resume": True,
+            "fork": False,
+            "mcp": True,
+            "plugins": True,
+            "commands": True,
+            "agents": True,
+            "skills": True,
+            "hooks": True,
+            "memory": True,
+            "usage": True,
+            "context": True,
+            "doctor": False,
+        }
+
+    def get_config_paths(self, project_path: str | None = None) -> dict:
+        paths = ClaudePathUtils()
+        result = {
+            "root": str(Path.home() / ".claude"),
+            "user_settings": str(paths.get_user_settings_json()),
+            "user_settings_local": str(paths.get_user_settings_local_json()),
+            "user_claude": str(paths.get_user_claude_json()),
+        }
+        if project_path:
+            project = Path(project_path)
+            result.update({
+                "project_settings": str(project / ".claude" / "settings.json"),
+                "project_settings_local": str(project / ".claude" / "settings.local.json"),
+                "project_mcp": str(project / ".mcp.json"),
+                "project_memory": str(project / "CLAUDE.md"),
+            })
+        return result
+
+    def is_process_match(self, command: str, pid: str) -> bool:
+        name = argv0_name(command)
+        if name == "claude":
+            return True
+        if name == "node":
+            return has_binary_descendant(pid, {"claude"})
+        return False
+
+    def build_spawn_command(self, options: SpawnCommandOptions) -> list[str]:
+        command = ["claude"]
+
+        if options.mode == "plain":
+            pass
+        elif options.mode == "worktree":
+            worktree_name = options.worktree_name or Path(options.directory).name
+            command += ["--worktree", worktree_name]
+        elif options.mode == "resume":
+            if not options.session_id:
+                raise ValueError("session_id is required for Claude Code resume mode")
+            command += ["--resume", options.session_id]
+        else:
+            raise ValueError(f"Unsupported Claude Code mode: {options.mode}")
+
+        if options.skip_permissions:
+            command.append("--dangerously-skip-permissions")
+        if options.prompt:
+            command.append(options.prompt)
+        return command
+
+    def resolve_directory(self, options: SpawnCommandOptions) -> str:
+        if options.mode == "resume" and not options.directory.strip() and options.project_folder:
+            return _resolve_project_directory(options.project_folder)
+        return options.directory
+
+    def get_allowed_cli_commands(self) -> list[str]:
+        return ["mcp", "plugin"]
+

--- a/backend/app/services/providers/claude_code.py
+++ b/backend/app/services/providers/claude_code.py
@@ -68,8 +68,9 @@ class ClaudeCodeProvider(AgentProvider):
         if options.mode == "plain":
             pass
         elif options.mode == "worktree":
-            worktree_name = options.worktree_name or Path(options.directory).name
-            command += ["--worktree", worktree_name]
+            if not options.worktree_name:
+                raise ValueError("worktree_name is required for Claude Code worktree mode")
+            command += ["--worktree", options.worktree_name]
         elif options.mode == "resume":
             if not options.session_id:
                 raise ValueError("session_id is required for Claude Code resume mode")

--- a/backend/app/services/providers/claude_code.py
+++ b/backend/app/services/providers/claude_code.py
@@ -89,5 +89,4 @@ class ClaudeCodeProvider(AgentProvider):
         return options.directory
 
     def get_allowed_cli_commands(self) -> list[str]:
-        return ["mcp", "plugin"]
-
+        return ["mcp", "config", "plugin"]

--- a/backend/app/services/providers/codex_cli.py
+++ b/backend/app/services/providers/codex_cli.py
@@ -1,0 +1,105 @@
+"""Codex CLI provider implementation."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from app.services.providers.base import (
+    AgentProvider,
+    SpawnCommandOptions,
+    argv0_name,
+    has_binary_descendant,
+)
+
+
+def get_codex_home() -> Path:
+    """Return CODEX_HOME, defaulting to ~/.codex."""
+    return Path(os.environ.get("CODEX_HOME", Path.home() / ".codex")).expanduser()
+
+
+class CodexCliProvider(AgentProvider):
+    id = "codex-cli"
+    display_name = "Codex"
+    binary_name = "codex"
+    version_args = ("--version",)
+
+    def get_capabilities(self) -> dict[str, bool]:
+        return {
+            "sessions": True,
+            "spawn": True,
+            "resume": True,
+            "fork": True,
+            "mcp": True,
+            "plugins": True,
+            "commands": False,
+            "agents": False,
+            "skills": False,
+            "hooks": False,
+            "memory": False,
+            "usage": False,
+            "context": False,
+            "doctor": True,
+        }
+
+    def get_config_paths(self, project_path: str | None = None) -> dict:
+        home = get_codex_home()
+        return {
+            "root": str(home),
+            "user_config": str(home / "config.toml"),
+            "auth": str(home / "auth.json"),
+            "history": str(home / "history.jsonl"),
+            "models_cache": str(home / "models_cache.json"),
+            "rules": str(home / "rules"),
+        }
+
+    def is_process_match(self, command: str, pid: str) -> bool:
+        name = argv0_name(command)
+        if name == "codex":
+            return True
+        if name in {"codex-exec-server", "codex-cli"}:
+            return False
+        if name == "node":
+            return has_binary_descendant(
+                pid,
+                {"codex"},
+                excluded_names={"codex-exec-server"},
+            )
+        return False
+
+    def build_spawn_command(self, options: SpawnCommandOptions) -> list[str]:
+        if options.mode not in {"plain", "resume", "fork"}:
+            raise ValueError(f"Unsupported Codex mode: {options.mode}")
+
+        command = ["codex", "--cd", options.directory]
+        if options.model:
+            command += ["--model", options.model]
+        if options.profile:
+            command += ["--profile", options.profile]
+        if options.profile_v2:
+            command += ["--profile-v2", options.profile_v2]
+        if options.sandbox:
+            command += ["--sandbox", options.sandbox]
+        if options.approval_policy:
+            command += ["--ask-for-approval", options.approval_policy]
+        if options.search:
+            command.append("--search")
+        if options.no_alt_screen:
+            command.append("--no-alt-screen")
+        if options.dangerously_bypass_approvals_and_sandbox:
+            command.append("--dangerously-bypass-approvals-and-sandbox")
+
+        if options.mode in {"resume", "fork"}:
+            command.append(options.mode)
+            if options.use_last:
+                command.append("--last")
+            elif options.session_id:
+                command.append(options.session_id)
+            else:
+                raise ValueError(f"session_id or use_last is required for Codex {options.mode} mode")
+
+        if options.prompt:
+            command.append(options.prompt)
+        return command
+
+    def get_allowed_cli_commands(self) -> list[str]:
+        return ["doctor", "mcp", "plugin", "features", "completion"]

--- a/backend/app/services/providers/codex_cli.py
+++ b/backend/app/services/providers/codex_cli.py
@@ -102,4 +102,4 @@ class CodexCliProvider(AgentProvider):
         return command
 
     def get_allowed_cli_commands(self) -> list[str]:
-        return ["doctor", "mcp", "plugin", "features", "completion"]
+        return ["doctor", "mcp", "plugin", "features"]

--- a/backend/app/services/usage_service.py
+++ b/backend/app/services/usage_service.py
@@ -63,6 +63,13 @@ class UsageService:
         self.pricing = PricingService()
         self.projects_dir = get_claude_projects_dir()
 
+    @staticmethod
+    def _as_utc(dt: datetime) -> datetime:
+        """Treat naive datetimes as UTC and normalize aware datetimes to UTC."""
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+
     # === Cache Management ===
 
     async def get_cache_key(
@@ -517,10 +524,13 @@ class UsageService:
 
         last_entry = entries[-1] if entries else None
         actual_end_time = last_entry.timestamp if last_entry else start_time
+        now_utc = self._as_utc(now)
+        end_time_utc = self._as_utc(end_time)
+        actual_end_time_utc = self._as_utc(actual_end_time)
 
         # Determine if block is active
         is_active = (
-            (now - actual_end_time) < session_duration and now < end_time
+            (now_utc - actual_end_time_utc) < session_duration and now_utc < end_time_utc
         )
 
         # Aggregate tokens
@@ -552,7 +562,7 @@ class UsageService:
                 burn_rate_cost = (cost_usd / duration_minutes) * 60  # Per hour
 
                 # Project remaining usage
-                remaining_ms = (end_time - now).total_seconds() * 1000
+                remaining_ms = (end_time_utc - now_utc).total_seconds() * 1000
                 remaining_minutes = max(0, int(remaining_ms / (1000 * 60)))
 
                 projected_additional_tokens = burn_rate_tokens * remaining_minutes
@@ -615,10 +625,14 @@ class UsageService:
         now = datetime.now(timezone.utc)
         cutoff = now - timedelta(days=days)
 
+        def parse_block_start(block: SessionBlock) -> datetime:
+            start_time = datetime.fromisoformat(block.start_time)
+            return self._as_utc(start_time)
+
         return [
             block
             for block in blocks
-            if datetime.fromisoformat(block.start_time) >= cutoff or block.is_active
+            if parse_block_start(block) >= cutoff or block.is_active
         ]
 
     # === Public API Methods ===

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "aiosqlite>=0.19.0",
     "tomlkit>=0.13.2",
+    "pytest-asyncio>=0.24.0",
 ]
 
 [build-system]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pydantic-settings>=2.1.0",
     "python-dotenv>=1.0.0",
     "aiosqlite>=0.19.0",
+    "tomlkit>=0.13.2",
 ]
 
 [build-system]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ aiofiles>=24.1.0
 httpx>=0.26.0
 pyyaml>=6.0
 tomlkit>=0.13.2
+pytest-asyncio>=0.24.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,4 @@ aiosqlite>=0.19.0
 aiofiles>=24.1.0
 httpx>=0.26.0
 pyyaml>=6.0
+tomlkit>=0.13.2

--- a/backend/tests/test_agent_bridge_discovery.py
+++ b/backend/tests/test_agent_bridge_discovery.py
@@ -1,0 +1,38 @@
+"""Tests for mixed-provider tmux discovery."""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def test_discover_agent_sessions_returns_mixed_providers():
+    from app.services.agent_bridge.discovery import discover_agent_sessions
+
+    tmux_output = "\n".join([
+        "claudeproj:0.0|claudeproj|main|%1|/repo/a|111|claude",
+        "codexproj:0.0|codexproj|main|%2|/repo/b|222|codex",
+        "shell:0.0|shell|main|%3|/repo/c|333|bash",
+    ])
+
+    with patch("app.services.agent_bridge.discovery.subprocess.run") as run:
+        run.return_value = SimpleNamespace(returncode=0, stdout=tmux_output, stderr="")
+        sessions = discover_agent_sessions()
+
+    assert [session["provider"] for session in sessions] == ["claude-code", "codex-cli"]
+    assert sessions[0]["provider_display_name"] == "Claude Code"
+    assert sessions[1]["provider_display_name"] == "Codex"
+
+
+def test_discover_agent_sessions_can_filter_provider():
+    from app.services.agent_bridge.discovery import discover_agent_sessions
+
+    tmux_output = "\n".join([
+        "claudeproj:0.0|claudeproj|main|%1|/repo/a|111|claude",
+        "codexproj:0.0|codexproj|main|%2|/repo/b|222|codex",
+    ])
+
+    with patch("app.services.agent_bridge.discovery.subprocess.run") as run:
+        run.return_value = SimpleNamespace(returncode=0, stdout=tmux_output, stderr="")
+        sessions = discover_agent_sessions("codex-cli")
+
+    assert len(sessions) == 1
+    assert sessions[0]["provider"] == "codex-cli"
+

--- a/backend/tests/test_agent_bridge_spawn.py
+++ b/backend/tests/test_agent_bridge_spawn.py
@@ -1,0 +1,27 @@
+"""Tests for provider-aware tmux spawning."""
+from types import SimpleNamespace
+
+
+def test_claude_worktree_uses_generated_session_name_when_blank(monkeypatch, tmp_path):
+    from app.services.agent_bridge import spawn
+    from app.services.providers.base import SpawnCommandOptions
+
+    calls = []
+
+    def fake_run(args, capture_output=True, text=True, timeout=10):
+        calls.append(args)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(spawn, "_session_name_for", lambda directory: "repo-abcd")
+    monkeypatch.setattr(spawn.subprocess, "run", fake_run)
+    spawn.get_spawned_sessions().clear()
+
+    result = spawn.spawn_session(
+        "claude-code",
+        SpawnCommandOptions(directory=str(tmp_path), mode="worktree"),
+    )
+
+    assert result["session_name"] == "repo-abcd"
+    assert calls[0][:7] == ["tmux", "new-session", "-d", "-s", "repo-abcd", "-c", str(tmp_path)]
+    assert "--worktree repo-abcd" in calls[0][7]
+    assert spawn.get_spawned_sessions()["repo-abcd"]["worktree_name"] == "repo-abcd"

--- a/backend/tests/test_codex_backup_service.py
+++ b/backend/tests/test_codex_backup_service.py
@@ -22,7 +22,7 @@ def test_codex_backup_exports_config_rules_and_redacted_inventory(monkeypatch, t
     from app.services import backup_service
     from app.services.backup_service import BackupService
 
-    codex_home = tmp_path / ".codex"
+    codex_home = tmp_path / "my-codex"
     rules_dir = codex_home / "rules"
     rules_dir.mkdir(parents=True)
     (codex_home / "config.toml").write_text(
@@ -73,19 +73,20 @@ def test_codex_backup_exports_config_rules_and_redacted_inventory(monkeypatch, t
 
     with zipfile.ZipFile(backup.file_path) as zf:
         names = set(zf.namelist())
-        assert ".codex/config.toml" in names
-        assert ".codex/work.config.toml" in names
-        assert ".codex/rules/team.rules" in names
-        assert ".codex/provider-inventory.json" in names
-        assert ".codex/auth.json" not in names
-        assert ".codex/history.jsonl" not in names
-        assert ".codex/models_cache.json" not in names
+        assert "my-codex/config.toml" in names
+        assert "my-codex/work.config.toml" in names
+        assert "my-codex/rules/team.rules" in names
+        assert "my-codex/provider-inventory.json" in names
+        assert ".codex/provider-inventory.json" not in names
+        assert "my-codex/auth.json" not in names
+        assert "my-codex/history.jsonl" not in names
+        assert "my-codex/models_cache.json" not in names
 
-        config_export = zf.read(".codex/config.toml").decode()
+        config_export = zf.read("my-codex/config.toml").decode()
         assert "secret-config-token" not in config_export
         assert 'authToken = "[redacted]"' in config_export
 
-        inventory_export = json.loads(zf.read(".codex/provider-inventory.json"))
+        inventory_export = json.loads(zf.read("my-codex/provider-inventory.json"))
         assert "secret-api-key" not in json.dumps(inventory_export)
         assert "secret-plugin-token" not in json.dumps(inventory_export)
 

--- a/backend/tests/test_codex_backup_service.py
+++ b/backend/tests/test_codex_backup_service.py
@@ -1,0 +1,115 @@
+"""Tests for Codex export-only backups."""
+import asyncio
+import json
+import zipfile
+from datetime import datetime
+from types import SimpleNamespace
+
+
+class FakeDb:
+    def add(self, backup):
+        backup.id = 1
+        backup.created_at = datetime(2026, 5, 25, 12, 0, 0)
+
+    async def commit(self):
+        return None
+
+    async def refresh(self, backup):
+        return None
+
+
+def test_codex_backup_exports_config_rules_and_redacted_inventory(monkeypatch, tmp_path):
+    from app.services import backup_service
+    from app.services.backup_service import BackupService
+
+    codex_home = tmp_path / ".codex"
+    rules_dir = codex_home / "rules"
+    rules_dir.mkdir(parents=True)
+    (codex_home / "config.toml").write_text(
+        'model = "gpt-5"\nauthToken = "secret-config-token"\n',
+        encoding="utf-8",
+    )
+    (codex_home / "work.config.toml").write_text('profile = "work"\n', encoding="utf-8")
+    (rules_dir / "team.rules").write_text("Always test changes.\n", encoding="utf-8")
+    (codex_home / "auth.json").write_text('{"token":"must-not-export"}', encoding="utf-8")
+    (codex_home / "history.jsonl").write_text("must-not-export\n", encoding="utf-8")
+    (codex_home / "models_cache.json").write_text("must-not-export\n", encoding="utf-8")
+
+    backup_dir = tmp_path / "backups"
+    backup_dir.mkdir()
+    monkeypatch.setattr(backup_service, "get_backup_storage_dir", lambda: backup_dir)
+
+    class FakeExecutor:
+        binary_path = "/usr/bin/codex"
+
+        def execute(self, command, args, timeout=30):
+            if command == "mcp":
+                return SimpleNamespace(
+                    stdout='{"servers":{"linear":{"command":"npx","env":{"LINEAR_API_KEY":"secret-api-key"}}}}',
+                    stderr="",
+                    exit_code=0,
+                )
+            if command == "plugin":
+                return SimpleNamespace(
+                    stdout="PLUGIN   STATUS   VERSION   PATH\nlinear   installed          /tmp/linear\n",
+                    stderr="auth_token=secret-plugin-token",
+                    exit_code=0,
+                )
+            raise AssertionError(command)
+
+    monkeypatch.setattr(backup_service, "ProviderCLIExecutor", lambda provider_id: FakeExecutor())
+
+    service = BackupService(FakeDb(), codex_home=codex_home)
+    backup, manifest = asyncio.run(service.create_backup(
+        name="codex-export",
+        scope="codex",
+        description="Codex export",
+    ))
+
+    assert backup.scope == "codex"
+    assert manifest.claude_code_version is None
+    assert manifest.contents.provider_inventory["provider"] == "codex-cli"
+    assert manifest.contents.provider_inventory["mcp"]["servers"]["servers"]["linear"]["env"]["LINEAR_API_KEY"] == "[redacted]"
+
+    with zipfile.ZipFile(backup.file_path) as zf:
+        names = set(zf.namelist())
+        assert ".codex/config.toml" in names
+        assert ".codex/work.config.toml" in names
+        assert ".codex/rules/team.rules" in names
+        assert ".codex/provider-inventory.json" in names
+        assert ".codex/auth.json" not in names
+        assert ".codex/history.jsonl" not in names
+        assert ".codex/models_cache.json" not in names
+
+        config_export = zf.read(".codex/config.toml").decode()
+        assert "secret-config-token" not in config_export
+        assert 'authToken = "[redacted]"' in config_export
+
+        inventory_export = json.loads(zf.read(".codex/provider-inventory.json"))
+        assert "secret-api-key" not in json.dumps(inventory_export)
+        assert "secret-plugin-token" not in json.dumps(inventory_export)
+
+
+def test_codex_backup_restore_is_export_only(tmp_path):
+    from app.services.backup_service import BackupService
+
+    archive_path = tmp_path / "codex.zip"
+    with zipfile.ZipFile(archive_path, "w") as zf:
+        zf.writestr("manifest.json", "{}")
+
+    service = BackupService(db=None, codex_home=tmp_path / ".codex")
+
+    async def fake_get_backup(_backup_id):
+        return SimpleNamespace(
+            scope="codex",
+            file_path=str(archive_path),
+            name="codex-export",
+            created_at=datetime(2026, 5, 25, 12, 0, 0),
+        )
+
+    service.get_backup = fake_get_backup
+
+    result = asyncio.run(service.restore_backup(1))
+
+    assert result.success is False
+    assert "export-only" in result.message

--- a/backend/tests/test_codex_config_service.py
+++ b/backend/tests/test_codex_config_service.py
@@ -75,6 +75,30 @@ def test_codex_config_summary_omits_full_config_and_secrets(tmp_path):
     assert "mcp_servers" not in serialized
 
 
+def test_codex_raw_view_rejects_auth_and_allows_safe_files(tmp_path):
+    from app.services.codex_config_service import CodexConfigService
+
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    (tmp_path / "config.toml").write_text('model = "gpt-5"\n', encoding="utf-8")
+    (tmp_path / "work.config.toml").write_text('profile = "work"\n', encoding="utf-8")
+    (rules_dir / "team.rules").write_text("be careful\n", encoding="utf-8")
+    (tmp_path / "auth.json").write_text('{"token":"secret"}', encoding="utf-8")
+
+    service = CodexConfigService(codex_home=tmp_path)
+
+    assert service.get_file_content(str(tmp_path / "config.toml"))["exists"] is True
+    assert service.get_file_content(str(tmp_path / "work.config.toml"))["exists"] is True
+    assert service.get_file_content(str(rules_dir / "team.rules"))["exists"] is True
+
+    try:
+        service.get_file_content(str(tmp_path / "auth.json"))
+    except ValueError as exc:
+        assert "raw viewer only supports" in str(exc)
+    else:
+        raise AssertionError("Expected auth.json raw access to be rejected")
+
+
 def test_codex_update_preserves_comments_and_creates_backup(tmp_path):
     from app.services.codex_config_service import CodexConfigService
 

--- a/backend/tests/test_codex_config_service.py
+++ b/backend/tests/test_codex_config_service.py
@@ -1,0 +1,41 @@
+"""Tests for Codex TOML config parsing."""
+
+
+def test_codex_config_parses_config_toml(tmp_path):
+    from app.services.codex_config_service import CodexConfigService
+
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        '\n'.join([
+            'model = "gpt-5.1-codex"',
+            'model_reasoning_effort = "medium"',
+            '',
+            '[projects."/repo/app"]',
+            'trust_level = "trusted"',
+            '',
+            '[features]',
+            'search = true',
+        ]),
+        encoding="utf-8",
+    )
+
+    data = CodexConfigService(codex_home=tmp_path).get_config()
+
+    assert data["exists"] is True
+    assert data["parse_error"] is None
+    assert data["summary"]["model"] == "gpt-5.1-codex"
+    assert data["summary"]["projects"]["/repo/app"]["trust_level"] == "trusted"
+    assert data["summary"]["features"]["search"] is True
+
+
+def test_codex_config_reports_parse_errors(tmp_path):
+    from app.services.codex_config_service import CodexConfigService
+
+    (tmp_path / "config.toml").write_text("invalid = [", encoding="utf-8")
+
+    data = CodexConfigService(codex_home=tmp_path).get_config()
+
+    assert data["exists"] is True
+    assert data["parse_error"]
+    assert data["config"] == {}
+

--- a/backend/tests/test_codex_config_service.py
+++ b/backend/tests/test_codex_config_service.py
@@ -37,7 +37,42 @@ def test_codex_config_reports_parse_errors(tmp_path):
 
     assert data["exists"] is True
     assert data["parse_error"]
-    assert data["config"] == {}
+    assert "config" not in data
+
+
+def test_codex_config_summary_omits_full_config_and_secrets(tmp_path):
+    from app.services.codex_config_service import CodexConfigService
+
+    (tmp_path / "config.toml").write_text(
+        '\n'.join([
+            'model = "gpt-5"',
+            '',
+            '[mcp_servers.linear]',
+            'command = "npx"',
+            'args = ["-y", "@linear/mcp"]',
+            '',
+            '[mcp_servers.linear.env]',
+            'LINEAR_API_KEY = "secret-api-key"',
+            '',
+            '[auth]',
+            'token = "secret-auth-token"',
+            '',
+            '[profiles.work]',
+            'api_key = "secret-profile-key"',
+        ]),
+        encoding="utf-8",
+    )
+
+    data = CodexConfigService(codex_home=tmp_path).get_config()
+    serialized = str(data)
+
+    assert "config" not in data
+    assert data["summary"]["model"] == "gpt-5"
+    assert data["summary"]["profiles"]["work"]["api_key"] == "[redacted]"
+    assert "secret-api-key" not in serialized
+    assert "secret-auth-token" not in serialized
+    assert "secret-profile-key" not in serialized
+    assert "mcp_servers" not in serialized
 
 
 def test_codex_update_preserves_comments_and_creates_backup(tmp_path):

--- a/backend/tests/test_codex_config_service.py
+++ b/backend/tests/test_codex_config_service.py
@@ -39,3 +39,133 @@ def test_codex_config_reports_parse_errors(tmp_path):
     assert data["parse_error"]
     assert data["config"] == {}
 
+
+def test_codex_update_preserves_comments_and_creates_backup(tmp_path):
+    from app.services.codex_config_service import CodexConfigService
+
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        '\n'.join([
+            "# keep this comment",
+            'model = "old-model"',
+            "",
+            "[features]",
+            "# feature comment",
+            "shell_tool = false",
+            "",
+        ]),
+        encoding="utf-8",
+    )
+
+    result = CodexConfigService(codex_home=tmp_path).update_safe_settings(
+        settings={"model": "new-model"},
+        features={"shell_tool": True},
+    )
+
+    updated = config_path.read_text(encoding="utf-8")
+    assert "# keep this comment" in updated
+    assert "# feature comment" in updated
+    assert 'model = "new-model"' in updated
+    assert "shell_tool = true" in updated
+    assert result["backup_path"] is not None
+    backup_path = tmp_path / result["backup_path"].split("/")[-1]
+    assert backup_path.exists()
+    assert 'model = "old-model"' in backup_path.read_text(encoding="utf-8")
+
+
+def test_codex_update_creates_missing_config(tmp_path):
+    from app.services.codex_config_service import CodexConfigService
+
+    result = CodexConfigService(codex_home=tmp_path).update_safe_settings(
+        settings={"model": "gpt-5.1-codex", "strict_config": True},
+        features={"search": True},
+    )
+
+    config_path = tmp_path / "config.toml"
+    assert config_path.exists()
+    assert result["backup_path"] is None
+    data = CodexConfigService(codex_home=tmp_path).get_config()
+    assert data["summary"]["model"] == "gpt-5.1-codex"
+    assert data["summary"]["strict_config"] is True
+    assert data["summary"]["features"]["search"] is True
+
+
+def test_codex_update_cleans_up_temp_file_on_atomic_write_failure(tmp_path, monkeypatch):
+    from app.services.codex_config_service import CodexConfigService
+
+    config_path = tmp_path / "config.toml"
+    config_path.write_text('model = "old-model"\n', encoding="utf-8")
+    original_replace = type(config_path).replace
+
+    def fail_replace(self, target):
+        if self.name.startswith(".config.toml.") and self.name.endswith(".tmp"):
+            raise OSError("replace failed")
+        return original_replace(self, target)
+
+    monkeypatch.setattr(type(config_path), "replace", fail_replace)
+
+    try:
+        CodexConfigService(codex_home=tmp_path).update_safe_settings(
+            settings={"model": "new-model"},
+        )
+    except OSError as exc:
+        assert "replace failed" in str(exc)
+    else:
+        raise AssertionError("Expected atomic replace failure")
+
+    assert config_path.read_text(encoding="utf-8") == 'model = "old-model"\n'
+    assert list(tmp_path.glob(".config.toml.*.tmp")) == []
+    assert list(tmp_path.glob("config.toml.*.bak"))
+
+
+def test_codex_update_rejects_unsafe_fields(tmp_path):
+    from app.services.codex_config_service import CodexConfigService
+
+    service = CodexConfigService(codex_home=tmp_path)
+
+    try:
+        service.update_safe_settings(settings={"auth": "secret"})
+    except ValueError as exc:
+        assert "Unsupported Codex setting" in str(exc)
+    else:
+        raise AssertionError("Expected unsafe setting to be rejected")
+
+    try:
+        service.update_safe_settings(features={"../bad": True})
+    except ValueError as exc:
+        assert "Unsafe feature name" in str(exc)
+    else:
+        raise AssertionError("Expected unsafe feature name to be rejected")
+
+
+def test_codex_update_rejects_traversal_config_home(tmp_path):
+    from app.services.codex_config_service import CodexConfigService
+
+    service = CodexConfigService(codex_home=tmp_path / "nested" / "..")
+
+    try:
+        service.update_safe_settings(settings={"model": "new-model"})
+    except ValueError as exc:
+        assert "Unsafe Codex config path" in str(exc)
+    else:
+        raise AssertionError("Expected traversal config path to be rejected")
+
+
+def test_codex_update_rejects_parse_error_without_overwriting(tmp_path):
+    from app.services.codex_config_service import CodexConfigService
+
+    config_path = tmp_path / "config.toml"
+    original = "invalid = ["
+    config_path.write_text(original, encoding="utf-8")
+
+    try:
+        CodexConfigService(codex_home=tmp_path).update_safe_settings(
+            settings={"model": "new-model"},
+        )
+    except ValueError as exc:
+        assert "parse errors" in str(exc)
+    else:
+        raise AssertionError("Expected parse-error config to be rejected")
+
+    assert config_path.read_text(encoding="utf-8") == original
+    assert list(tmp_path.glob("*.bak")) == []

--- a/backend/tests/test_provider_cli_executor.py
+++ b/backend/tests/test_provider_cli_executor.py
@@ -16,6 +16,32 @@ def test_provider_cli_executor_uses_codex_binary_and_whitelist():
     assert result.exit_code == 0
 
 
+def test_provider_cli_api_redacts_sensitive_output(monkeypatch):
+    from app.api.v1 import providers as providers_api
+    from app.models.schemas import CLIExecuteRequest
+
+    class FakeExecutor:
+        binary_path = "/usr/bin/codex"
+        provider = SimpleNamespace(display_name="Codex")
+        ALLOWED_COMMANDS = ["doctor"]
+
+        def validate_command(self, command):
+            return command == "doctor"
+
+        def execute(self, command, args):
+            return SimpleNamespace(stdout="token=secret-token", stderr="api_key=secret-key", exit_code=0)
+
+    monkeypatch.setattr(providers_api, "ProviderCLIExecutor", lambda provider_id: FakeExecutor())
+
+    response = providers_api.execute_provider_cli(
+        "codex-cli",
+        CLIExecuteRequest(command="doctor", args=[]),
+    )
+
+    assert response.stdout == "token=[redacted]"
+    assert response.stderr == "api_key=[redacted]"
+
+
 def test_provider_cli_executor_rejects_unsafe_codex_command():
     from app.services.cli_executor import ProviderCLIExecutor
 
@@ -34,4 +60,3 @@ def test_legacy_cli_executor_defaults_to_claude_code():
 
     assert executor.provider_id == "claude-code"
     assert executor.claude_binary == "/usr/bin/claude"
-

--- a/backend/tests/test_provider_cli_executor.py
+++ b/backend/tests/test_provider_cli_executor.py
@@ -1,0 +1,37 @@
+"""Tests for provider-aware CLI execution."""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def test_provider_cli_executor_uses_codex_binary_and_whitelist():
+    from app.services.cli_executor import ProviderCLIExecutor
+
+    with patch("app.services.cli_executor.shutil.which", return_value="/usr/bin/codex"), \
+         patch("app.services.cli_executor.subprocess.run") as run:
+        run.return_value = SimpleNamespace(stdout="{}", stderr="", returncode=0)
+        result = ProviderCLIExecutor("codex-cli").execute("doctor", ["--json"])
+
+    run.assert_called_once()
+    assert run.call_args.args[0] == ["/usr/bin/codex", "doctor", "--json"]
+    assert result.exit_code == 0
+
+
+def test_provider_cli_executor_rejects_unsafe_codex_command():
+    from app.services.cli_executor import ProviderCLIExecutor
+
+    executor = ProviderCLIExecutor("codex-cli")
+
+    assert executor.validate_command("exec") is False
+    assert executor.validate_command("logout") is False
+    assert executor.validate_command("doctor") is True
+
+
+def test_legacy_cli_executor_defaults_to_claude_code():
+    from app.services.cli_executor import CLIExecutor
+
+    with patch("app.services.cli_executor.shutil.which", return_value="/usr/bin/claude"):
+        executor = CLIExecutor()
+
+    assert executor.provider_id == "claude-code"
+    assert executor.claude_binary == "/usr/bin/claude"
+

--- a/backend/tests/test_provider_doctor_api.py
+++ b/backend/tests/test_provider_doctor_api.py
@@ -1,0 +1,28 @@
+"""Tests for provider doctor API."""
+from types import SimpleNamespace
+
+
+def test_provider_doctor_returns_parsed_codex_report(monkeypatch):
+    from app.api.v1 import providers as providers_api
+
+    class FakeExecutor:
+        binary_path = "/usr/bin/codex"
+
+        def execute(self, command, args, timeout=30):
+            assert command == "doctor"
+            assert args == ["--json"]
+            assert timeout == 30
+            return SimpleNamespace(
+                stdout='{"overallStatus":"ok","codexVersion":"0.133.0"}',
+                stderr="",
+                exit_code=0,
+            )
+
+    monkeypatch.setattr(providers_api, "ProviderCLIExecutor", lambda provider_id: FakeExecutor())
+
+    response = providers_api.get_provider_doctor("codex-cli")
+
+    assert response["provider"] == "codex-cli"
+    assert response["exit_code"] == 0
+    assert response["report"]["overallStatus"] == "ok"
+

--- a/backend/tests/test_provider_doctor_api.py
+++ b/backend/tests/test_provider_doctor_api.py
@@ -26,3 +26,24 @@ def test_provider_doctor_returns_parsed_codex_report(monkeypatch):
     assert response["exit_code"] == 0
     assert response["report"]["overallStatus"] == "ok"
 
+
+def test_provider_doctor_redacts_report_and_stderr(monkeypatch):
+    from app.api.v1 import providers as providers_api
+
+    class FakeExecutor:
+        binary_path = "/usr/bin/codex"
+
+        def execute(self, command, args, timeout=30):
+            return SimpleNamespace(
+                stdout='{"checks":{"auth":{"token":"secret-token"}}}',
+                stderr="api_key=secret-key",
+                exit_code=1,
+            )
+
+    monkeypatch.setattr(providers_api, "ProviderCLIExecutor", lambda provider_id: FakeExecutor())
+
+    response = providers_api.get_provider_doctor("codex-cli")
+
+    assert response["report"]["checks"]["auth"] == "[redacted]"
+    assert "secret-token" not in str(response)
+    assert "api_key=[redacted]" in response["stderr"]

--- a/backend/tests/test_provider_inventory_api.py
+++ b/backend/tests/test_provider_inventory_api.py
@@ -1,0 +1,108 @@
+"""Tests for read-only Codex MCP and plugin inventory endpoints."""
+from types import SimpleNamespace
+
+
+def test_codex_mcp_inventory_parses_json_and_redacts(monkeypatch):
+    from app.api.v1 import providers as providers_api
+
+    class FakeExecutor:
+        binary_path = "/usr/bin/codex"
+
+        def execute(self, command, args, timeout=30):
+            assert command == "mcp"
+            assert args == ["list", "--json"]
+            return SimpleNamespace(
+                stdout='{"servers":{"local":{"command":"node","authToken":"abc123"}}}',
+                stderr="",
+                exit_code=0,
+            )
+
+    monkeypatch.setattr(providers_api, "ProviderCLIExecutor", lambda provider_id: FakeExecutor())
+
+    response = providers_api.get_provider_mcp_inventory("codex-cli")
+
+    assert response["exit_code"] == 0
+    assert response["parse_error"] is None
+    assert response["servers"]["servers"]["local"]["authToken"] == "[redacted]"
+
+
+def test_codex_mcp_inventory_surfaces_errors(monkeypatch):
+    from app.api.v1 import providers as providers_api
+
+    class FakeExecutor:
+        binary_path = "/usr/bin/codex"
+
+        def execute(self, command, args, timeout=30):
+            return SimpleNamespace(
+                stdout="{not-json",
+                stderr="auth_token=secret-value failed",
+                exit_code=2,
+            )
+
+    monkeypatch.setattr(providers_api, "ProviderCLIExecutor", lambda provider_id: FakeExecutor())
+
+    response = providers_api.get_provider_mcp_inventory("codex-cli")
+
+    assert response["exit_code"] == 2
+    assert response["servers"] is None
+    assert response["parse_error"]
+    assert "auth_token=[redacted]" in response["stderr"]
+
+
+def test_codex_plugin_inventory_returns_text_and_best_effort_rows(monkeypatch):
+    from app.api.v1 import providers as providers_api
+
+    header = f"{'PLUGIN':<28}{'STATUS':<16}{'VERSION':<12}PATH"
+    blank_version_row = (
+        f"{'linear@openai-curated':<28}"
+        f"{'not installed':<16}"
+        f"{'':<12}"
+        "/home/user/.codex/plugins/linear"
+    )
+    version_row = (
+        f"{'review@openai-curated':<28}"
+        f"{'installed':<16}"
+        f"{'0.4.0':<12}"
+        "/tmp/review plugin"
+    )
+
+    class FakeExecutor:
+        binary_path = "/usr/bin/codex"
+
+        def execute(self, command, args, timeout=30):
+            assert command == "plugin"
+            assert args == ["list"]
+            return SimpleNamespace(
+                stdout=(
+                    "Marketplace `openai-curated`\n"
+                    "/home/user/.codex/marketplaces/openai-curated/marketplace.json\n"
+                    "\n"
+                    f"{header}\n"
+                    f"{blank_version_row}\n"
+                    f"{version_row}\n"
+                ),
+                stderr="",
+                exit_code=0,
+            )
+
+    monkeypatch.setattr(providers_api, "ProviderCLIExecutor", lambda provider_id: FakeExecutor())
+
+    response = providers_api.get_provider_plugin_inventory("codex-cli")
+
+    assert response["exit_code"] == 0
+    assert response["raw_stdout"].startswith("Marketplace")
+    assert response["plugins"] == [
+        {
+            "name": "linear@openai-curated",
+            "status": "not installed",
+            "path": "/home/user/.codex/plugins/linear",
+        },
+        {
+            "name": "review@openai-curated",
+            "status": "installed",
+            "version": "0.4.0",
+            "path": "/tmp/review plugin",
+        },
+    ]
+    assert "version" not in response["plugins"][0]
+    assert all("marketplace.json" not in plugin["name"] for plugin in response["plugins"])

--- a/backend/tests/test_provider_inventory_api.py
+++ b/backend/tests/test_provider_inventory_api.py
@@ -24,6 +24,8 @@ def test_codex_mcp_inventory_parses_json_and_redacts(monkeypatch):
     assert response["exit_code"] == 0
     assert response["parse_error"] is None
     assert response["servers"]["servers"]["local"]["authToken"] == "[redacted]"
+    assert "abc123" not in response["raw_stdout"]
+    assert '"authToken": "[redacted]"' in response["raw_stdout"]
 
 
 def test_codex_mcp_inventory_surfaces_errors(monkeypatch):

--- a/backend/tests/test_provider_inventory_api.py
+++ b/backend/tests/test_provider_inventory_api.py
@@ -1,6 +1,8 @@
 """Tests for read-only Codex MCP and plugin inventory endpoints."""
 from types import SimpleNamespace
 
+import pytest
+
 
 def test_codex_mcp_inventory_parses_json_and_redacts(monkeypatch):
     from app.api.v1 import providers as providers_api
@@ -108,3 +110,105 @@ def test_codex_plugin_inventory_returns_text_and_best_effort_rows(monkeypatch):
     ]
     assert "version" not in response["plugins"][0]
     assert all("marketplace.json" not in plugin["name"] for plugin in response["plugins"])
+
+
+def test_codex_mcp_add_uses_cli_command_args_and_env(monkeypatch):
+    from app.api.v1 import providers as providers_api
+
+    calls = []
+
+    class FakeExecutor:
+        binary_path = "/usr/bin/codex"
+
+        def execute(self, command, args, timeout=30):
+            calls.append((command, args, timeout))
+            return SimpleNamespace(stdout="added auth_token=secret-value", stderr="", exit_code=0)
+
+    monkeypatch.setattr(providers_api, "ProviderCLIExecutor", lambda provider_id: FakeExecutor())
+
+    response = providers_api.add_provider_mcp_server(
+        "codex-cli",
+        providers_api.CodexMcpAddRequest(
+            name="linear",
+            command="npx",
+            args=["-y", "@linear/mcp"],
+            env={"LINEAR_API_KEY": "secret-value"},
+        ),
+    )
+
+    assert calls == [
+        (
+            "mcp",
+            ["add", "--env", "LINEAR_API_KEY=secret-value", "linear", "--", "npx", "-y", "@linear/mcp"],
+            30,
+        )
+    ]
+    assert response["exit_code"] == 0
+    assert "secret-value" not in response["stdout"]
+
+
+def test_codex_mcp_add_uses_url_cli_args(monkeypatch):
+    from app.api.v1 import providers as providers_api
+
+    calls = []
+
+    class FakeExecutor:
+        binary_path = "/usr/bin/codex"
+
+        def execute(self, command, args, timeout=30):
+            calls.append((command, args, timeout))
+            return SimpleNamespace(stdout="added", stderr="", exit_code=0)
+
+    monkeypatch.setattr(providers_api, "ProviderCLIExecutor", lambda provider_id: FakeExecutor())
+
+    providers_api.add_provider_mcp_server(
+        "codex-cli",
+        providers_api.CodexMcpAddRequest(
+            name="remote-server",
+            url="https://example.com/mcp",
+            bearer_token_env_var="MCP_TOKEN",
+        ),
+    )
+
+    assert calls == [
+        (
+            "mcp",
+            ["add", "--url", "https://example.com/mcp", "--bearer-token-env-var", "MCP_TOKEN", "remote-server"],
+            30,
+        )
+    ]
+
+
+def test_codex_mcp_add_rejects_ambiguous_payload():
+    from app.api.v1 import providers as providers_api
+
+    request = providers_api.CodexMcpAddRequest(
+        name="bad-server",
+        command="npx",
+        url="https://example.com/mcp",
+    )
+
+    with pytest.raises(providers_api.HTTPException) as exc_info:
+        providers_api.add_provider_mcp_server("codex-cli", request)
+
+    assert exc_info.value.status_code == 400
+
+
+def test_codex_mcp_remove_uses_cli_remove(monkeypatch):
+    from app.api.v1 import providers as providers_api
+
+    calls = []
+
+    class FakeExecutor:
+        binary_path = "/usr/bin/codex"
+
+        def execute(self, command, args, timeout=30):
+            calls.append((command, args, timeout))
+            return SimpleNamespace(stdout="removed", stderr="", exit_code=0)
+
+    monkeypatch.setattr(providers_api, "ProviderCLIExecutor", lambda provider_id: FakeExecutor())
+
+    response = providers_api.remove_provider_mcp_server("codex-cli", "linear")
+
+    assert calls == [("mcp", ["remove", "linear"], 30)]
+    assert response["exit_code"] == 0

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -1,0 +1,34 @@
+"""Tests for agent provider registry and Codex detection."""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def test_provider_registry_contains_initial_providers():
+    from app.services.providers import get_provider, get_providers
+
+    provider_ids = {provider.id for provider in get_providers()}
+
+    assert provider_ids == {"claude-code", "codex-cli"}
+    assert get_provider("claude-code").display_name == "Claude Code"
+    assert get_provider("codex-cli").binary_name == "codex"
+
+
+def test_codex_process_detection_matches_interactive_binary():
+    from app.services.providers import get_provider
+
+    provider = get_provider("codex-cli")
+
+    assert provider.is_process_match("codex", "123") is True
+    assert provider.is_process_match("/usr/local/bin/codex", "123") is True
+    assert provider.is_process_match("codex-exec-server", "123") is False
+
+
+def test_codex_process_detection_matches_node_wrapper_descendant():
+    from app.services.providers import get_provider
+
+    provider = get_provider("codex-cli")
+
+    with patch("app.services.providers.base.subprocess.run") as run:
+        run.return_value = SimpleNamespace(stdout="456 /usr/local/bin/codex\n")
+        assert provider.is_process_match("node", "123") is True
+

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitepress'
 
 export default defineConfig({
   title: 'Claude Deck',
-  description: 'Documentation for Claude Deck — Web Dashboard for Claude Code',
+  description: 'Documentation for Claude Deck — Web dashboard for local AI coding agents',
   appearance: 'force-dark',
   base: '/docs/',
   head: [
@@ -52,6 +52,7 @@ export default defineConfig({
             { text: 'Output Styles', link: '/features/output-styles' },
             { text: 'Status Line', link: '/features/statusline' },
             { text: 'Sessions', link: '/features/sessions' },
+            { text: 'Agent Bridge', link: '/features/agent-bridge' },
             { text: 'CC Bridge', link: '/features/cc-bridge' },
             { text: 'Usage Tracking', link: '/features/usage' },
             { text: 'Backup & Restore', link: '/features/backup' },
@@ -64,6 +65,7 @@ export default defineConfig({
           items: [
             { text: 'Overview', link: '/api/' },
             { text: 'Config', link: '/api/config' },
+            { text: 'Providers', link: '/api/providers' },
             { text: 'MCP Servers', link: '/api/mcp' },
             { text: 'Commands', link: '/api/commands' },
             { text: 'Plugins', link: '/api/plugins' },
@@ -75,6 +77,7 @@ export default defineConfig({
             { text: 'Plans', link: '/api/plans' },
             { text: 'Output Styles', link: '/api/output-styles' },
             { text: 'Status Line', link: '/api/statusline' },
+            { text: 'Agent Bridge', link: '/api/agent-bridge' },
             { text: 'CC Bridge', link: '/api/cc-bridge' },
             { text: 'Usage', link: '/api/usage' },
             { text: 'Memory', link: '/api/memory' },

--- a/docs/api/agent-bridge.md
+++ b/docs/api/agent-bridge.md
@@ -1,0 +1,98 @@
+# Agent Bridge API
+
+Provider-aware live terminal monitoring for Claude Code and Codex CLI tmux sessions.
+
+## Endpoints
+
+### List Sessions
+
+```http
+GET /api/v1/agent-bridge/sessions?provider={provider_id}
+```
+
+`provider` is optional. Supported values are `claude-code` and `codex-cli`.
+
+```json
+{
+  "sessions": [
+    {
+      "provider": "codex-cli",
+      "provider_display_name": "Codex",
+      "tmux_target": "repo-1234:0.0",
+      "session_name": "repo-1234",
+      "window_name": "main",
+      "pane_id": "%1",
+      "cwd": "/home/user/repo",
+      "pid": "12345",
+      "status": "active"
+    }
+  ],
+  "count": 1
+}
+```
+
+### Get Preview
+
+```http
+GET /api/v1/agent-bridge/sessions/{target}/preview
+```
+
+Returns a captured pane preview.
+
+### Get Terminal Token
+
+```http
+GET /api/v1/agent-bridge/token
+```
+
+Returns a short-lived one-time token for WebSocket terminal access.
+
+### Attach Terminal
+
+```http
+WS /api/v1/agent-bridge/sessions/{target}/terminal?token={token}&mode={mode}
+```
+
+`mode` can be `readonly` or `interactive`.
+
+### Spawn Session
+
+```http
+POST /api/v1/agent-bridge/sessions
+```
+
+Claude Code example:
+
+```json
+{
+  "provider": "claude-code",
+  "directory": "/home/user/repo",
+  "mode": "plain",
+  "prompt": "Review the current branch"
+}
+```
+
+Codex example:
+
+```json
+{
+  "provider": "codex-cli",
+  "directory": "/home/user/repo",
+  "mode": "resume",
+  "use_last": true,
+  "model": "gpt-5.5",
+  "approval_policy": "on-request"
+}
+```
+
+### Delete Session
+
+```http
+DELETE /api/v1/agent-bridge/sessions/{target}
+```
+
+Kills the tmux session or pane target.
+
+## Legacy Route
+
+`/api/v1/cc-bridge/*` remains for compatibility. New clients should use `/api/v1/agent-bridge/*`.

--- a/docs/api/cc-bridge.md
+++ b/docs/api/cc-bridge.md
@@ -1,5 +1,9 @@
 # CC Bridge API
 
+::: warning Legacy route
+Use `/api/v1/agent-bridge/*` for new provider-aware clients. `/api/v1/cc-bridge/*` remains for compatibility with Claude Code-only integrations.
+:::
+
 Monitor and manage live Claude Code terminal sessions.
 
 ## REST Endpoints

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -1,6 +1,6 @@
 # Config API
 
-Manage Claude Code configuration across all scopes.
+Manage Claude Code configuration across all scopes. Codex CLI uses a separate TOML-backed config API because its file format and safety rules differ from Claude Code JSON settings.
 
 ## Endpoints
 
@@ -96,3 +96,37 @@ Validates permission patterns without saving.
   "settings": { "permissions": { "allow": ["Bash(npm run *)"] } }
 }
 ```
+
+## Codex Config Endpoints
+
+### Get Codex Config Summary
+
+```http
+GET /api/v1/codex-config
+```
+
+Returns safe Codex config metadata, file list, summary values, and parse errors. The full parsed TOML config is not returned automatically.
+
+### List Codex Config Files
+
+```http
+GET /api/v1/codex-config/files
+```
+
+Returns `$CODEX_HOME/config.toml`, profile config files, and rules files. Auth, history, cache, and log files are not exposed as raw config files.
+
+### Get Raw Codex File
+
+```http
+GET /api/v1/codex-config/raw?path={file_path}
+```
+
+Returns raw content only for safe files under `$CODEX_HOME`.
+
+### Update Codex Settings
+
+```http
+PUT /api/v1/codex-config/settings
+```
+
+Updates whitelisted Codex settings using a TOML writer that preserves formatting where possible. A backup is created before writing and the file is parsed before save.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -55,7 +55,8 @@ FastAPI generates interactive API docs at:
 
 | Module | Prefix | Description |
 |--------|--------|-------------|
-| [Config](/api/config) | `/config` | Configuration management |
+| [Config](/api/config) | `/config` and `/codex-config` | Configuration management |
+| [Providers](/api/providers) | `/providers` | Provider metadata, status, diagnostics, and inventory |
 | [MCP Servers](/api/mcp) | `/mcp` | MCP server management |
 | [Commands](/api/commands) | `/commands` | Slash commands |
 | [Plugins](/api/plugins) | `/plugins` | Plugin management |
@@ -67,7 +68,8 @@ FastAPI generates interactive API docs at:
 | [Plans](/api/plans) | `/plans` | Implementation plans |
 | [Output Styles](/api/output-styles) | `/output-styles` | Response formatting |
 | [Status Line](/api/statusline) | `/statusline` | Terminal status bar |
-| [CC Bridge](/api/cc-bridge) | `/cc-bridge` | Live terminal monitoring |
+| [Agent Bridge](/api/agent-bridge) | `/agent-bridge` | Provider-aware live terminal monitoring |
+| [CC Bridge](/api/cc-bridge) | `/cc-bridge` | Legacy Claude Code terminal monitoring route |
 | [Usage](/api/usage) | `/usage` | Token usage tracking |
 | [Memory](/api/memory) | `/memory` | Memory hierarchy |
 | [Backup](/api/backup) | `/backup` | Configuration backups |

--- a/docs/api/providers.md
+++ b/docs/api/providers.md
@@ -1,0 +1,46 @@
+# Providers API
+
+Provider endpoints expose installed agent CLI metadata, capabilities, diagnostics, and safe provider-specific command surfaces.
+
+## Endpoints
+
+### List Providers
+
+```http
+GET /api/v1/providers
+```
+
+Returns registered providers such as `claude-code` and `codex-cli`, including install status, version, capabilities, and config paths.
+
+### Provider Status
+
+```http
+GET /api/v1/providers/{provider_id}/status
+```
+
+Returns status for one provider.
+
+### Codex Doctor
+
+```http
+GET /api/v1/providers/codex-cli/doctor
+```
+
+Runs Codex diagnostics and returns redacted output.
+
+### Codex Inventory
+
+```http
+GET /api/v1/providers/codex-cli/inventory
+```
+
+Returns read-only Codex MCP and plugin inventory. Secret-like values are redacted.
+
+### Codex MCP Mutation
+
+```http
+POST /api/v1/providers/codex-cli/mcp
+DELETE /api/v1/providers/codex-cli/mcp/{name}
+```
+
+Adds or removes Codex MCP servers through the Codex CLI with strict validation. Plugin mutation remains read-only in this version.

--- a/docs/features/agent-bridge.md
+++ b/docs/features/agent-bridge.md
@@ -1,0 +1,42 @@
+# Agent Bridge
+
+Agent Bridge discovers and manages local agent CLIs running inside tmux. It supports mixed Claude Code and Codex CLI sessions in the same view.
+
+## Overview
+
+The bridge performs a provider-aware tmux discovery pass and classifies each matching pane as `claude-code` or `codex-cli`. The UI can show all sessions together or filter to one provider.
+
+Session cards include:
+
+- Provider badge
+- tmux target
+- Current working directory
+- Live preview
+- Attach, fullscreen, and kill controls
+
+The terminal grid is shared across providers. Read-only and interactive modes work the same way whether the pane is Claude Code or Codex.
+
+## New Sessions
+
+The new session dialog starts with a provider choice.
+
+Claude Code keeps the existing session modes:
+
+- Plain session
+- Worktree session
+- Resume session
+
+Codex CLI supports:
+
+- New session with `codex --cd <directory>`
+- Resume by session id or `--last`
+- Fork by session id or `--last`
+- Optional model, profile, profile v2, sandbox, approval policy, web search, and prompt seed
+
+Dangerous Codex bypass mode is exposed as an explicit advanced option because it disables approval and sandbox protections.
+
+## Compatibility
+
+The frontend route `/agent-bridge` is the primary route. `/cc-bridge` remains as a compatibility alias.
+
+The backend keeps `/api/v1/cc-bridge/*` for existing callers and adds `/api/v1/agent-bridge/*` for provider-aware clients.

--- a/docs/features/cc-bridge.md
+++ b/docs/features/cc-bridge.md
@@ -1,5 +1,9 @@
 # CC Bridge
 
+::: warning Legacy name
+The provider-aware feature is now Agent Bridge. This page describes the original Claude Code-only bridge naming; use [Agent Bridge](/features/agent-bridge) for mixed Claude Code and Codex CLI sessions.
+:::
+
 Discover and monitor live Claude Code sessions running in tmux with a multi-terminal grid view.
 
 ## Overview

--- a/docs/features/config.md
+++ b/docs/features/config.md
@@ -1,10 +1,10 @@
 # Config
 
-The Config page lets you view, edit, and understand Claude Code settings across all configuration scopes.
+The Config page lets you view, edit, and understand provider configuration. Claude Code uses JSON settings across multiple scopes; Codex CLI uses TOML files under `$CODEX_HOME`.
 
 ## Overview
 
-Claude Code stores settings in multiple files at different scopes. The Config page provides three views:
+Claude Code stores settings in multiple files at different scopes. The Claude Code config page provides three views:
 
 - **Settings Editor** — form-based editor for common settings
 - **Scope Resolver** — shows how settings merge from different scopes
@@ -56,6 +56,22 @@ Sensitive values (tokens, secrets, passwords, API keys) are automatically masked
 ## Configuration
 
 The Config page reads and writes to the standard Claude Code configuration files. No additional Claude Deck configuration is needed.
+
+## Codex CLI
+
+When the selected provider is Codex CLI, the Config page switches to Codex-specific cards:
+
+- General settings such as model, reasoning effort, and profile
+- Runtime settings such as sandbox, approval policy, search, strict config, and alternate screen behavior
+- Project trust entries
+- Profile v2 files
+- Rules files
+- MCP and plugin inventory
+- Diagnostics from `codex doctor`
+
+Codex config writes are intentionally narrower than Claude Code settings. Claude Deck only updates whitelisted TOML keys, creates a backup before saving, and refuses unsafe paths. Auth, history, model cache, and log files are not shown in the raw viewer.
+
+Codex backups are export-only in this version. They include redacted config, profile files, rules, and provider inventory metadata, but automatic restore is disabled.
 
 ## Tips
 

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -42,7 +42,7 @@ backend/
 
 All routes live under `/api/v1/`. The frontend's Vite dev server proxies `/api` requests to the backend at `http://localhost:8000`.
 
-Route modules: `health`, `config`, `projects`, `cli`, `mcp`, `commands`, `plugins`, `hooks`, `permissions`, `agents`, `backup`, `output-styles`, `statusline`, `sessions`, `cc-bridge`, `usage`, `memory`
+Route modules: `health`, `config`, `codex-config`, `providers`, `projects`, `cli`, `mcp`, `commands`, `plugins`, `hooks`, `permissions`, `agents`, `backup`, `output-styles`, `statusline`, `sessions`, `agent-bridge`, `cc-bridge`, `usage`, `memory`
 
 ### Database
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Claude Deck is a self-hosted web application for visualizing and managing [Claude Code](https://docs.anthropic.com/en/docs/claude-code) configuration. It provides a unified interface for managing MCP servers, plugins, slash commands, hooks, agents, permissions, usage tracking, and other Claude Code extensions.
+Claude Deck is a self-hosted web application for visualizing and managing local AI coding agents. It started with [Claude Code](https://docs.anthropic.com/en/docs/claude-code) configuration and now includes Codex CLI support for tmux sessions, TOML settings, diagnostics, MCP inventory, and redacted config exports.
 
 ## Why Claude Deck?
 
@@ -15,13 +15,13 @@ Claude Code stores configuration across multiple JSON files and directories (`~/
 
 ## Features
 
-Claude Deck covers all aspects of Claude Code configuration:
+Claude Deck covers Claude Code configuration and the shared local-agent operations layer:
 
 | Category | Features |
 |----------|----------|
-| **Core Config** | Settings editor, MCP servers, slash commands |
+| **Core Config** | Claude Code settings editor, Codex TOML settings editor, MCP servers, slash commands |
 | **Extensions** | Plugins, hooks, permissions, agents, skills |
-| **Monitoring** | Sessions, usage tracking, context window, CC Bridge |
+| **Monitoring** | Sessions, usage tracking, context window, Agent Bridge |
 | **Customization** | Output styles, status line, memory |
 | **Management** | Projects, plans, backup & restore |
 

--- a/docs/plans/2026-05-25-codex-cli-support.html
+++ b/docs/plans/2026-05-25-codex-cli-support.html
@@ -1,0 +1,589 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>Codex CLI Support Across Claude Deck</title>
+<style>
+:root{color-scheme:light dark;--bg:#f7f4ed;--panel:#fffdfa;--text:#171717;--muted:#64615b;--border:#ddd5c8;--accent:#155e75;--accent2:#7c2d12;--code:#f0ebe2;--shadow:0 18px 50px rgba(20,18,14,.10)}
+@media (prefers-color-scheme: dark){:root{--bg:#151412;--panel:#201f1c;--text:#f4f0e8;--muted:#b8b0a3;--border:#3a352e;--accent:#67e8f9;--accent2:#fdba74;--code:#2b2925;--shadow:0 18px 50px rgba(0,0,0,.35)}}
+*{box-sizing:border-box} html{scroll-behavior:smooth} body{margin:0;background:var(--bg);color:var(--text);font:16px/1.62 ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif} .wrap{max-width:900px;margin:0 auto;padding:22px 16px 56px}.hero{padding:28px 0 18px;border-bottom:1px solid var(--border);margin-bottom:18px}.eyebrow{font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:var(--accent2);font-weight:700}.hero h1{font-size:clamp(30px,8vw,54px);line-height:1.02;margin:8px 0 12px}.meta{display:flex;gap:8px;flex-wrap:wrap}.pill{border:1px solid var(--border);border-radius:999px;padding:5px 10px;background:var(--panel);color:var(--muted);font-size:13px}.layout{display:grid;grid-template-columns:minmax(0,1fr);gap:18px}.toc{position:sticky;top:0;z-index:2;background:color-mix(in srgb,var(--bg) 88%,transparent);backdrop-filter:blur(10px);border:1px solid var(--border);border-radius:12px;padding:12px;margin-bottom:18px;box-shadow:var(--shadow)}.toc-title{font-size:13px;font-weight:800;color:var(--muted);margin-bottom:8px}.toc-links{display:flex;gap:8px;overflow:auto;padding-bottom:2px}.toc a{white-space:nowrap;text-decoration:none;color:var(--accent);font-size:13px;border:1px solid var(--border);border-radius:999px;padding:5px 10px;background:var(--panel)}main{background:var(--panel);border:1px solid var(--border);border-radius:14px;padding:20px;box-shadow:var(--shadow)}h1,h2,h3,h4{line-height:1.18;letter-spacing:0;margin:1.4em 0 .55em}main>h1:first-child{display:none}h2{font-size:1.45rem;border-top:1px solid var(--border);padding-top:1.1em}h2:first-of-type{border-top:0;padding-top:0}h3{font-size:1.12rem;color:var(--accent2)}p{margin:.8em 0}ul,ol{padding-left:1.25rem;margin:.65em 0}li{margin:.35em 0}code{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;background:var(--code);border:1px solid var(--border);border-radius:5px;padding:.1em .32em;font-size:.92em}pre{overflow:auto;background:var(--code);border:1px solid var(--border);border-radius:10px;padding:14px;-webkit-overflow-scrolling:touch}pre code{border:0;padding:0;background:transparent;white-space:pre;font-size:.86rem}a{color:var(--accent)}@media(min-width:960px){.wrap{padding-top:34px}.layout{grid-template-columns:220px minmax(0,1fr);align-items:start}.toc{top:18px;margin-bottom:0}.toc-links{display:block;overflow:visible}.toc a{display:block;margin:0 0 7px;white-space:normal}main{padding:34px}}
+</style>
+</head>
+<body>
+<div class="wrap"><section class="hero"><div class="eyebrow">Claude Deck plan</div><h1>Codex CLI Support</h1><div class="meta"><span class="pill">2026-05-25</span><span class="pill">Initial plan</span><span class="pill">Phone review</span></div></section><div class="layout"><nav class="toc" aria-label="Plan sections"><div class="toc-title">Sections</div><div class="toc-links"><a href="#goal">Goal</a><a href="#product-shape">Product</a><a href="#mixed-provider-sessions">Mixed Sessions</a><a href="#architecture-decision">Architecture</a><a href="#backend-plan">Backend</a><a href="#frontend-plan">Frontend</a><a href="#testing-plan">Testing</a><a href="#implementation-order">Order</a><a href="#open-questions">Questions</a></div></nav><main><h1>Codex CLI Support Across Claude Deck</h1>
+<p><strong>Date:</strong> 2026-05-25 <strong>Status:</strong> Initial plan for iteration <strong>Scope:</strong> Backend provider abstraction, tmux bridge, configuration surfaces, navigation/UI layout, docs, tests</p>
+<h2>Goal</h2>
+<p>Add first-class Codex CLI support to Claude Deck so the app can manage Claude Code and Codex side by side:</p>
+<ul>
+<li>Discover, spawn, attach to, and kill tmux sessions for both CLIs.</li>
+<li>View and edit Codex configuration with parity to the existing Claude Code configuration experience.</li>
+<li>Keep Claude-specific features intact while moving shared concepts into provider-neutral surfaces.</li>
+<li>Rework the left sidebar so the app can grow beyond a single Claude Code toolchain without becoming a long flat menu.</li>
+</ul>
+<p>This should make Claude Deck behave like a local agent operations console. Public branding can stay Claude Deck for now, but the internal architecture should become multi-agent.</p>
+<h2>Current State</h2>
+<p>The repo is now up to date with <code>origin/master</code> as of 2026-05-25.</p>
+<p>Relevant existing surfaces:</p>
+<ul>
+<li>Backend config service: <code>backend/app/services/config_service.py</code></li>
+<li>Claude path helpers: <code>backend/app/utils/path_utils.py</code></li>
+<li>Claude CLI executor: <code>backend/app/services/cli_executor.py</code></li>
+<li>CC Bridge discovery/spawn/relay:</li>
+<li><code>backend/app/services/cc_bridge/discovery.py</code></li>
+<li><code>backend/app/services/cc_bridge/spawn.py</code></li>
+<li><code>backend/app/services/cc_bridge/pty_relay.py</code></li>
+<li><code>backend/app/api/v1/cc_bridge/router.py</code></li>
+<li>Frontend config page:</li>
+<li><code>frontend/src/features/config/ConfigViewerPage.tsx</code></li>
+<li><code>frontend/src/features/config/settings/SettingsEditor.tsx</code></li>
+<li><code>frontend/src/features/config/settings/cards/*</code></li>
+<li>Frontend bridge page:</li>
+<li><code>frontend/src/features/cc-bridge/CCBridgePage.tsx</code></li>
+<li><code>frontend/src/features/cc-bridge/*</code></li>
+<li>Current sidebar: <code>frontend/src/components/layout/Sidebar.tsx</code></li>
+<li>Routes: <code>frontend/src/App.tsx</code></li>
+<li>Header/status: <code>backend/app/api/v1/status.py</code>, <code>frontend/src/components/layout/Header.tsx</code></li>
+</ul>
+<p>Local Codex CLI snapshot used for this plan:</p>
+<ul>
+<li>Installed binary: <code>codex-cli 0.133.0</code></li>
+<li>Main config file: <code>~/.codex/config.toml</code></li>
+<li>Relevant commands: <code>codex</code>, <code>codex exec</code>, <code>codex review</code>, <code>codex login/logout</code>, <code>codex mcp</code>, <code>codex plugin</code>, <code>codex doctor</code>, <code>codex resume</code>, <code>codex fork</code></li>
+<li>Important CLI flags: <code>--model</code>, <code>--profile</code>, <code>--profile-v2</code>, <code>--sandbox</code>, <code>--ask-for-approval</code>, <code>--search</code>, <code>--cd</code>, <code>--add-dir</code>, <code>--no-alt-screen</code>, <code>--strict-config</code>, <code>--config key=value</code></li>
+<li>Observed config examples: <code>model</code>, <code>model_reasoning_effort</code>, <code>[projects."&lt;path&gt;"].trust_level</code>, <code>[notice.model_migrations]</code>, <code>[tui.model_availability_nux]</code></li>
+</ul>
+<h2>Product Shape</h2>
+<p>The target product model:</p>
+<ul>
+<li><strong>Agents</strong> are provider-backed local CLIs: Claude Code, Codex CLI, later others.</li>
+<li><strong>Sessions</strong> are tmux panes/windows running one provider.</li>
+<li><strong>Configuration</strong> is provider-specific, but the app presents shared patterns consistently:</li>
+<li>user/global config</li>
+<li>project config</li>
+<li>profiles</li>
+<li>permissions/sandbox/trust</li>
+<li>MCP</li>
+<li>plugins/skills/extensions where supported</li>
+<li>diagnostics</li>
+<li><strong>Bridge</strong> becomes provider-neutral: one terminal/tmux experience with provider filtering.</li>
+</ul>
+<p>Avoid building a separate Codex-only duplicate of every Claude page. Use provider-aware building blocks and keep provider-specific cards where the config model genuinely differs.</p>
+<h2>Mixed Provider Sessions</h2>
+<p>Claude Code and Codex sessions should be visible together in the same Agent Bridge.</p>
+<p>The backend should run one tmux discovery pass across all panes, classify each matching pane with a provider id, and return a mixed session list. The frontend should default to an <strong>All agents</strong> view and offer provider filters for <strong>Claude Code</strong> and <strong>Codex</strong>.</p>
+<p>Example mixed response:</p>
+<pre><code>{
+  "sessions": [
+    { "provider": "claude-code", "tmux_target": "snazzy-1234:0.0", "cwd": "/home/joni/repos/snazzyemail" },
+    { "provider": "codex-cli", "tmux_target": "deck-5678:0.0", "cwd": "/home/joni/repos/claude-deck" },
+    { "provider": "claude-code", "tmux_target": "sam-9012:0.0", "cwd": "/home/joni/repos/linode-migration" },
+    { "provider": "codex-cli", "tmux_target": "stocks-3456:0.0", "cwd": "/home/joni/repos/stocks-dashboard" }
+  ]
+}</code></pre>
+<p>In the UI:</p>
+<ul>
+<li>Session cards show a provider badge.</li>
+<li>The bridge grid can display mixed sessions side by side.</li>
+<li>A user can attach to, watch, and interact with Claude Code and Codex panes at the same time.</li>
+<li>Provider-specific behavior is limited to discovery, spawn/resume/fork options, prompt-state handling, and configuration/diagnostics.</li>
+<li>Terminal rendering, WebSocket relay, fullscreen mode, multi-pane layout, and kill/preview mechanics stay shared.</li>
+</ul>
+<h2>Architecture Decision</h2>
+<p>Introduce an <code>AgentProvider</code> abstraction in the backend and mirror it in the frontend.</p>
+<p>Initial provider ids:</p>
+<ul>
+<li><code>claude-code</code></li>
+<li><code>codex-cli</code></li>
+</ul>
+<p>Provider metadata should include:</p>
+<ul>
+<li>display name</li>
+<li>binary name</li>
+<li>version command</li>
+<li>config root paths</li>
+<li>supported capabilities</li>
+<li>tmux process detection rules</li>
+<li>spawn command builder</li>
+<li>resume/fork support</li>
+<li>allowed CLI subcommands</li>
+<li>config schema/editor card list</li>
+</ul>
+<p>Example capability flags:</p>
+<pre><code>{
+  "sessions": true,
+  "spawn": true,
+  "resume": true,
+  "fork": true,
+  "mcp": true,
+  "plugins": true,
+  "commands": false,
+  "agents": false,
+  "skills": false,
+  "hooks": false,
+  "memory": false,
+  "usage": false,
+  "context": false,
+  "doctor": true
+}</code></pre>
+<p>Claude Code will expose the current richer Claude-specific feature set. Codex starts with tmux, config, MCP, plugins, doctor/status, and project trust.</p>
+<h2>Backend Plan</h2>
+<h3>Phase 1: Provider Registry</h3>
+<p>Create a small provider layer:</p>
+<ul>
+<li><code>backend/app/services/providers/__init__.py</code></li>
+<li><code>backend/app/services/providers/base.py</code></li>
+<li><code>backend/app/services/providers/claude_code.py</code></li>
+<li><code>backend/app/services/providers/codex_cli.py</code></li>
+<li><code>backend/app/api/v1/providers.py</code></li>
+</ul>
+<p>Provider interface:</p>
+<ul>
+<li><code>id</code></li>
+<li><code>display_name</code></li>
+<li><code>binary_name</code></li>
+<li><code>get_version()</code></li>
+<li><code>get_status()</code></li>
+<li><code>get_config_paths(project_path?: str)</code></li>
+<li><code>get_capabilities()</code></li>
+<li><code>is_process_match(command: str, pid: str) -&gt; bool</code></li>
+<li><code>build_spawn_command(request) -&gt; list[str]</code></li>
+<li><code>get_allowed_cli_commands() -&gt; list[str]</code></li>
+</ul>
+<p>Expose:</p>
+<ul>
+<li><code>GET /api/v1/providers</code></li>
+<li><code>GET /api/v1/providers/{provider_id}/status</code></li>
+<li><code>GET /api/v1/status</code> should eventually return both Claude and Codex versions.</li>
+</ul>
+<p>Migration rule: keep the existing <code>/cc-bridge</code> and <code>/config</code> routes during the transition. New routes can run in parallel until frontend migration is complete.</p>
+<h3>Phase 2: Generalize CC Bridge Into Agent Bridge</h3>
+<p>Keep the relay implementation, but rename the surrounding service concept from <code>cc_bridge</code> to <code>agent_bridge</code>.</p>
+<p>New backend files:</p>
+<ul>
+<li><code>backend/app/services/agent_bridge/discovery.py</code></li>
+<li><code>backend/app/services/agent_bridge/spawn.py</code></li>
+<li><code>backend/app/services/agent_bridge/pty_relay.py</code> or re-export existing relay</li>
+<li><code>backend/app/api/v1/agent_bridge/router.py</code></li>
+</ul>
+<p>New endpoints:</p>
+<ul>
+<li><code>GET /api/v1/agent-bridge/sessions</code></li>
+<li><code>GET /api/v1/agent-bridge/sessions?provider=codex-cli</code></li>
+<li><code>GET /api/v1/agent-bridge/sessions/{target:path}/preview</code></li>
+<li><code>GET /api/v1/agent-bridge/token</code></li>
+<li><code>WS /api/v1/agent-bridge/sessions/{target:path}/terminal</code></li>
+<li><code>POST /api/v1/agent-bridge/sessions</code></li>
+<li><code>DELETE /api/v1/agent-bridge/sessions/{target}</code></li>
+</ul>
+<p>Session response should add:</p>
+<pre><code>{
+  "provider": "codex-cli",
+  "provider_display_name": "Codex",
+  "tmux_target": "repo-1234:0.0",
+  "session_name": "repo-1234",
+  "window_name": "main",
+  "pane_id": "%1",
+  "cwd": "/home/joni/repos/foo",
+  "pid": "12345",
+  "status": "active"
+}</code></pre>
+<p>Codex detection:</p>
+<ul>
+<li>Match direct pane command <code>codex</code>.</li>
+<li>Match node wrapper descendants where argv0 basename is <code>codex</code>, mirroring the existing Claude descendant walk.</li>
+<li>Avoid matching <code>codex-exec-server</code> or unrelated helper processes unless a real interactive Codex TUI descendant is present.</li>
+</ul>
+<p>Claude detection:</p>
+<ul>
+<li>Move the existing <code>claude</code> and node-wrapper logic into <code>ClaudeCodeProvider</code>.</li>
+</ul>
+<p>Spawn behavior:</p>
+<ul>
+<li>Claude Code keeps existing modes: <code>plain</code>, <code>worktree</code>, <code>resume</code>.</li>
+<li>Codex should support:</li>
+<li><code>plain</code>: <code>codex --cd &lt;directory&gt;</code></li>
+<li><code>resume</code>: <code>codex resume &lt;session_id&gt;</code> or <code>codex resume --last</code>, with <code>--cd &lt;directory&gt;</code> when applicable</li>
+<li><code>fork</code>: <code>codex fork &lt;session_id&gt;</code> or <code>codex fork --last</code></li>
+<li>prompt seed: optional initial prompt argument</li>
+<li>options: <code>--model</code>, <code>--profile</code>, <code>--profile-v2</code>, <code>--sandbox</code>, <code>--ask-for-approval</code>, <code>--search</code>, <code>--no-alt-screen</code>, <code>--dangerously-bypass-approvals-and-sandbox</code></li>
+</ul>
+<p>Important tmux input rule:</p>
+<ul>
+<li>Preserve and formalize the defensive Enter behavior learned from Claude Code and Codex:</li>
+<li>paste/send prompt</li>
+<li>send explicit Enter</li>
+<li>capture pane</li>
+<li>if the prompt is still visibly sitting at the prompt, send Enter again</li>
+<li>This belongs in the shared bridge layer, not inside one provider.</li>
+</ul>
+<h3>Phase 3: Provider-Aware CLI Executor</h3>
+<p>Replace <code>CLIExecutor</code> with a provider-aware executor:</p>
+<ul>
+<li><code>backend/app/services/cli_executor.py</code> can become <code>ProviderCLIExecutor</code>.</li>
+<li>Existing <code>/cli/execute</code> can gain a <code>provider</code> field or be superseded by <code>POST /providers/{provider_id}/cli</code>.</li>
+</ul>
+<p>Codex whitelist:</p>
+<ul>
+<li><code>doctor</code></li>
+<li><code>mcp</code></li>
+<li><code>plugin</code></li>
+<li><code>features</code></li>
+<li><code>completion</code> only if needed later</li>
+</ul>
+<p>Do not expose:</p>
+<ul>
+<li><code>logout</code></li>
+<li><code>update</code></li>
+<li><code>apply</code></li>
+<li><code>sandbox</code></li>
+<li><code>exec</code></li>
+<li><code>review</code></li>
+<li><code>cloud</code></li>
+</ul>
+<p>Those can change user state, run commands, or perform broad external actions and should only be added with explicit UX and safety review.</p>
+<h3>Phase 4: Codex Configuration Service</h3>
+<p>Codex uses TOML, not Claude's JSON settings model. Add a separate service rather than forcing it through <code>ConfigService</code>.</p>
+<p>New files:</p>
+<ul>
+<li><code>backend/app/services/codex_config_service.py</code></li>
+<li><code>backend/app/utils/codex_path_utils.py</code></li>
+<li><code>backend/app/api/v1/codex_config.py</code> or provider-scoped config routes</li>
+</ul>
+<p>Paths:</p>
+<ul>
+<li>User config: <code>$CODEX_HOME/config.toml</code>, defaulting to <code>~/.codex/config.toml</code></li>
+<li>Auth file: <code>$CODEX_HOME/auth.json</code>, display status only, never raw content</li>
+<li>History: <code>$CODEX_HOME/history.jsonl</code>, future read-only surface</li>
+<li>Models cache: <code>$CODEX_HOME/models_cache.json</code>, future read-only surface</li>
+<li>Rules: <code>$CODEX_HOME/rules/*.rules</code></li>
+<li>Profiles v2: <code>$CODEX_HOME/&lt;name&gt;.config.toml</code></li>
+</ul>
+<p>Use a TOML parser/writer, not regex editing. Python 3.11+ has <code>tomllib</code> for reading only, so add a write-capable TOML dependency if the backend does not already have one. Candidates:</p>
+<ul>
+<li><code>tomlkit</code> preferred because it preserves comments/formatting.</li>
+<li><code>tomli-w</code> acceptable if formatting preservation is not required.</li>
+</ul>
+<p>Initial editable Codex config cards:</p>
+<ul>
+<li>General:</li>
+<li><code>model</code></li>
+<li><code>model_reasoning_effort</code></li>
+<li><code>profile</code></li>
+<li><code>profile-v2</code> references, if present</li>
+<li>Runtime:</li>
+<li><code>sandbox_mode</code> or equivalent persisted key if present</li>
+<li><code>approval_policy</code> or equivalent persisted key if present</li>
+<li><code>search</code></li>
+<li><code>strict_config</code></li>
+<li><code>no_alt_screen</code></li>
+<li>Projects:</li>
+<li><code>[projects."&lt;path&gt;"].trust_level</code></li>
+<li>add/remove trusted project paths</li>
+<li>show invalid/missing paths</li>
+<li>Profiles:</li>
+<li><code>[profiles.&lt;name&gt;]</code> entries in <code>config.toml</code></li>
+<li>v2 profile files under <code>$CODEX_HOME/*.config.toml</code></li>
+<li>MCP:</li>
+<li>read via TOML config and/or <code>codex mcp list</code></li>
+<li>add/remove via <code>codex mcp</code> where safer than direct TOML writes</li>
+<li>Plugins:</li>
+<li>read installed/marketplace state via <code>codex plugin list</code> and local config where possible</li>
+<li>add/remove through explicit command workflows later</li>
+<li>Features:</li>
+<li><code>[features]</code> booleans</li>
+<li><code>codex features</code> read-only diagnostics if useful</li>
+</ul>
+<p>Read-only Codex status cards:</p>
+<ul>
+<li><code>codex doctor --json</code></li>
+<li>installed version</li>
+<li>auth present/missing</li>
+<li>config parse errors</li>
+<li>unknown fields when <code>--strict-config</code> would fail</li>
+</ul>
+<h3>Phase 5: Backup Support</h3>
+<p>Extend backup/export to include provider-specific files.</p>
+<p>Current backup service is Claude-specific. Add provider options:</p>
+<ul>
+<li><code>claude-code</code> files:</li>
+<li>current behavior</li>
+<li><code>codex-cli</code> files:</li>
+<li><code>~/.codex/config.toml</code></li>
+<li><code>~/.codex/*.config.toml</code></li>
+<li><code>~/.codex/rules/*.rules</code></li>
+<li>exclude <code>auth.json</code> by default</li>
+<li>exclude SQLite/log/history files by default unless a later explicit export mode is added</li>
+</ul>
+<p>UI backup wizard should allow:</p>
+<ul>
+<li>provider selection</li>
+<li>include/exclude auth-sensitive files</li>
+<li>clear warning when exporting Codex auth is not included</li>
+</ul>
+<h2>Frontend Plan</h2>
+<h3>Phase 1: Provider Context</h3>
+<p>Add a provider selector independent of project selection:</p>
+<ul>
+<li><code>frontend/src/contexts/ProviderContext.tsx</code></li>
+<li><code>frontend/src/types/providers.ts</code></li>
+<li><code>frontend/src/hooks/useProviders.ts</code></li>
+</ul>
+<p>Provider state:</p>
+<ul>
+<li>selected provider</li>
+<li>provider capabilities</li>
+<li>installed/missing status</li>
+<li>versions</li>
+</ul>
+<p>Default behavior:</p>
+<ul>
+<li>If both are installed, keep last selected provider.</li>
+<li>If only one is installed, select it automatically.</li>
+<li>If Codex is missing, show install/status guidance but keep Claude pages usable.</li>
+</ul>
+<h3>Phase 2: Sidebar Rework</h3>
+<p>Replace the flat sidebar array with grouped navigation and provider-aware filtering.</p>
+<p>Recommended left sidebar structure:</p>
+<ul>
+<li>Top area:</li>
+<li>Project switcher</li>
+<li>Agent provider switcher: Claude Code / Codex</li>
+<li>Primary:</li>
+<li>Dashboard</li>
+<li>Agent Bridge</li>
+<li>Sessions</li>
+<li>Configuration:</li>
+<li>Overview</li>
+<li>Settings</li>
+<li>MCP</li>
+<li>Plugins</li>
+<li>Permissions / Trust</li>
+<li>Hooks</li>
+<li>Commands</li>
+<li>Agents</li>
+<li>Skills</li>
+<li>Memory</li>
+<li>Output Styles</li>
+<li>Status Line</li>
+<li>Operations:</li>
+<li>Presence</li>
+<li>Plans</li>
+<li>Context</li>
+<li>Usage</li>
+<li>Backup</li>
+<li>Diagnostics</li>
+</ul>
+<p>Hide items unsupported by the selected provider by default, with a small "Claude-only" or "Unsupported for Codex" affordance in search/overflow if needed. Do not show a dead Codex page for Claude-only concepts like Claude agents unless we intentionally build a Codex equivalent.</p>
+<p>Implementation approach:</p>
+<ul>
+<li>Convert <code>navigation</code> in <code>Sidebar.tsx</code> into a grouped <code>NavGroup[]</code>.</li>
+<li>Add collapsible groups using the existing <code>Collapsible</code> UI primitive.</li>
+<li>Keep collapsed-icon mode working.</li>
+<li>Add route metadata with <code>providerSupport</code>.</li>
+<li>Rename visible "CC Bridge" to "Agent Bridge".</li>
+</ul>
+<h3>Phase 3: Agent Bridge UI</h3>
+<p>Move frontend bridge feature:</p>
+<ul>
+<li>from <code>frontend/src/features/cc-bridge/*</code></li>
+<li>to <code>frontend/src/features/agent-bridge/*</code></li>
+</ul>
+<p>Page changes:</p>
+<ul>
+<li>Provider filter tabs or segmented control: All / Claude Code / Codex</li>
+<li>Session cards show provider badge.</li>
+<li>New session dialog starts with provider choice and then shows provider-specific fields.</li>
+<li>Codex spawn options:</li>
+<li>directory</li>
+<li>mode: new / resume / fork</li>
+<li>resume/fork id or <code>--last</code></li>
+<li>model</li>
+<li>profile</li>
+<li>profile v2</li>
+<li>sandbox mode</li>
+<li>approval policy</li>
+<li>search toggle</li>
+<li>no-alt-screen toggle</li>
+<li>optional initial prompt</li>
+<li>dangerous bypass toggle with explicit warning</li>
+<li>Claude spawn options keep current fields.</li>
+</ul>
+<p>Keep the current terminal grid behavior, fullscreen behavior, and tokenized WebSocket flow.</p>
+<h3>Phase 4: Configuration UI</h3>
+<p>Current <code>ConfigViewerPage</code> assumes Claude Code. Evolve it into provider-aware configuration.</p>
+<p>Recommended route shape:</p>
+<ul>
+<li><code>/config</code> stays as provider-selected config overview.</li>
+<li>Optional explicit routes:</li>
+<li><code>/config/claude-code</code></li>
+<li><code>/config/codex-cli</code></li>
+</ul>
+<p>UI layout:</p>
+<ul>
+<li>Provider header with version/status.</li>
+<li>Tabs:</li>
+<li>Settings Editor</li>
+<li>Scope/Profile Resolver</li>
+<li>Raw Viewer</li>
+<li>Diagnostics</li>
+</ul>
+<p>Claude path:</p>
+<ul>
+<li>Reuse existing <code>SettingsEditor</code>, <code>ScopeResolver</code>, <code>ConfigFileList</code>, and <code>ConfigFileViewer</code>.</li>
+</ul>
+<p>Codex path:</p>
+<ul>
+<li>New <code>CodexSettingsEditor</code>.</li>
+<li>New <code>CodexProfileResolver</code>.</li>
+<li>New <code>CodexConfigFileList</code>.</li>
+<li>New <code>CodexDiagnosticsPanel</code>.</li>
+</ul>
+<p>Codex config cards:</p>
+<ul>
+<li><code>CodexGeneralCard</code></li>
+<li><code>CodexRuntimeCard</code></li>
+<li><code>CodexProjectsCard</code></li>
+<li><code>CodexProfilesCard</code></li>
+<li><code>CodexMcpCard</code></li>
+<li><code>CodexPluginsCard</code></li>
+<li><code>CodexFeaturesCard</code></li>
+<li><code>CodexRulesCard</code></li>
+<li><code>CodexDiagnosticsCard</code></li>
+</ul>
+<p>Raw viewer:</p>
+<ul>
+<li>TOML syntax display/edit for <code>config.toml</code>.</li>
+<li>Warn before saving raw TOML.</li>
+<li>Validate by parsing TOML before write.</li>
+<li>Offer <code>codex doctor --json</code> after save.</li>
+</ul>
+<h3>Phase 5: Header and Dashboard</h3>
+<p>Header currently shows only Claude Code version. Update status payload and UI:</p>
+<ul>
+<li>show selected provider version</li>
+<li>show both provider install statuses in a compact popover later</li>
+<li>active sessions should be provider-count aware</li>
+</ul>
+<p>Dashboard:</p>
+<ul>
+<li>add provider status summary</li>
+<li>split active sessions by provider</li>
+<li>keep Claude-only metrics clearly labeled where Codex has no equivalent yet</li>
+</ul>
+<h3>Phase 6: Docs</h3>
+<p>Docs to add/update:</p>
+<ul>
+<li><code>docs/features/agent-bridge.md</code></li>
+<li><code>docs/features/config.md</code></li>
+<li><code>docs/api/providers.md</code></li>
+<li><code>docs/api/agent-bridge.md</code></li>
+<li><code>docs/api/config.md</code></li>
+<li><code>docs/guide/architecture.md</code></li>
+<li>README feature list</li>
+</ul>
+<p>Keep old <code>cc-bridge</code> docs as compatibility notes until routes/components are fully migrated.</p>
+<h2>Route/API Migration</h2>
+<p>Compatibility period:</p>
+<ul>
+<li>Keep <code>/cc-bridge</code> frontend route as a redirect or alias to <code>/agent-bridge?provider=claude-code</code>.</li>
+<li>Keep backend <code>/api/v1/cc-bridge/*</code> until the UI no longer calls it.</li>
+<li>New code should call <code>/api/v1/agent-bridge/*</code>.</li>
+</ul>
+<p>Final cleanup later:</p>
+<ul>
+<li>Remove old CC Bridge route names after one release cycle.</li>
+<li>Update screenshots and docs.</li>
+</ul>
+<h2>Data Model Notes</h2>
+<p>No database migration is required for the initial plan unless we decide to persist provider preferences server-side.</p>
+<p>If persisted preferences are needed:</p>
+<ul>
+<li>selected provider</li>
+<li>last bridge filters</li>
+<li>default spawn options per provider</li>
+</ul>
+<p>Prefer local browser storage first for UI preferences. Use backend persistence only for shared machine-level preferences.</p>
+<h2>Testing Plan</h2>
+<p>Backend tests:</p>
+<ul>
+<li>Provider registry returns Claude and Codex providers.</li>
+<li>Missing Codex binary reports installed=false without failing.</li>
+<li>Codex version parsing handles <code>codex-cli 0.133.0</code>.</li>
+<li>Codex tmux discovery matches direct <code>codex</code>.</li>
+<li>Codex tmux discovery matches node wrapper descendant.</li>
+<li>Codex tmux discovery rejects helper processes.</li>
+<li>Codex spawn command builder validates directory and modes.</li>
+<li>Codex config service reads TOML.</li>
+<li>Codex config service writes TOML without dropping unrelated keys.</li>
+<li>Codex config service masks secrets and never returns <code>auth.json</code>.</li>
+<li>Provider-aware CLI executor enforces per-provider whitelist.</li>
+</ul>
+<p>Frontend tests:</p>
+<ul>
+<li>Sidebar groups render and collapse.</li>
+<li>Provider switcher hides unsupported nav items.</li>
+<li>Agent Bridge lists mixed provider sessions.</li>
+<li>New session dialog renders Codex fields when Codex is selected.</li>
+<li>Config page renders Claude editor for Claude provider.</li>
+<li>Config page renders Codex editor for Codex provider.</li>
+<li>Raw TOML validation blocks invalid saves.</li>
+</ul>
+<p>Manual verification:</p>
+<ul>
+<li>Start existing Claude Code tmux session and confirm discovery.</li>
+<li>Start existing Codex tmux session and confirm discovery.</li>
+<li>Spawn Codex from a repo and attach terminal.</li>
+<li>Send prompt through interactive bridge and verify Enter handling.</li>
+<li>Edit a harmless Codex setting in a temp <code>$CODEX_HOME</code>.</li>
+<li>Run <code>codex doctor --json</code> from diagnostics with redacted output.</li>
+</ul>
+<h2>Implementation Order</h2>
+<ol>
+<li>Add backend provider registry and status endpoint.</li>
+<li>Add Codex provider with version/status/config path detection.</li>
+<li>Generalize bridge backend into <code>agent_bridge</code> while keeping <code>/cc-bridge</code>.</li>
+<li>Add Codex discovery and spawn command building.</li>
+<li>Add frontend provider context and provider selector.</li>
+<li>Rework sidebar into grouped provider-aware navigation.</li>
+<li>Rename/migrate CC Bridge frontend to Agent Bridge with provider filtering.</li>
+<li>Add Codex new-session dialog fields.</li>
+<li>Add Codex TOML config service and read-only config files endpoint.</li>
+<li>Add Codex settings editor cards for general/runtime/projects/profiles.</li>
+<li>Add Codex MCP/plugins/diagnostics surfaces.</li>
+<li>Extend backup/export for Codex config.</li>
+<li>Update docs and screenshots.</li>
+<li>Remove or alias old naming after compatibility is verified.</li>
+</ol>
+<h2>Open Questions</h2>
+<ul>
+<li>Should the public product name remain Claude Deck, or should the UI start using a broader label like "Agent Deck" while the repo remains <code>claude-deck</code>?</li>
+<li>Should provider selection be global, per page, or per project?</li>
+<li>Should Codex project trust be edited directly in TOML, only via CLI if Codex adds commands for it, or both?</li>
+<li>Should Codex <code>auth.json</code> ever be included in backups behind an explicit advanced option?</li>
+<li>Do we want OpenAI account/model usage metrics in Claude Deck, or keep Codex usage out of scope until the CLI exposes stable local usage data?</li>
+<li>Should non-interactive <code>codex exec</code> and <code>codex review</code> be exposed as task actions later, or should v1 stay strictly interactive/tmux plus config?</li>
+</ul>
+<h2>Risks</h2>
+<ul>
+<li>Codex CLI config shape may evolve quickly. Use permissive TOML read/write and avoid hardcoding too much schema.</li>
+<li>Raw TOML writing can damage comments/formatting unless we use <code>tomlkit</code>.</li>
+<li>Naming migration from CC Bridge to Agent Bridge touches docs, routes, screenshots, and mental model.</li>
+<li>Sidebar grouping can become a UX project by itself. Keep the first version functional and restrained.</li>
+<li>Provider-specific config can drift. Tests should use temp homes and fixture configs for both providers.</li>
+</ul>
+<h2>Definition of Done for v1</h2>
+<ul>
+<li>Claude Code behavior is unchanged.</li>
+<li>Codex sessions are discoverable in tmux.</li>
+<li>Claude and Codex sessions can be viewed in the same Agent Bridge grid.</li>
+<li>Codex sessions can be spawned from the UI with core runtime options.</li>
+<li>Codex <code>~/.codex/config.toml</code> can be viewed and safely edited through structured cards.</li>
+<li>Codex project trust and profiles are visible and manageable.</li>
+<li>Codex doctor output is available as a redacted diagnostics panel.</li>
+<li>Sidebar is grouped and provider-aware.</li>
+<li>Tests cover provider detection, bridge discovery/spawn, TOML config editing, and core UI routing.</li>
+</ul>
+</main></div></div>
+<script>document.querySelectorAll('main h2, main h3').forEach(h=>{if(!h.id){h.id=h.textContent.toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-|-$/g,'')}});</script>
+</body></html>

--- a/docs/plans/2026-05-25-codex-cli-support.md
+++ b/docs/plans/2026-05-25-codex-cli-support.md
@@ -1,0 +1,628 @@
+# Codex CLI Support Across Claude Deck
+
+**Date:** 2026-05-25  
+**Status:** Initial plan for iteration  
+**Scope:** Backend provider abstraction, tmux bridge, configuration surfaces, navigation/UI layout, docs, tests
+
+## Goal
+
+Add first-class Codex CLI support to Claude Deck so the app can manage Claude Code and Codex side by side:
+
+- Discover, spawn, attach to, and kill tmux sessions for both CLIs.
+- View and edit Codex configuration with parity to the existing Claude Code configuration experience.
+- Keep Claude-specific features intact while moving shared concepts into provider-neutral surfaces.
+- Rework the left sidebar so the app can grow beyond a single Claude Code toolchain without becoming a long flat menu.
+
+This should make Claude Deck behave like a local agent operations console. Public branding can stay Claude Deck for now, but the internal architecture should become multi-agent.
+
+## Current State
+
+The repo is now up to date with `origin/master` as of 2026-05-25.
+
+Relevant existing surfaces:
+
+- Backend config service: `backend/app/services/config_service.py`
+- Claude path helpers: `backend/app/utils/path_utils.py`
+- Claude CLI executor: `backend/app/services/cli_executor.py`
+- CC Bridge discovery/spawn/relay:
+  - `backend/app/services/cc_bridge/discovery.py`
+  - `backend/app/services/cc_bridge/spawn.py`
+  - `backend/app/services/cc_bridge/pty_relay.py`
+  - `backend/app/api/v1/cc_bridge/router.py`
+- Frontend config page:
+  - `frontend/src/features/config/ConfigViewerPage.tsx`
+  - `frontend/src/features/config/settings/SettingsEditor.tsx`
+  - `frontend/src/features/config/settings/cards/*`
+- Frontend bridge page:
+  - `frontend/src/features/cc-bridge/CCBridgePage.tsx`
+  - `frontend/src/features/cc-bridge/*`
+- Current sidebar: `frontend/src/components/layout/Sidebar.tsx`
+- Routes: `frontend/src/App.tsx`
+- Header/status: `backend/app/api/v1/status.py`, `frontend/src/components/layout/Header.tsx`
+
+Local Codex CLI snapshot used for this plan:
+
+- Installed binary: `codex-cli 0.133.0`
+- Main config file: `~/.codex/config.toml`
+- Relevant commands: `codex`, `codex exec`, `codex review`, `codex login/logout`, `codex mcp`, `codex plugin`, `codex doctor`, `codex resume`, `codex fork`
+- Important CLI flags: `--model`, `--profile`, `--profile-v2`, `--sandbox`, `--ask-for-approval`, `--search`, `--cd`, `--add-dir`, `--no-alt-screen`, `--strict-config`, `--config key=value`
+- Observed config examples: `model`, `model_reasoning_effort`, `[projects."<path>"].trust_level`, `[notice.model_migrations]`, `[tui.model_availability_nux]`
+
+## Product Shape
+
+The target product model:
+
+- **Agents** are provider-backed local CLIs: Claude Code, Codex CLI, later others.
+- **Sessions** are tmux panes/windows running one provider.
+- **Configuration** is provider-specific, but the app presents shared patterns consistently:
+  - user/global config
+  - project config
+  - profiles
+  - permissions/sandbox/trust
+  - MCP
+  - plugins/skills/extensions where supported
+  - diagnostics
+- **Bridge** becomes provider-neutral: one terminal/tmux experience with provider filtering.
+
+Avoid building a separate Codex-only duplicate of every Claude page. Use provider-aware building blocks and keep provider-specific cards where the config model genuinely differs.
+
+## Mixed Provider Sessions
+
+Claude Code and Codex sessions should be visible together in the same Agent Bridge.
+
+The backend should run one tmux discovery pass across all panes, classify each matching pane with a provider id, and return a mixed session list. The frontend should default to an **All agents** view and offer provider filters for **Claude Code** and **Codex**.
+
+Example mixed response:
+
+```json
+{
+  "sessions": [
+    { "provider": "claude-code", "tmux_target": "snazzy-1234:0.0", "cwd": "/home/joni/repos/snazzyemail" },
+    { "provider": "codex-cli", "tmux_target": "deck-5678:0.0", "cwd": "/home/joni/repos/claude-deck" },
+    { "provider": "claude-code", "tmux_target": "sam-9012:0.0", "cwd": "/home/joni/repos/linode-migration" },
+    { "provider": "codex-cli", "tmux_target": "stocks-3456:0.0", "cwd": "/home/joni/repos/stocks-dashboard" }
+  ]
+}
+```
+
+In the UI:
+
+- Session cards show a provider badge.
+- The bridge grid can display mixed sessions side by side.
+- A user can attach to, watch, and interact with Claude Code and Codex panes at the same time.
+- Provider-specific behavior is limited to discovery, spawn/resume/fork options, prompt-state handling, and configuration/diagnostics.
+- Terminal rendering, WebSocket relay, fullscreen mode, multi-pane layout, and kill/preview mechanics stay shared.
+
+## Architecture Decision
+
+Introduce an `AgentProvider` abstraction in the backend and mirror it in the frontend.
+
+Initial provider ids:
+
+- `claude-code`
+- `codex-cli`
+
+Provider metadata should include:
+
+- display name
+- binary name
+- version command
+- config root paths
+- supported capabilities
+- tmux process detection rules
+- spawn command builder
+- resume/fork support
+- allowed CLI subcommands
+- config schema/editor card list
+
+Example capability flags:
+
+```json
+{
+  "sessions": true,
+  "spawn": true,
+  "resume": true,
+  "fork": true,
+  "mcp": true,
+  "plugins": true,
+  "commands": false,
+  "agents": false,
+  "skills": false,
+  "hooks": false,
+  "memory": false,
+  "usage": false,
+  "context": false,
+  "doctor": true
+}
+```
+
+Claude Code will expose the current richer Claude-specific feature set. Codex starts with tmux, config, MCP, plugins, doctor/status, and project trust.
+
+## Backend Plan
+
+### Phase 1: Provider Registry
+
+Create a small provider layer:
+
+- `backend/app/services/providers/__init__.py`
+- `backend/app/services/providers/base.py`
+- `backend/app/services/providers/claude_code.py`
+- `backend/app/services/providers/codex_cli.py`
+- `backend/app/api/v1/providers.py`
+
+Provider interface:
+
+- `id`
+- `display_name`
+- `binary_name`
+- `get_version()`
+- `get_status()`
+- `get_config_paths(project_path?: str)`
+- `get_capabilities()`
+- `is_process_match(command: str, pid: str) -> bool`
+- `build_spawn_command(request) -> list[str]`
+- `get_allowed_cli_commands() -> list[str]`
+
+Expose:
+
+- `GET /api/v1/providers`
+- `GET /api/v1/providers/{provider_id}/status`
+- `GET /api/v1/status` should eventually return both Claude and Codex versions.
+
+Migration rule: keep the existing `/cc-bridge` and `/config` routes during the transition. New routes can run in parallel until frontend migration is complete.
+
+### Phase 2: Generalize CC Bridge Into Agent Bridge
+
+Keep the relay implementation, but rename the surrounding service concept from `cc_bridge` to `agent_bridge`.
+
+New backend files:
+
+- `backend/app/services/agent_bridge/discovery.py`
+- `backend/app/services/agent_bridge/spawn.py`
+- `backend/app/services/agent_bridge/pty_relay.py` or re-export existing relay
+- `backend/app/api/v1/agent_bridge/router.py`
+
+New endpoints:
+
+- `GET /api/v1/agent-bridge/sessions`
+- `GET /api/v1/agent-bridge/sessions?provider=codex-cli`
+- `GET /api/v1/agent-bridge/sessions/{target:path}/preview`
+- `GET /api/v1/agent-bridge/token`
+- `WS /api/v1/agent-bridge/sessions/{target:path}/terminal`
+- `POST /api/v1/agent-bridge/sessions`
+- `DELETE /api/v1/agent-bridge/sessions/{target}`
+
+Session response should add:
+
+```json
+{
+  "provider": "codex-cli",
+  "provider_display_name": "Codex",
+  "tmux_target": "repo-1234:0.0",
+  "session_name": "repo-1234",
+  "window_name": "main",
+  "pane_id": "%1",
+  "cwd": "/home/joni/repos/foo",
+  "pid": "12345",
+  "status": "active"
+}
+```
+
+Codex detection:
+
+- Match direct pane command `codex`.
+- Match node wrapper descendants where argv0 basename is `codex`, mirroring the existing Claude descendant walk.
+- Avoid matching `codex-exec-server` or unrelated helper processes unless a real interactive Codex TUI descendant is present.
+
+Claude detection:
+
+- Move the existing `claude` and node-wrapper logic into `ClaudeCodeProvider`.
+
+Spawn behavior:
+
+- Claude Code keeps existing modes: `plain`, `worktree`, `resume`.
+- Codex should support:
+  - `plain`: `codex --cd <directory>`
+  - `resume`: `codex resume <session_id>` or `codex resume --last`, with `--cd <directory>` when applicable
+  - `fork`: `codex fork <session_id>` or `codex fork --last`
+  - prompt seed: optional initial prompt argument
+  - options: `--model`, `--profile`, `--profile-v2`, `--sandbox`, `--ask-for-approval`, `--search`, `--no-alt-screen`, `--dangerously-bypass-approvals-and-sandbox`
+
+Important tmux input rule:
+
+- Preserve and formalize the defensive Enter behavior learned from Claude Code and Codex:
+  - paste/send prompt
+  - send explicit Enter
+  - capture pane
+  - if the prompt is still visibly sitting at the prompt, send Enter again
+- This belongs in the shared bridge layer, not inside one provider.
+
+### Phase 3: Provider-Aware CLI Executor
+
+Replace `CLIExecutor` with a provider-aware executor:
+
+- `backend/app/services/cli_executor.py` can become `ProviderCLIExecutor`.
+- Existing `/cli/execute` can gain a `provider` field or be superseded by `POST /providers/{provider_id}/cli`.
+
+Codex whitelist:
+
+- `doctor`
+- `mcp`
+- `plugin`
+- `features`
+- `completion` only if needed later
+
+Do not expose:
+
+- `logout`
+- `update`
+- `apply`
+- `sandbox`
+- `exec`
+- `review`
+- `cloud`
+
+Those can change user state, run commands, or perform broad external actions and should only be added with explicit UX and safety review.
+
+### Phase 4: Codex Configuration Service
+
+Codex uses TOML, not Claude's JSON settings model. Add a separate service rather than forcing it through `ConfigService`.
+
+New files:
+
+- `backend/app/services/codex_config_service.py`
+- `backend/app/utils/codex_path_utils.py`
+- `backend/app/api/v1/codex_config.py` or provider-scoped config routes
+
+Paths:
+
+- User config: `$CODEX_HOME/config.toml`, defaulting to `~/.codex/config.toml`
+- Auth file: `$CODEX_HOME/auth.json`, display status only, never raw content
+- History: `$CODEX_HOME/history.jsonl`, future read-only surface
+- Models cache: `$CODEX_HOME/models_cache.json`, future read-only surface
+- Rules: `$CODEX_HOME/rules/*.rules`
+- Profiles v2: `$CODEX_HOME/<name>.config.toml`
+
+Use a TOML parser/writer, not regex editing. Python 3.11+ has `tomllib` for reading only, so add a write-capable TOML dependency if the backend does not already have one. Candidates:
+
+- `tomlkit` preferred because it preserves comments/formatting.
+- `tomli-w` acceptable if formatting preservation is not required.
+
+Initial editable Codex config cards:
+
+- General:
+  - `model`
+  - `model_reasoning_effort`
+  - `profile`
+  - `profile-v2` references, if present
+- Runtime:
+  - `sandbox_mode` or equivalent persisted key if present
+  - `approval_policy` or equivalent persisted key if present
+  - `search`
+  - `strict_config`
+  - `no_alt_screen`
+- Projects:
+  - `[projects."<path>"].trust_level`
+  - add/remove trusted project paths
+  - show invalid/missing paths
+- Profiles:
+  - `[profiles.<name>]` entries in `config.toml`
+  - v2 profile files under `$CODEX_HOME/*.config.toml`
+- MCP:
+  - read via TOML config and/or `codex mcp list`
+  - add/remove via `codex mcp` where safer than direct TOML writes
+- Plugins:
+  - read installed/marketplace state via `codex plugin list` and local config where possible
+  - add/remove through explicit command workflows later
+- Features:
+  - `[features]` booleans
+  - `codex features` read-only diagnostics if useful
+
+Read-only Codex status cards:
+
+- `codex doctor --json`
+- installed version
+- auth present/missing
+- config parse errors
+- unknown fields when `--strict-config` would fail
+
+### Phase 5: Backup Support
+
+Extend backup/export to include provider-specific files.
+
+Current backup service is Claude-specific. Add provider options:
+
+- `claude-code` files:
+  - current behavior
+- `codex-cli` files:
+  - `~/.codex/config.toml`
+  - `~/.codex/*.config.toml`
+  - `~/.codex/rules/*.rules`
+  - exclude `auth.json` by default
+  - exclude SQLite/log/history files by default unless a later explicit export mode is added
+
+UI backup wizard should allow:
+
+- provider selection
+- include/exclude auth-sensitive files
+- clear warning when exporting Codex auth is not included
+
+## Frontend Plan
+
+### Phase 1: Provider Context
+
+Add a provider selector independent of project selection:
+
+- `frontend/src/contexts/ProviderContext.tsx`
+- `frontend/src/types/providers.ts`
+- `frontend/src/hooks/useProviders.ts`
+
+Provider state:
+
+- selected provider
+- provider capabilities
+- installed/missing status
+- versions
+
+Default behavior:
+
+- If both are installed, keep last selected provider.
+- If only one is installed, select it automatically.
+- If Codex is missing, show install/status guidance but keep Claude pages usable.
+
+### Phase 2: Sidebar Rework
+
+Replace the flat sidebar array with grouped navigation and provider-aware filtering.
+
+Recommended left sidebar structure:
+
+- Top area:
+  - Project switcher
+  - Agent provider switcher: Claude Code / Codex
+- Primary:
+  - Dashboard
+  - Agent Bridge
+  - Sessions
+- Configuration:
+  - Overview
+  - Settings
+  - MCP
+  - Plugins
+  - Permissions / Trust
+  - Hooks
+  - Commands
+  - Agents
+  - Skills
+  - Memory
+  - Output Styles
+  - Status Line
+- Operations:
+  - Presence
+  - Plans
+  - Context
+  - Usage
+  - Backup
+  - Diagnostics
+
+Hide items unsupported by the selected provider by default, with a small "Claude-only" or "Unsupported for Codex" affordance in search/overflow if needed. Do not show a dead Codex page for Claude-only concepts like Claude agents unless we intentionally build a Codex equivalent.
+
+Implementation approach:
+
+- Convert `navigation` in `Sidebar.tsx` into a grouped `NavGroup[]`.
+- Add collapsible groups using the existing `Collapsible` UI primitive.
+- Keep collapsed-icon mode working.
+- Add route metadata with `providerSupport`.
+- Rename visible "CC Bridge" to "Agent Bridge".
+
+### Phase 3: Agent Bridge UI
+
+Move frontend bridge feature:
+
+- from `frontend/src/features/cc-bridge/*`
+- to `frontend/src/features/agent-bridge/*`
+
+Page changes:
+
+- Provider filter tabs or segmented control: All / Claude Code / Codex
+- Session cards show provider badge.
+- New session dialog starts with provider choice and then shows provider-specific fields.
+- Codex spawn options:
+  - directory
+  - mode: new / resume / fork
+  - resume/fork id or `--last`
+  - model
+  - profile
+  - profile v2
+  - sandbox mode
+  - approval policy
+  - search toggle
+  - no-alt-screen toggle
+  - optional initial prompt
+  - dangerous bypass toggle with explicit warning
+- Claude spawn options keep current fields.
+
+Keep the current terminal grid behavior, fullscreen behavior, and tokenized WebSocket flow.
+
+### Phase 4: Configuration UI
+
+Current `ConfigViewerPage` assumes Claude Code. Evolve it into provider-aware configuration.
+
+Recommended route shape:
+
+- `/config` stays as provider-selected config overview.
+- Optional explicit routes:
+  - `/config/claude-code`
+  - `/config/codex-cli`
+
+UI layout:
+
+- Provider header with version/status.
+- Tabs:
+  - Settings Editor
+  - Scope/Profile Resolver
+  - Raw Viewer
+  - Diagnostics
+
+Claude path:
+
+- Reuse existing `SettingsEditor`, `ScopeResolver`, `ConfigFileList`, and `ConfigFileViewer`.
+
+Codex path:
+
+- New `CodexSettingsEditor`.
+- New `CodexProfileResolver`.
+- New `CodexConfigFileList`.
+- New `CodexDiagnosticsPanel`.
+
+Codex config cards:
+
+- `CodexGeneralCard`
+- `CodexRuntimeCard`
+- `CodexProjectsCard`
+- `CodexProfilesCard`
+- `CodexMcpCard`
+- `CodexPluginsCard`
+- `CodexFeaturesCard`
+- `CodexRulesCard`
+- `CodexDiagnosticsCard`
+
+Raw viewer:
+
+- TOML syntax display/edit for `config.toml`.
+- Warn before saving raw TOML.
+- Validate by parsing TOML before write.
+- Offer `codex doctor --json` after save.
+
+### Phase 5: Header and Dashboard
+
+Header currently shows only Claude Code version. Update status payload and UI:
+
+- show selected provider version
+- show both provider install statuses in a compact popover later
+- active sessions should be provider-count aware
+
+Dashboard:
+
+- add provider status summary
+- split active sessions by provider
+- keep Claude-only metrics clearly labeled where Codex has no equivalent yet
+
+### Phase 6: Docs
+
+Docs to add/update:
+
+- `docs/features/agent-bridge.md`
+- `docs/features/config.md`
+- `docs/api/providers.md`
+- `docs/api/agent-bridge.md`
+- `docs/api/config.md`
+- `docs/guide/architecture.md`
+- README feature list
+
+Keep old `cc-bridge` docs as compatibility notes until routes/components are fully migrated.
+
+## Route/API Migration
+
+Compatibility period:
+
+- Keep `/cc-bridge` frontend route as a redirect or alias to `/agent-bridge?provider=claude-code`.
+- Keep backend `/api/v1/cc-bridge/*` until the UI no longer calls it.
+- New code should call `/api/v1/agent-bridge/*`.
+
+Final cleanup later:
+
+- Remove old CC Bridge route names after one release cycle.
+- Update screenshots and docs.
+
+## Data Model Notes
+
+No database migration is required for the initial plan unless we decide to persist provider preferences server-side.
+
+If persisted preferences are needed:
+
+- selected provider
+- last bridge filters
+- default spawn options per provider
+
+Prefer local browser storage first for UI preferences. Use backend persistence only for shared machine-level preferences.
+
+## Testing Plan
+
+Backend tests:
+
+- Provider registry returns Claude and Codex providers.
+- Missing Codex binary reports installed=false without failing.
+- Codex version parsing handles `codex-cli 0.133.0`.
+- Codex tmux discovery matches direct `codex`.
+- Codex tmux discovery matches node wrapper descendant.
+- Codex tmux discovery rejects helper processes.
+- Codex spawn command builder validates directory and modes.
+- Codex config service reads TOML.
+- Codex config service writes TOML without dropping unrelated keys.
+- Codex config service masks secrets and never returns `auth.json`.
+- Provider-aware CLI executor enforces per-provider whitelist.
+
+Frontend tests:
+
+- Sidebar groups render and collapse.
+- Provider switcher hides unsupported nav items.
+- Agent Bridge lists mixed provider sessions.
+- New session dialog renders Codex fields when Codex is selected.
+- Config page renders Claude editor for Claude provider.
+- Config page renders Codex editor for Codex provider.
+- Raw TOML validation blocks invalid saves.
+
+Manual verification:
+
+- Start existing Claude Code tmux session and confirm discovery.
+- Start existing Codex tmux session and confirm discovery.
+- Spawn Codex from a repo and attach terminal.
+- Send prompt through interactive bridge and verify Enter handling.
+- Edit a harmless Codex setting in a temp `$CODEX_HOME`.
+- Run `codex doctor --json` from diagnostics with redacted output.
+
+## Implementation Order
+
+1. Add backend provider registry and status endpoint.
+2. Add Codex provider with version/status/config path detection.
+3. Generalize bridge backend into `agent_bridge` while keeping `/cc-bridge`.
+4. Add Codex discovery and spawn command building.
+5. Add frontend provider context and provider selector.
+6. Rework sidebar into grouped provider-aware navigation.
+7. Rename/migrate CC Bridge frontend to Agent Bridge with provider filtering.
+8. Add Codex new-session dialog fields.
+9. Add Codex TOML config service and read-only config files endpoint.
+10. Add Codex settings editor cards for general/runtime/projects/profiles.
+11. Add Codex MCP/plugins/diagnostics surfaces.
+12. Extend backup/export for Codex config.
+13. Update docs and screenshots.
+14. Remove or alias old naming after compatibility is verified.
+
+## Open Questions
+
+- Should the public product name remain Claude Deck, or should the UI start using a broader label like "Agent Deck" while the repo remains `claude-deck`?
+- Should provider selection be global, per page, or per project?
+- Should Codex project trust be edited directly in TOML, only via CLI if Codex adds commands for it, or both?
+- Should Codex `auth.json` ever be included in backups behind an explicit advanced option?
+- Do we want OpenAI account/model usage metrics in Claude Deck, or keep Codex usage out of scope until the CLI exposes stable local usage data?
+- Should non-interactive `codex exec` and `codex review` be exposed as task actions later, or should v1 stay strictly interactive/tmux plus config?
+
+## Risks
+
+- Codex CLI config shape may evolve quickly. Use permissive TOML read/write and avoid hardcoding too much schema.
+- Raw TOML writing can damage comments/formatting unless we use `tomlkit`.
+- Naming migration from CC Bridge to Agent Bridge touches docs, routes, screenshots, and mental model.
+- Sidebar grouping can become a UX project by itself. Keep the first version functional and restrained.
+- Provider-specific config can drift. Tests should use temp homes and fixture configs for both providers.
+
+## Definition of Done for v1
+
+- Claude Code behavior is unchanged.
+- Codex sessions are discoverable in tmux.
+- Claude and Codex sessions can be viewed in the same Agent Bridge grid.
+- Codex sessions can be spawned from the UI with core runtime options.
+- Codex `~/.codex/config.toml` can be viewed and safely edited through structured cards.
+- Codex project trust and profiles are visible and manageable.
+- Codex doctor output is available as a redacted diagnostics panel.
+- Sidebar is grouped and provider-aware.
+- Tests cover provider detection, bridge discovery/spawn, TOML config editing, and core UI routing.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { Toaster } from 'sonner'
 import { ProjectProvider } from './contexts/ProjectContext'
 import { DashboardProvider } from './contexts/DashboardContext'
+import { ProviderProvider } from './contexts/ProviderContext'
 import { MainLayout } from './components/layout/MainLayout'
 import { DashboardPage } from './features/dashboard/DashboardPage'
 import { ConfigViewerPage } from './features/config/ConfigViewerPage'
@@ -29,37 +30,40 @@ import { PresencePage } from './features/presence/PresencePage'
 function App() {
   return (
     <ProjectProvider>
-      <DashboardProvider>
-        <BrowserRouter>
-          <Toaster richColors position="top-right" />
-          <Routes>
-            <Route path="/" element={<MainLayout />}>
-              <Route index element={<DashboardPage />} />
-              <Route path="config" element={<ConfigViewerPage />} />
-              <Route path="mcp" element={<MCPServersPage />} />
-              <Route path="commands" element={<CommandsPage />} />
-              <Route path="plugins" element={<PluginsPage />} />
-              <Route path="hooks" element={<HooksPage />} />
-              <Route path="permissions" element={<PermissionsPage />} />
-              <Route path="agents" element={<AgentsPage />} />
-              <Route path="skills" element={<SkillsPage />} />
-              <Route path="memory" element={<MemoryPage />} />
-              <Route path="projects" element={<ProjectsPage />} />
-              <Route path="backup" element={<BackupPage />} />
-              <Route path="output-styles" element={<OutputStylesPage />} />
-              <Route path="statusline" element={<StatusLinePage />} />
-              <Route path="sessions/:projectFolder/:sessionId" element={<SessionViewPage />} />
-              <Route path="sessions" element={<SessionsPage />} />
-              <Route path="cc-bridge" element={<CCBridgePage />} />
-              <Route path="presence" element={<PresencePage />} />
-              <Route path="plans/:filename" element={<PlanDetailPage />} />
-              <Route path="plans" element={<PlansPage />} />
-              <Route path="context" element={<ContextPage />} />
-              <Route path="usage" element={<UsagePage />} />
-            </Route>
-          </Routes>
-        </BrowserRouter>
-      </DashboardProvider>
+      <ProviderProvider>
+        <DashboardProvider>
+          <BrowserRouter>
+            <Toaster richColors position="top-right" />
+            <Routes>
+              <Route path="/" element={<MainLayout />}>
+                <Route index element={<DashboardPage />} />
+                <Route path="config" element={<ConfigViewerPage />} />
+                <Route path="mcp" element={<MCPServersPage />} />
+                <Route path="commands" element={<CommandsPage />} />
+                <Route path="plugins" element={<PluginsPage />} />
+                <Route path="hooks" element={<HooksPage />} />
+                <Route path="permissions" element={<PermissionsPage />} />
+                <Route path="agents" element={<AgentsPage />} />
+                <Route path="skills" element={<SkillsPage />} />
+                <Route path="memory" element={<MemoryPage />} />
+                <Route path="projects" element={<ProjectsPage />} />
+                <Route path="backup" element={<BackupPage />} />
+                <Route path="output-styles" element={<OutputStylesPage />} />
+                <Route path="statusline" element={<StatusLinePage />} />
+                <Route path="sessions/:projectFolder/:sessionId" element={<SessionViewPage />} />
+                <Route path="sessions" element={<SessionsPage />} />
+                <Route path="agent-bridge" element={<CCBridgePage />} />
+                <Route path="cc-bridge" element={<CCBridgePage />} />
+                <Route path="presence" element={<PresencePage />} />
+                <Route path="plans/:filename" element={<PlanDetailPage />} />
+                <Route path="plans" element={<PlansPage />} />
+                <Route path="context" element={<ContextPage />} />
+                <Route path="usage" element={<UsagePage />} />
+              </Route>
+            </Routes>
+          </BrowserRouter>
+        </DashboardProvider>
+      </ProviderProvider>
     </ProjectProvider>
   )
 }

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { Terminal, Radio } from "lucide-react";
+import { Terminal, Radio, AlertCircle } from "lucide-react";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { Badge } from "@/components/ui/badge";
 import { useTheme } from "@/contexts/ThemeContext";
@@ -29,12 +29,21 @@ export function Header() {
         <div className="flex items-center gap-2">
           {status && (
             <>
-              {selectedStatus?.version && (
-                <Badge variant="outline" className="gap-1 font-mono text-xs">
+              <Badge
+                variant="outline"
+                className={cn(
+                  "gap-1 text-xs",
+                  selectedStatus?.installed ? "font-mono" : "border-destructive/40 text-destructive"
+                )}
+              >
+                {selectedStatus?.installed ? (
                   <Terminal className="h-3 w-3" />
-                  {selectedStatus.display_name} v{selectedStatus.version}
-                </Badge>
-              )}
+                ) : (
+                  <AlertCircle className="h-3 w-3" />
+                )}
+                {selectedStatus?.display_name ?? selectedProvider?.display_name ?? "Provider"}
+                {selectedStatus?.version ? ` v${selectedStatus.version}` : selectedStatus?.installed ? " ready" : " missing"}
+              </Badge>
               <Badge
                 variant="secondary"
                 className={cn(

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -3,11 +3,14 @@ import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { Badge } from "@/components/ui/badge";
 import { useTheme } from "@/contexts/ThemeContext";
 import { useSystemStatus } from "@/hooks/useSystemStatus";
+import { useProviderContext } from "@/contexts/ProviderContext";
 import { cn } from "@/lib/utils";
 
 export function Header() {
   const { theme } = useTheme();
   const status = useSystemStatus();
+  const { selectedProviderId, selectedProvider } = useProviderContext();
+  const selectedStatus = status?.providers?.[selectedProviderId] ?? selectedProvider;
 
   return (
     <header className="border-b bg-background">
@@ -20,16 +23,16 @@ export function Header() {
           />
           <div>
             <h1 className="text-2xl font-bold text-primary leading-tight">Claude Deck</h1>
-            <p className="text-xs text-muted-foreground">Your Claude Code command centre</p>
+            <p className="text-xs text-muted-foreground">Your local agent command centre</p>
           </div>
         </div>
         <div className="flex items-center gap-2">
           {status && (
             <>
-              {status.claudeCodeVersion && (
+              {selectedStatus?.version && (
                 <Badge variant="outline" className="gap-1 font-mono text-xs">
                   <Terminal className="h-3 w-3" />
-                  Claude Code v{status.claudeCodeVersion}
+                  {selectedStatus.display_name} v{selectedStatus.version}
                 </Badge>
               )}
               <Badge

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -49,60 +49,121 @@ type NavGroup = {
   items: NavItem[]
 }
 
-const CLAUDE_ONLY: AgentProviderId[] = ['claude-code']
-const ALL_PROVIDERS: AgentProviderId[] = ['claude-code', 'codex-cli']
-
-const navigation: NavGroup[] = [
+const commonNavigation: NavGroup[] = [
   {
-    name: 'Primary',
+    name: 'Core',
     items: [
-      { name: 'Dashboard', href: '/', icon: LayoutDashboard, providerSupport: ALL_PROVIDERS },
-      { name: 'Projects', href: '/projects', icon: FolderOpen, providerSupport: ALL_PROVIDERS },
-      { name: 'Agent Bridge', href: '/agent-bridge', icon: MonitorPlay, providerSupport: ALL_PROVIDERS },
-      { name: 'Sessions', href: '/sessions', icon: MessageSquare, providerSupport: CLAUDE_ONLY },
-    ],
-  },
-  {
-    name: 'Configuration',
-    items: [
-      { name: 'Config', href: '/config', icon: Settings, providerSupport: ALL_PROVIDERS },
-      { name: 'MCP Servers', href: '/mcp', icon: Server, providerSupport: CLAUDE_ONLY },
-      { name: 'Plugins', href: '/plugins', icon: Package, providerSupport: CLAUDE_ONLY },
-      { name: 'Permissions / Trust', href: '/permissions', icon: Shield, providerSupport: CLAUDE_ONLY },
-      { name: 'Commands', href: '/commands', icon: Terminal, providerSupport: CLAUDE_ONLY },
-      { name: 'Hooks', href: '/hooks', icon: Webhook, providerSupport: CLAUDE_ONLY },
-      { name: 'Agents', href: '/agents', icon: Bot, providerSupport: CLAUDE_ONLY },
-      { name: 'Skills', href: '/skills', icon: Sparkles, providerSupport: CLAUDE_ONLY },
-      { name: 'Memory', href: '/memory', icon: Brain, providerSupport: CLAUDE_ONLY },
-      { name: 'Output Styles', href: '/output-styles', icon: Paintbrush, providerSupport: CLAUDE_ONLY },
-      { name: 'Status Line', href: '/statusline', icon: Activity, providerSupport: CLAUDE_ONLY },
+      { name: 'Dashboard', href: '/', icon: LayoutDashboard },
+      { name: 'Projects', href: '/projects', icon: FolderOpen },
+      { name: 'Agent Bridge', href: '/agent-bridge', icon: MonitorPlay },
     ],
   },
   {
     name: 'Operations',
     items: [
-      { name: 'Presence', href: '/presence', icon: Radio, providerSupport: ALL_PROVIDERS },
-      { name: 'Plans', href: '/plans', icon: ClipboardList, providerSupport: ALL_PROVIDERS },
-      { name: 'Context', href: '/context', icon: Gauge, providerSupport: CLAUDE_ONLY },
-      { name: 'Usage', href: '/usage', icon: BarChart3, providerSupport: CLAUDE_ONLY },
-      { name: 'Backup', href: '/backup', icon: Archive, providerSupport: ALL_PROVIDERS },
+      { name: 'Presence', href: '/presence', icon: Radio },
+      { name: 'Plans', href: '/plans', icon: ClipboardList },
+      { name: 'Backup', href: '/backup', icon: Archive },
     ],
   },
 ]
+
+const providerNavigation: Record<AgentProviderId, NavGroup[]> = {
+  'claude-code': [
+    {
+      name: 'Claude Code',
+      items: [
+        { name: 'Config', href: '/config', icon: Settings },
+        { name: 'Sessions', href: '/sessions', icon: MessageSquare },
+        { name: 'MCP Servers', href: '/mcp', icon: Server },
+        { name: 'Plugins', href: '/plugins', icon: Package },
+        { name: 'Permissions / Trust', href: '/permissions', icon: Shield },
+      ],
+    },
+    {
+      name: 'Claude Tools',
+      items: [
+        { name: 'Commands', href: '/commands', icon: Terminal },
+        { name: 'Hooks', href: '/hooks', icon: Webhook },
+        { name: 'Agents', href: '/agents', icon: Bot },
+        { name: 'Skills', href: '/skills', icon: Sparkles },
+        { name: 'Memory', href: '/memory', icon: Brain },
+        { name: 'Output Styles', href: '/output-styles', icon: Paintbrush },
+        { name: 'Status Line', href: '/statusline', icon: Activity },
+      ],
+    },
+    {
+      name: 'Claude Metrics',
+      items: [
+        { name: 'Context', href: '/context', icon: Gauge },
+        { name: 'Usage', href: '/usage', icon: BarChart3 },
+      ],
+    },
+  ],
+  'codex-cli': [
+    {
+      name: 'Codex',
+      items: [
+        { name: 'Config', href: '/config', icon: Settings },
+      ],
+    },
+  ],
+}
+
+function getNavigation(providerId: AgentProviderId): NavGroup[] {
+  return [
+    ...commonNavigation,
+    ...(providerNavigation[providerId] ?? []),
+  ]
+}
 
 function supportsProvider(item: NavItem, providerId: AgentProviderId) {
   return !item.providerSupport || item.providerSupport.includes(providerId)
 }
 
+function NavGroupSection({ group, collapsed, selectedProviderId }: {
+  group: NavGroup
+  collapsed: boolean
+  selectedProviderId: AgentProviderId
+}) {
+  const visibleItems = group.items.filter((item) => supportsProvider(item, selectedProviderId))
+  if (visibleItems.length === 0) return null
+
+  return (
+    <div className="space-y-1">
+      {!collapsed && (
+        <p className="px-3 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+          {group.name}
+        </p>
+      )}
+      {visibleItems.map((item) => (
+        <NavLink
+          key={item.href}
+          to={item.href}
+          end={item.href === '/'}
+          title={collapsed ? item.name : undefined}
+          className={({ isActive }) =>
+            cn(
+              'flex items-center rounded-md text-sm font-medium transition-colors',
+              collapsed ? 'justify-center p-2' : 'gap-2 px-3 py-2',
+              isActive
+                ? 'bg-primary text-primary-foreground'
+                : 'text-foreground hover:bg-accent hover:text-accent-foreground'
+            )
+          }
+        >
+          <item.icon className="h-4 w-4 shrink-0" />
+          {!collapsed && item.name}
+        </NavLink>
+      ))}
+    </div>
+  )
+}
+
 export function Sidebar() {
   const { collapsed, setCollapsed } = useSidebar()
   const { providers, selectedProviderId, setSelectedProviderId } = useProviderContext()
-  const visibleGroups = navigation
-    .map((group) => ({
-      ...group,
-      items: group.items.filter((item) => supportsProvider(item, selectedProviderId)),
-    }))
-    .filter((group) => group.items.length > 0)
+  const visibleGroups = getNavigation(selectedProviderId)
 
   return (
     <aside className={cn(
@@ -134,33 +195,12 @@ export function Sidebar() {
         collapsed ? 'gap-1 p-2' : 'gap-4 p-4'
       )}>
         {visibleGroups.map((group) => (
-          <div key={group.name} className="space-y-1">
-            {!collapsed && (
-              <p className="px-3 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                {group.name}
-              </p>
-            )}
-            {group.items.map((item) => (
-              <NavLink
-                key={item.href}
-                to={item.href}
-                end={item.href === '/'}
-                title={collapsed ? item.name : undefined}
-                className={({ isActive }) =>
-                  cn(
-                    'flex items-center rounded-md text-sm font-medium transition-colors',
-                    collapsed ? 'justify-center p-2' : 'gap-2 px-3 py-2',
-                    isActive
-                      ? 'bg-primary text-primary-foreground'
-                      : 'text-foreground hover:bg-accent hover:text-accent-foreground'
-                  )
-                }
-              >
-                <item.icon className="h-4 w-4 shrink-0" />
-                {!collapsed && item.name}
-              </NavLink>
-            ))}
-          </div>
+          <NavGroupSection
+            key={group.name}
+            group={group}
+            collapsed={collapsed}
+            selectedProviderId={selectedProviderId}
+          />
         ))}
       </nav>
       <button

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -66,9 +66,9 @@ const navigation: NavGroup[] = [
     name: 'Configuration',
     items: [
       { name: 'Config', href: '/config', icon: Settings, providerSupport: ALL_PROVIDERS },
-      { name: 'MCP Servers', href: '/mcp', icon: Server, providerSupport: ALL_PROVIDERS },
-      { name: 'Plugins', href: '/plugins', icon: Package, providerSupport: ALL_PROVIDERS },
-      { name: 'Permissions / Trust', href: '/permissions', icon: Shield, providerSupport: ALL_PROVIDERS },
+      { name: 'MCP Servers', href: '/mcp', icon: Server, providerSupport: CLAUDE_ONLY },
+      { name: 'Plugins', href: '/plugins', icon: Package, providerSupport: CLAUDE_ONLY },
+      { name: 'Permissions / Trust', href: '/permissions', icon: Shield, providerSupport: CLAUDE_ONLY },
       { name: 'Commands', href: '/commands', icon: Terminal, providerSupport: CLAUDE_ONLY },
       { name: 'Hooks', href: '/hooks', icon: Webhook, providerSupport: CLAUDE_ONLY },
       { name: 'Agents', href: '/agents', icon: Bot, providerSupport: CLAUDE_ONLY },

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -2,6 +2,15 @@ import { NavLink } from 'react-router-dom'
 import { cn } from '@/lib/utils'
 import { ProjectSwitcher } from '@/features/projects/ProjectSwitcher'
 import { useSidebar } from '@/contexts/SidebarContext'
+import { useProviderContext } from '@/contexts/ProviderContext'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import type { AgentProviderId } from '@/types/providers'
 import {
   LayoutDashboard,
   Settings,
@@ -28,38 +37,72 @@ import {
   type LucideIcon,
 } from 'lucide-react'
 
-const navigation: { name: string; href: string; icon: LucideIcon }[] = [
-  // Tier 1: Overview & Setup
-  { name: 'Dashboard', href: '/', icon: LayoutDashboard },
-  { name: 'Projects', href: '/projects', icon: FolderOpen },
-  { name: 'Config', href: '/config', icon: Settings },
+type NavItem = {
+  name: string
+  href: string
+  icon: LucideIcon
+  providerSupport?: AgentProviderId[]
+}
 
-  // Tier 2: Core Configuration Sections
-  { name: 'MCP Servers', href: '/mcp', icon: Server },
-  { name: 'Commands', href: '/commands', icon: Terminal },
-  { name: 'Plugins', href: '/plugins', icon: Package },
-  { name: 'Hooks', href: '/hooks', icon: Webhook },
-  { name: 'Permissions', href: '/permissions', icon: Shield },
-  { name: 'Agents', href: '/agents', icon: Bot },
-  { name: 'Skills', href: '/skills', icon: Sparkles },
-  { name: 'Memory', href: '/memory', icon: Brain },
+type NavGroup = {
+  name: string
+  items: NavItem[]
+}
 
-  // Tier 3: Customization
-  { name: 'Output Styles', href: '/output-styles', icon: Paintbrush },
-  { name: 'Status Line', href: '/statusline', icon: Activity },
+const CLAUDE_ONLY: AgentProviderId[] = ['claude-code']
+const ALL_PROVIDERS: AgentProviderId[] = ['claude-code', 'codex-cli']
 
-  // Tier 4: Monitoring & Tools
-  { name: 'Sessions', href: '/sessions', icon: MessageSquare },
-  { name: 'Presence', href: '/presence', icon: Radio },
-  { name: 'CC Bridge', href: '/cc-bridge', icon: MonitorPlay },
-  { name: 'Plans', href: '/plans', icon: ClipboardList },
-  { name: 'Context', href: '/context', icon: Gauge },
-  { name: 'Usage', href: '/usage', icon: BarChart3 },
-  { name: 'Backup', href: '/backup', icon: Archive },
+const navigation: NavGroup[] = [
+  {
+    name: 'Primary',
+    items: [
+      { name: 'Dashboard', href: '/', icon: LayoutDashboard, providerSupport: ALL_PROVIDERS },
+      { name: 'Projects', href: '/projects', icon: FolderOpen, providerSupport: ALL_PROVIDERS },
+      { name: 'Agent Bridge', href: '/agent-bridge', icon: MonitorPlay, providerSupport: ALL_PROVIDERS },
+      { name: 'Sessions', href: '/sessions', icon: MessageSquare, providerSupport: ALL_PROVIDERS },
+    ],
+  },
+  {
+    name: 'Configuration',
+    items: [
+      { name: 'Config', href: '/config', icon: Settings, providerSupport: ALL_PROVIDERS },
+      { name: 'MCP Servers', href: '/mcp', icon: Server, providerSupport: ALL_PROVIDERS },
+      { name: 'Plugins', href: '/plugins', icon: Package, providerSupport: ALL_PROVIDERS },
+      { name: 'Permissions / Trust', href: '/permissions', icon: Shield, providerSupport: ALL_PROVIDERS },
+      { name: 'Commands', href: '/commands', icon: Terminal, providerSupport: CLAUDE_ONLY },
+      { name: 'Hooks', href: '/hooks', icon: Webhook, providerSupport: CLAUDE_ONLY },
+      { name: 'Agents', href: '/agents', icon: Bot, providerSupport: CLAUDE_ONLY },
+      { name: 'Skills', href: '/skills', icon: Sparkles, providerSupport: CLAUDE_ONLY },
+      { name: 'Memory', href: '/memory', icon: Brain, providerSupport: CLAUDE_ONLY },
+      { name: 'Output Styles', href: '/output-styles', icon: Paintbrush, providerSupport: CLAUDE_ONLY },
+      { name: 'Status Line', href: '/statusline', icon: Activity, providerSupport: CLAUDE_ONLY },
+    ],
+  },
+  {
+    name: 'Operations',
+    items: [
+      { name: 'Presence', href: '/presence', icon: Radio, providerSupport: ALL_PROVIDERS },
+      { name: 'Plans', href: '/plans', icon: ClipboardList, providerSupport: ALL_PROVIDERS },
+      { name: 'Context', href: '/context', icon: Gauge, providerSupport: CLAUDE_ONLY },
+      { name: 'Usage', href: '/usage', icon: BarChart3, providerSupport: CLAUDE_ONLY },
+      { name: 'Backup', href: '/backup', icon: Archive, providerSupport: ALL_PROVIDERS },
+    ],
+  },
 ]
+
+function supportsProvider(item: NavItem, providerId: AgentProviderId) {
+  return !item.providerSupport || item.providerSupport.includes(providerId)
+}
 
 export function Sidebar() {
   const { collapsed, setCollapsed } = useSidebar()
+  const { providers, selectedProviderId, setSelectedProviderId } = useProviderContext()
+  const visibleGroups = navigation
+    .map((group) => ({
+      ...group,
+      items: group.items.filter((item) => supportsProvider(item, selectedProviderId)),
+    }))
+    .filter((group) => group.items.length > 0)
 
   return (
     <aside className={cn(
@@ -67,33 +110,57 @@ export function Sidebar() {
       collapsed ? 'w-14' : 'w-64'
     )}>
       {!collapsed && (
-        <div className="py-4 border-b">
+        <div className="py-4 border-b space-y-3">
           <ProjectSwitcher />
+          <div className="px-4 space-y-1.5">
+            <p className="text-xs font-medium text-muted-foreground">Agent Provider</p>
+            <Select value={selectedProviderId} onValueChange={(value) => setSelectedProviderId(value as AgentProviderId)}>
+              <SelectTrigger className="h-9">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {providers.map((provider) => (
+                  <SelectItem key={provider.id} value={provider.id}>
+                    {provider.display_name}{!provider.installed ? ' (missing)' : ''}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
         </div>
       )}
       <nav className={cn(
-        'flex flex-col gap-1 flex-1 overflow-y-auto',
-        collapsed ? 'p-2' : 'p-4'
+        'flex flex-col flex-1 overflow-y-auto',
+        collapsed ? 'gap-1 p-2' : 'gap-4 p-4'
       )}>
-        {navigation.map((item) => (
-          <NavLink
-            key={item.href}
-            to={item.href}
-            end={item.href === '/'}
-            title={collapsed ? item.name : undefined}
-            className={({ isActive }) =>
-              cn(
-                'flex items-center rounded-md text-sm font-medium transition-colors',
-                collapsed ? 'justify-center p-2' : 'gap-2 px-3 py-2',
-                isActive
-                  ? 'bg-primary text-primary-foreground'
-                  : 'text-foreground hover:bg-accent hover:text-accent-foreground'
-              )
-            }
-          >
-            <item.icon className="h-4 w-4 shrink-0" />
-            {!collapsed && item.name}
-          </NavLink>
+        {visibleGroups.map((group) => (
+          <div key={group.name} className="space-y-1">
+            {!collapsed && (
+              <p className="px-3 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                {group.name}
+              </p>
+            )}
+            {group.items.map((item) => (
+              <NavLink
+                key={item.href}
+                to={item.href}
+                end={item.href === '/'}
+                title={collapsed ? item.name : undefined}
+                className={({ isActive }) =>
+                  cn(
+                    'flex items-center rounded-md text-sm font-medium transition-colors',
+                    collapsed ? 'justify-center p-2' : 'gap-2 px-3 py-2',
+                    isActive
+                      ? 'bg-primary text-primary-foreground'
+                      : 'text-foreground hover:bg-accent hover:text-accent-foreground'
+                  )
+                }
+              >
+                <item.icon className="h-4 w-4 shrink-0" />
+                {!collapsed && item.name}
+              </NavLink>
+            ))}
+          </div>
         ))}
       </nav>
       <button

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -59,7 +59,7 @@ const navigation: NavGroup[] = [
       { name: 'Dashboard', href: '/', icon: LayoutDashboard, providerSupport: ALL_PROVIDERS },
       { name: 'Projects', href: '/projects', icon: FolderOpen, providerSupport: ALL_PROVIDERS },
       { name: 'Agent Bridge', href: '/agent-bridge', icon: MonitorPlay, providerSupport: ALL_PROVIDERS },
-      { name: 'Sessions', href: '/sessions', icon: MessageSquare, providerSupport: ALL_PROVIDERS },
+      { name: 'Sessions', href: '/sessions', icon: MessageSquare, providerSupport: CLAUDE_ONLY },
     ],
   },
   {

--- a/frontend/src/contexts/ProviderContext.tsx
+++ b/frontend/src/contexts/ProviderContext.tsx
@@ -1,0 +1,76 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { useProviders } from '@/hooks/useProviders'
+import type { AgentProviderId, AgentProviderStatus } from '@/types/providers'
+
+interface ProviderContextValue {
+  providers: AgentProviderStatus[]
+  loading: boolean
+  error: string | null
+  selectedProviderId: AgentProviderId
+  selectedProvider: AgentProviderStatus | null
+  setSelectedProviderId: (providerId: AgentProviderId) => void
+  refreshProviders: () => void
+}
+
+const DEFAULT_PROVIDER: AgentProviderId = 'claude-code'
+const STORAGE_KEY = 'claude-deck:selected-provider'
+
+const ProviderContext = createContext<ProviderContextValue | undefined>(undefined)
+
+function readStoredProvider(): AgentProviderId {
+  const stored = window.localStorage.getItem(STORAGE_KEY)
+  return stored === 'codex-cli' || stored === 'claude-code' ? stored : DEFAULT_PROVIDER
+}
+
+export function ProviderProvider({ children }: { children: ReactNode }) {
+  const { providers, loading, error, refresh } = useProviders()
+  const [selectedProviderId, setSelectedProviderIdState] = useState<AgentProviderId>(readStoredProvider)
+
+  useEffect(() => {
+    if (providers.length === 0) return
+
+    const installed = providers.filter((provider) => provider.installed)
+    const selectedExists = providers.some((provider) => provider.id === selectedProviderId)
+    if (!selectedExists) {
+      setSelectedProviderIdState(DEFAULT_PROVIDER)
+      return
+    }
+    if (installed.length === 1 && selectedProviderId !== installed[0].id) {
+      setSelectedProviderIdState(installed[0].id)
+    }
+  }, [providers, selectedProviderId])
+
+  const setSelectedProviderId = useCallback((providerId: AgentProviderId) => {
+    window.localStorage.setItem(STORAGE_KEY, providerId)
+    setSelectedProviderIdState(providerId)
+  }, [])
+
+  const selectedProvider = useMemo(
+    () => providers.find((provider) => provider.id === selectedProviderId) ?? null,
+    [providers, selectedProviderId],
+  )
+
+  const value = useMemo<ProviderContextValue>(() => ({
+    providers,
+    loading,
+    error,
+    selectedProviderId,
+    selectedProvider,
+    setSelectedProviderId,
+    refreshProviders: refresh,
+  }), [providers, loading, error, selectedProviderId, selectedProvider, setSelectedProviderId, refresh])
+
+  return (
+    <ProviderContext.Provider value={value}>
+      {children}
+    </ProviderContext.Provider>
+  )
+}
+
+export function useProviderContext() {
+  const context = useContext(ProviderContext)
+  if (!context) {
+    throw new Error('useProviderContext must be used within ProviderProvider')
+  }
+  return context
+}

--- a/frontend/src/features/backup/BackupList.tsx
+++ b/frontend/src/features/backup/BackupList.tsx
@@ -13,6 +13,7 @@ import {
   Loader2,
   Monitor,
   AlertTriangle,
+  Bot,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -87,6 +88,8 @@ export function BackupList({ backups, onRestore, onDownload, onDelete }: BackupL
         return <User className="h-4 w-4" />;
       case "project":
         return <FolderOpen className="h-4 w-4" />;
+      case "codex":
+        return <Bot className="h-4 w-4" />;
     }
   };
 
@@ -98,6 +101,8 @@ export function BackupList({ backups, onRestore, onDownload, onDelete }: BackupL
         return "secondary" as const;
       case "project":
         return "outline" as const;
+      case "codex":
+        return "default" as const;
     }
   };
 
@@ -131,7 +136,9 @@ export function BackupList({ backups, onRestore, onDownload, onDelete }: BackupL
   return (
     <>
       <div className="space-y-4">
-        {backups.map((backup) => (
+        {backups.map((backup) => {
+          const isCodexBackup = backup.scope === "codex";
+          return (
             <Card key={backup.id} className="hover:bg-muted/50 transition-colors">
               <CardHeader className="pb-2">
                 <div className="flex items-start justify-between">
@@ -165,14 +172,16 @@ export function BackupList({ backups, onRestore, onDownload, onDelete }: BackupL
                       <Download className="h-4 w-4" />
                     </Button>
 
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => onRestore(backup)}
-                      title="Restore backup"
-                    >
-                      <RotateCcw className="h-4 w-4" />
-                    </Button>
+                    {!isCodexBackup && (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => onRestore(backup)}
+                        title="Restore backup"
+                      >
+                        <RotateCcw className="h-4 w-4" />
+                      </Button>
+                    )}
 
                     <AlertDialog>
                       <AlertDialogTrigger asChild>
@@ -259,7 +268,8 @@ export function BackupList({ backups, onRestore, onDownload, onDelete }: BackupL
                 </div>
               </CardContent>
             </Card>
-        ))}
+          );
+        })}
       </div>
 
       {/* View Plan Dialog */}
@@ -395,17 +405,19 @@ export function BackupList({ backups, onRestore, onDownload, onDelete }: BackupL
                 <Button variant="outline" onClick={() => setPlanDialogOpen(false)}>
                   Close
                 </Button>
-                <Button
-                  onClick={() => {
-                    setPlanDialogOpen(false);
-                    if (selectedBackup) {
-                      onRestore(selectedBackup);
-                    }
-                  }}
-                >
-                  <RotateCcw className="h-4 w-4 mr-2" />
-                  Restore Now
-                </Button>
+                {selectedBackup?.scope !== "codex" && (
+                  <Button
+                    onClick={() => {
+                      setPlanDialogOpen(false);
+                      if (selectedBackup) {
+                        onRestore(selectedBackup);
+                      }
+                    }}
+                  >
+                    <RotateCcw className="h-4 w-4 mr-2" />
+                    Restore Now
+                  </Button>
+                )}
               </div>
             </div>
           ) : null}

--- a/frontend/src/features/backup/BackupPage.tsx
+++ b/frontend/src/features/backup/BackupPage.tsx
@@ -14,6 +14,7 @@ import { RestoreWizard } from "./RestoreWizard";
 import { RefreshButton } from "@/components/shared/RefreshButton";
 import { apiClient, buildEndpoint } from "@/lib/api";
 import { useProjectContext } from "@/contexts/ProjectContext";
+import { useProviderContext } from "@/contexts/ProviderContext";
 import { toast } from "sonner";
 import {
   type Backup,
@@ -24,6 +25,7 @@ import {
 
 export function BackupPage() {
   const { activeProject } = useProjectContext();
+  const { selectedProviderId, selectedProvider } = useProviderContext();
   const [backups, setBackups] = useState<Backup[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -82,6 +84,10 @@ export function BackupPage() {
   };
 
   const handleRestore = (backup: Backup) => {
+    if (backup.scope === "codex") {
+      toast.error("Codex backups are export-only; automatic restore is not supported");
+      return;
+    }
     setSelectedBackup(backup);
     setShowRestoreWizard(true);
   };
@@ -132,8 +138,15 @@ export function BackupPage() {
             Backup & Restore
           </h1>
           <p className="text-muted-foreground mt-1">
-            Create and manage configuration backups with dependency tracking
+            {selectedProviderId === "codex-cli"
+              ? "Create redacted Codex config exports for download"
+              : "Create and manage configuration backups with dependency tracking"}
           </p>
+          {selectedProviderId === "codex-cli" && selectedProvider && (
+            <p className="text-xs text-muted-foreground mt-1">
+              Provider: {selectedProvider.display_name}
+            </p>
+          )}
         </div>
         <div className="flex gap-2">
           <RefreshButton onClick={fetchBackups} loading={loading} />
@@ -208,6 +221,7 @@ export function BackupPage() {
         onOpenChange={setShowCreateWizard}
         onCreate={handleCreate}
         currentProjectPath={activeProject?.path}
+        providerId={selectedProviderId}
       />
 
       {/* Restore Wizard */}

--- a/frontend/src/features/backup/BackupWizard.tsx
+++ b/frontend/src/features/backup/BackupWizard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -27,6 +27,7 @@ import {
   FileCode,
   Download,
   Info,
+  Bot,
 } from "lucide-react";
 import {
   type Backup,
@@ -41,6 +42,7 @@ interface BackupWizardProps {
   onOpenChange: (open: boolean) => void;
   onCreate: (backup: BackupCreate) => Promise<Backup>;
   currentProjectPath?: string;
+  providerId?: "claude-code" | "codex-cli";
 }
 
 const STEPS = [
@@ -55,23 +57,35 @@ export function BackupWizard({
   onOpenChange,
   onCreate,
   currentProjectPath,
+  providerId = "claude-code",
 }: BackupWizardProps) {
+  const defaultScope: BackupScope = providerId === "codex-cli" ? "codex" : "user";
   const [step, setStep] = useState(0);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
-  const [scope, setScope] = useState<BackupScope>("user");
+  const [scope, setScope] = useState<BackupScope>(defaultScope);
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [createdBackup, setCreatedBackup] = useState<Backup | null>(null);
+  const availableScopes = useMemo(
+    () => BACKUP_SCOPES.filter((backupScope) => (
+      providerId === "codex-cli" ? backupScope.value === "codex" : backupScope.value !== "codex"
+    )),
+    [providerId],
+  );
 
   const resetForm = () => {
     setStep(0);
     setName("");
     setDescription("");
-    setScope("user");
+    setScope(defaultScope);
     setError(null);
     setCreatedBackup(null);
   };
+
+  useEffect(() => {
+    if (open) setScope(defaultScope);
+  }, [defaultScope, open]);
 
   const handleOpenChange = (open: boolean) => {
     if (!open) {
@@ -126,7 +140,7 @@ export function BackupWizard({
         name: name.trim() || generateDefaultName(),
         description: description.trim() || undefined,
         scope,
-        project_path: scope !== "user" ? currentProjectPath : undefined,
+        project_path: scope === "full" || scope === "project" ? currentProjectPath : undefined,
       });
       setCreatedBackup(backup);
       setStep(3); // Go to completion step
@@ -145,6 +159,8 @@ export function BackupWizard({
         return <User className="h-5 w-5" />;
       case "project":
         return <FolderOpen className="h-5 w-5" />;
+      case "codex":
+        return <Bot className="h-5 w-5" />;
     }
   };
 
@@ -189,7 +205,7 @@ export function BackupWizard({
               value={scope}
               onValueChange={(v) => setScope(v as BackupScope)}
             >
-              {BACKUP_SCOPES.map((s) => {
+              {availableScopes.map((s) => {
                 const isDisabled =
                   (s.value === "full" || s.value === "project") && !currentProjectPath;
                 return (
@@ -247,6 +263,14 @@ export function BackupWizard({
                     <li>CLAUDE.md file</li>
                   </>
                 )}
+                {scope === "codex" && (
+                  <>
+                    <li>Redacted ~/.codex/config.toml</li>
+                    <li>Codex profile config files</li>
+                    <li>Codex rules files</li>
+                    <li>Redacted provider inventory metadata</li>
+                  </>
+                )}
               </ul>
             </div>
           </div>
@@ -286,11 +310,12 @@ export function BackupWizard({
             <div className="p-3 bg-blue-50 border border-blue-200 rounded-lg text-sm">
               <h4 className="font-medium text-blue-800 flex items-center gap-2">
                 <Download className="h-4 w-4" />
-                Dependency Tracking
+                {scope === "codex" ? "Export Only" : "Dependency Tracking"}
               </h4>
               <p className="text-blue-700 mt-1">
-                The backup will include a manifest tracking all skill dependencies
-                (npm, pip) and plugin install commands for easy restoration.
+                {scope === "codex"
+                  ? "The backup will include redacted Codex files and provider inventory metadata. Automatic restore is not enabled for Codex exports."
+                  : "The backup will include a manifest tracking all skill dependencies (npm, pip) and plugin install commands for easy restoration."}
               </p>
             </div>
           </div>

--- a/frontend/src/features/cc-bridge/CCBridgePage.tsx
+++ b/frontend/src/features/cc-bridge/CCBridgePage.tsx
@@ -7,8 +7,10 @@ import { TerminalView } from './TerminalView'
 import { NewSessionDialog } from './NewSessionDialog'
 import { KillSessionDialog } from './KillSessionDialog'
 import type { CCSession } from './types'
+import type { AgentProviderId } from '@/types/providers'
 
 const MAX_GRID_PANES = 4
+type ProviderFilter = 'all' | AgentProviderId
 
 function addTarget(prev: string[], target: string): string[] {
   if (prev.includes(target)) return prev
@@ -17,7 +19,10 @@ function addTarget(prev: string[], target: string): string[] {
 }
 
 export function CCBridgePage() {
-  const { sessions, loading, error, refresh } = useCCSessions()
+  const [providerFilter, setProviderFilter] = useState<ProviderFilter>('all')
+  const { sessions, loading, error, refresh } = useCCSessions(
+    providerFilter === 'all' ? undefined : providerFilter,
+  )
   const [activeTargets, setActiveTargets] = useState<string[]>([])
   const [fullscreenTarget, setFullscreenTarget] = useState<string | null>(null)
   const [focusedTarget, setFocusedTarget] = useState<string | null>(null)
@@ -72,11 +77,32 @@ export function CCBridgePage() {
       {!isFullscreen && (
         <div className="flex items-center gap-3 px-4 py-3 border-b shrink-0 bg-muted/30">
           <MonitorPlay className="h-5 w-5 shrink-0" />
-          <div className="flex items-baseline gap-2 flex-wrap">
-            <h1 className="text-base font-semibold">CC Bridge</h1>
+          <div className="flex items-baseline gap-2 flex-wrap min-w-0">
+            <h1 className="text-base font-semibold">Agent Bridge</h1>
             <span className="text-xs text-muted-foreground">
-              Discover and observe Claude Code sessions running in tmux. Select up to 4 sessions to monitor simultaneously.
+              Discover and observe Claude Code and Codex sessions running in tmux. Select up to 4 sessions to monitor simultaneously.
             </span>
+          </div>
+          <div className="ml-auto flex rounded-md bg-background border p-0.5 shrink-0">
+            {[
+              ['all', 'All agents'],
+              ['claude-code', 'Claude Code'],
+              ['codex-cli', 'Codex'],
+            ].map(([value, label]) => (
+              <button
+                key={value}
+                type="button"
+                className={cn(
+                  'px-2.5 py-1 text-xs rounded-sm transition-colors',
+                  providerFilter === value
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
+                onClick={() => setProviderFilter(value as ProviderFilter)}
+              >
+                {label}
+              </button>
+            ))}
           </div>
         </div>
       )}
@@ -93,6 +119,7 @@ export function CCBridgePage() {
               onRefresh={refresh}
               onNewSession={() => setNewSessionOpen(true)}
               onKillSession={setKillSession}
+              providerFilter={providerFilter}
             />
           </div>
         )}

--- a/frontend/src/features/cc-bridge/KillSessionDialog.tsx
+++ b/frontend/src/features/cc-bridge/KillSessionDialog.tsx
@@ -69,7 +69,7 @@ export function KillSessionDialog({
           <DialogDescription>
             Are you sure you want to kill session{' '}
             <strong>{session?.session_name}</strong>? This will terminate the
-            Claude Code process.
+            {session?.provider_display_name ?? 'agent'} process.
           </DialogDescription>
         </DialogHeader>
 

--- a/frontend/src/features/cc-bridge/NewSessionDialog.tsx
+++ b/frontend/src/features/cc-bridge/NewSessionDialog.tsx
@@ -11,16 +11,25 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { MODAL_SIZES } from '@/lib/constants'
 import { cn } from '@/lib/utils'
 import { formatTimestamp } from '@/features/usage/utils'
 import { spawnSession } from './api'
 import { useSessionsApi } from '@/hooks/useSessionsApi'
 import { useProjectContext } from '@/contexts/ProjectContext'
+import { useProviderContext } from '@/contexts/ProviderContext'
+import type { AgentProviderId } from '@/types/providers'
 import type { SpawnSessionRequest } from './types'
 import type { SessionSummary } from '@/types/sessions'
 
-type Mode = 'plain' | 'worktree' | 'resume'
+type Mode = 'plain' | 'worktree' | 'resume' | 'fork'
 
 interface NewSessionDialogProps {
   open: boolean
@@ -34,11 +43,29 @@ const MODE_OPTIONS: { value: Mode; label: string }[] = [
   { value: 'resume', label: 'Resume' },
 ]
 
+const CODEX_MODE_OPTIONS: { value: Mode; label: string }[] = [
+  { value: 'plain', label: 'New' },
+  { value: 'resume', label: 'Resume' },
+  { value: 'fork', label: 'Fork' },
+]
+
 export function NewSessionDialog({ open, onOpenChange, onSpawned }: NewSessionDialogProps) {
+  const { providers, selectedProviderId } = useProviderContext()
+  const [provider, setProvider] = useState<AgentProviderId>(selectedProviderId)
   const [directory, setDirectory] = useState('')
   const [mode, setMode] = useState<Mode>('plain')
   const [worktreeName, setWorktreeName] = useState('')
   const [skipPermissions, setSkipPermissions] = useState(false)
+  const [prompt, setPrompt] = useState('')
+  const [model, setModel] = useState('')
+  const [profile, setProfile] = useState('')
+  const [sandbox, setSandbox] = useState('')
+  const [approvalPolicy, setApprovalPolicy] = useState('')
+  const [search, setSearch] = useState(false)
+  const [noAltScreen, setNoAltScreen] = useState(true)
+  const [dangerousBypass, setDangerousBypass] = useState(false)
+  const [codexSessionId, setCodexSessionId] = useState('')
+  const [useLast, setUseLast] = useState(true)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -48,10 +75,12 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned }: NewSessionDi
 
   const { listSessions } = useSessionsApi()
   const { projects } = useProjectContext()
+  const isCodex = provider === 'codex-cli'
+  const modeOptions = isCodex ? CODEX_MODE_OPTIONS : MODE_OPTIONS
 
   // Fetch sessions when switching to resume mode
   useEffect(() => {
-    if (mode !== 'resume') return
+    if (mode !== 'resume' || isCodex) return
     let cancelled = false
     setLoadingSessions(true)
     listSessions({ limit: 20, sort_by: 'date', sort_order: 'desc' })
@@ -59,25 +88,39 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned }: NewSessionDi
       .catch(() => { if (!cancelled) setRecentSessions([]) })
       .finally(() => { if (!cancelled) setLoadingSessions(false) })
     return () => { cancelled = true }
-  }, [mode, listSessions])
+  }, [mode, isCodex, listSessions])
 
   // Reset state when dialog closes
   useEffect(() => {
     if (!open) {
       setDirectory('')
+      setProvider(selectedProviderId)
       setMode('plain')
       setWorktreeName('')
       setSkipPermissions(false)
+      setPrompt('')
+      setModel('')
+      setProfile('')
+      setSandbox('')
+      setApprovalPolicy('')
+      setSearch(false)
+      setNoAltScreen(true)
+      setDangerousBypass(false)
+      setCodexSessionId('')
+      setUseLast(true)
       setError(null)
       setSelectedSession(null)
       setRecentSessions([])
       setSubmitting(false)
     }
-  }, [open])
+  }, [open, selectedProviderId])
 
   const canLaunch = (() => {
     if (submitting) return false
-    if (mode === 'resume') return selectedSession !== null
+    if (isCodex && (mode === 'resume' || mode === 'fork')) {
+      return directory.trim().length > 0 && (useLast || codexSessionId.trim().length > 0)
+    }
+    if (!isCodex && mode === 'resume') return selectedSession !== null
     return directory.trim().length > 0
   })()
 
@@ -87,14 +130,27 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned }: NewSessionDi
 
     try {
       const request: SpawnSessionRequest = {
-        directory: mode === 'resume' ? '' : directory.trim(),
+        provider,
+        directory: !isCodex && mode === 'resume' ? '' : directory.trim(),
         mode,
-        ...(mode === 'worktree' && worktreeName.trim() && { worktree_name: worktreeName.trim() }),
-        ...(mode === 'resume' && selectedSession && {
+        ...(provider === 'claude-code' && mode === 'worktree' && worktreeName.trim() && { worktree_name: worktreeName.trim() }),
+        ...(provider === 'claude-code' && mode === 'resume' && selectedSession && {
           session_id: selectedSession.id,
           project_folder: selectedSession.project_folder,
         }),
-        ...(skipPermissions && { skip_permissions: true }),
+        ...(provider === 'claude-code' && skipPermissions && { skip_permissions: true }),
+        ...(isCodex && prompt.trim() && { prompt: prompt.trim() }),
+        ...(isCodex && model.trim() && { model: model.trim() }),
+        ...(isCodex && profile.trim() && { profile: profile.trim() }),
+        ...(isCodex && sandbox && { sandbox }),
+        ...(isCodex && approvalPolicy && { approval_policy: approvalPolicy }),
+        ...(isCodex && search && { search: true }),
+        ...(isCodex && { no_alt_screen: noAltScreen }),
+        ...(isCodex && dangerousBypass && { dangerously_bypass_approvals_and_sandbox: true }),
+        ...(isCodex && (mode === 'resume' || mode === 'fork') && {
+          use_last: useLast,
+          ...(!useLast && codexSessionId.trim() && { session_id: codexSessionId.trim() }),
+        }),
       }
 
       const response = await spawnSession(request)
@@ -111,18 +167,42 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned }: NewSessionDi
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className={MODAL_SIZES.MD}>
         <DialogHeader>
-          <DialogTitle>New Claude Code Session</DialogTitle>
+          <DialogTitle>New Agent Session</DialogTitle>
           <DialogDescription>
-            Launch a new Claude Code instance in a tmux session.
+            Launch a new agent CLI instance in a tmux session.
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4 min-w-0">
+          <div className="space-y-1.5">
+            <Label>Provider</Label>
+            <Select
+              value={provider}
+              onValueChange={(value) => {
+                setProvider(value as AgentProviderId)
+                setMode('plain')
+                setSelectedSession(null)
+                setError(null)
+              }}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {providers.map((item) => (
+                  <SelectItem key={item.id} value={item.id}>
+                    {item.display_name}{!item.installed ? ' (missing)' : ''}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
           {/* Mode selector */}
           <div className="space-y-1.5">
             <Label>Mode</Label>
             <div className="flex gap-1 rounded-md bg-muted p-1">
-              {MODE_OPTIONS.map((opt) => (
+              {modeOptions.map((opt) => (
                 <button
                   key={opt.value}
                   type="button"
@@ -145,7 +225,7 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned }: NewSessionDi
           </div>
 
           {/* Directory input (hidden in resume mode) */}
-          {mode !== 'resume' && (
+          {(isCodex || mode !== 'resume') && (
             <div className="space-y-1.5">
               <Label htmlFor="session-directory">Project Directory</Label>
               <Input
@@ -172,7 +252,7 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned }: NewSessionDi
           )}
 
           {/* Worktree name (only in worktree mode) */}
-          {mode === 'worktree' && (
+          {!isCodex && mode === 'worktree' && (
             <div className="space-y-1.5">
               <Label htmlFor="worktree-name">Worktree Name</Label>
               <Input
@@ -188,7 +268,7 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned }: NewSessionDi
           )}
 
           {/* Resume session picker */}
-          {mode === 'resume' && (
+          {!isCodex && mode === 'resume' && (
             <div className="space-y-1.5">
               <Label>Recent Sessions</Label>
               {loadingSessions ? (
@@ -233,22 +313,108 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned }: NewSessionDi
             </div>
           )}
 
-          {/* Skip permissions checkbox */}
-          <div className="space-y-1">
-            <div className="flex items-center space-x-2">
-              <Checkbox
-                id="skip-permissions"
-                checked={skipPermissions}
-                onCheckedChange={(checked) => setSkipPermissions(checked === true)}
-              />
-              <Label htmlFor="skip-permissions" className="cursor-pointer">
-                Skip permission prompts
-              </Label>
+          {isCodex && (mode === 'resume' || mode === 'fork') && (
+            <div className="space-y-2">
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="codex-use-last"
+                  checked={useLast}
+                  onCheckedChange={(checked) => setUseLast(checked === true)}
+                />
+                <Label htmlFor="codex-use-last" className="cursor-pointer">
+                  Use last Codex session
+                </Label>
+              </div>
+              {!useLast && (
+                <div className="space-y-1.5">
+                  <Label htmlFor="codex-session-id">Codex Session ID</Label>
+                  <Input
+                    id="codex-session-id"
+                    value={codexSessionId}
+                    onChange={(e) => setCodexSessionId(e.target.value)}
+                    placeholder="session id"
+                  />
+                </div>
+              )}
             </div>
-            <p className="text-xs text-destructive/80 ml-6">
-              Allows Claude to run tools without asking for confirmation
-            </p>
-          </div>
+          )}
+
+          {isCodex && (
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="codex-model">Model</Label>
+                <Input id="codex-model" value={model} onChange={(e) => setModel(e.target.value)} placeholder="default" />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="codex-profile">Profile</Label>
+                <Input id="codex-profile" value={profile} onChange={(e) => setProfile(e.target.value)} placeholder="default" />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Sandbox</Label>
+                <Select value={sandbox || 'default'} onValueChange={(value) => setSandbox(value === 'default' ? '' : value)}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="default">Default</SelectItem>
+                    <SelectItem value="read-only">Read-only</SelectItem>
+                    <SelectItem value="workspace-write">Workspace write</SelectItem>
+                    <SelectItem value="danger-full-access">Full access</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <Label>Approval</Label>
+                <Select value={approvalPolicy || 'default'} onValueChange={(value) => setApprovalPolicy(value === 'default' ? '' : value)}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="default">Default</SelectItem>
+                    <SelectItem value="untrusted">Untrusted</SelectItem>
+                    <SelectItem value="on-failure">On failure</SelectItem>
+                    <SelectItem value="on-request">On request</SelectItem>
+                    <SelectItem value="never">Never</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="col-span-2 space-y-1.5">
+                <Label htmlFor="codex-prompt">Initial Prompt</Label>
+                <Input id="codex-prompt" value={prompt} onChange={(e) => setPrompt(e.target.value)} placeholder="Optional prompt" />
+              </div>
+            </div>
+          )}
+
+          {!isCodex && (
+            <div className="space-y-1">
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="skip-permissions"
+                  checked={skipPermissions}
+                  onCheckedChange={(checked) => setSkipPermissions(checked === true)}
+                />
+                <Label htmlFor="skip-permissions" className="cursor-pointer">
+                  Skip permission prompts
+                </Label>
+              </div>
+              <p className="text-xs text-destructive/80 ml-6">
+                Allows Claude to run tools without asking for confirmation
+              </p>
+            </div>
+          )}
+
+          {isCodex && (
+            <div className="space-y-2">
+              <div className="flex items-center space-x-2">
+                <Checkbox id="codex-search" checked={search} onCheckedChange={(checked) => setSearch(checked === true)} />
+                <Label htmlFor="codex-search" className="cursor-pointer">Enable web search</Label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <Checkbox id="codex-no-alt-screen" checked={noAltScreen} onCheckedChange={(checked) => setNoAltScreen(checked === true)} />
+                <Label htmlFor="codex-no-alt-screen" className="cursor-pointer">Disable alternate screen</Label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <Checkbox id="codex-dangerous" checked={dangerousBypass} onCheckedChange={(checked) => setDangerousBypass(checked === true)} />
+                <Label htmlFor="codex-dangerous" className="cursor-pointer text-destructive">Bypass approvals and sandbox</Label>
+              </div>
+            </div>
+          )}
 
           {/* Error message */}
           {error && (

--- a/frontend/src/features/cc-bridge/SessionCard.tsx
+++ b/frontend/src/features/cc-bridge/SessionCard.tsx
@@ -1,5 +1,6 @@
 import { Trash2 } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
 import { CLICKABLE_CARD } from '@/lib/constants'
 import { cn } from '@/lib/utils'
 import type { CCSession } from './types'
@@ -52,6 +53,9 @@ export function SessionCard({ session, gridPosition, onClick, onKill }: SessionC
             )}
           </div>
         </div>
+        <Badge variant="outline" className="mt-2 max-w-full truncate">
+          {session.provider_display_name}
+        </Badge>
         <p className="text-xs text-muted-foreground truncate mt-1" title={session.cwd}>
           {projectName}
         </p>

--- a/frontend/src/features/cc-bridge/SessionList.tsx
+++ b/frontend/src/features/cc-bridge/SessionList.tsx
@@ -3,6 +3,9 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { SessionCard } from './SessionCard'
 import type { CCSession } from './types'
+import type { AgentProviderId } from '@/types/providers'
+
+type ProviderFilter = 'all' | AgentProviderId
 
 interface SessionListProps {
   sessions: CCSession[]
@@ -13,6 +16,7 @@ interface SessionListProps {
   onRefresh: () => void
   onNewSession: () => void
   onKillSession: (session: CCSession) => void
+  providerFilter: ProviderFilter
 }
 
 export function SessionList({
@@ -24,7 +28,12 @@ export function SessionList({
   onRefresh,
   onNewSession,
   onKillSession,
+  providerFilter,
 }: SessionListProps) {
+  const emptyName = providerFilter === 'all'
+    ? 'agent'
+    : providerFilter === 'codex-cli' ? 'Codex' : 'Claude Code'
+
   return (
     <div className="flex flex-col h-full">
       <div className="flex items-center justify-between p-3 border-b">
@@ -55,8 +64,8 @@ export function SessionList({
         {!loading && !error && sessions.length === 0 && (
           <div className="flex flex-col items-center justify-center py-8 text-muted-foreground">
             <MonitorX className="h-8 w-8 mb-2" />
-            <p className="text-sm">No CC sessions found</p>
-            <p className="text-xs mt-1">Start Claude Code in a tmux session</p>
+            <p className="text-sm">No {emptyName} sessions found</p>
+            <p className="text-xs mt-1">Start a supported CLI in tmux</p>
           </div>
         )}
 

--- a/frontend/src/features/cc-bridge/api.ts
+++ b/frontend/src/features/cc-bridge/api.ts
@@ -1,10 +1,11 @@
-import { apiClient } from '@/lib/api'
+import { apiClient, buildEndpoint } from '@/lib/api'
+import type { AgentProviderId } from '@/types/providers'
 import type { CCSessionsResponse, CCPreviewResponse, CCTokenResponse, SpawnSessionRequest, SpawnSessionResponse, KillSessionResponse } from './types'
 
-const BASE = 'cc-bridge'
+const BASE = 'agent-bridge'
 
-export async function fetchCCSessions(): Promise<CCSessionsResponse> {
-  return apiClient<CCSessionsResponse>(BASE + '/sessions')
+export async function fetchCCSessions(provider?: AgentProviderId): Promise<CCSessionsResponse> {
+  return apiClient<CCSessionsResponse>(buildEndpoint(BASE + '/sessions', { provider }))
 }
 
 export async function fetchSessionPreview(target: string): Promise<CCPreviewResponse> {

--- a/frontend/src/features/cc-bridge/types.ts
+++ b/frontend/src/features/cc-bridge/types.ts
@@ -1,4 +1,8 @@
-export interface CCSession {
+import type { AgentProviderId } from '@/types/providers'
+
+export interface AgentSession {
+  provider: AgentProviderId
+  provider_display_name: string
   tmux_target: string
   session_name: string
   window_name: string
@@ -8,10 +12,14 @@ export interface CCSession {
   status: string
 }
 
-export interface CCSessionsResponse {
-  sessions: CCSession[]
+export type CCSession = AgentSession
+
+export interface AgentSessionsResponse {
+  sessions: AgentSession[]
   count: number
 }
+
+export type CCSessionsResponse = AgentSessionsResponse
 
 export interface CCPreviewResponse {
   target: string
@@ -23,12 +31,23 @@ export interface CCTokenResponse {
 }
 
 export interface SpawnSessionRequest {
+  provider?: AgentProviderId
   directory: string
-  mode: 'plain' | 'worktree' | 'resume'
+  mode: 'plain' | 'worktree' | 'resume' | 'fork'
   worktree_name?: string
   session_id?: string
   project_folder?: string
   skip_permissions?: boolean
+  prompt?: string
+  model?: string
+  profile?: string
+  profile_v2?: string
+  sandbox?: string
+  approval_policy?: string
+  search?: boolean
+  no_alt_screen?: boolean
+  dangerously_bypass_approvals_and_sandbox?: boolean
+  use_last?: boolean
 }
 
 export interface SpawnSessionResponse {

--- a/frontend/src/features/cc-bridge/useCCSessions.ts
+++ b/frontend/src/features/cc-bridge/useCCSessions.ts
@@ -1,10 +1,11 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
+import type { AgentProviderId } from '@/types/providers'
 import type { CCSession } from './types'
 import { fetchCCSessions } from './api'
 
 const POLL_INTERVAL = 5000
 
-export function useCCSessions() {
+export function useCCSessions(provider?: AgentProviderId) {
   const [sessions, setSessions] = useState<CCSession[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -12,7 +13,7 @@ export function useCCSessions() {
 
   const refresh = useCallback(async () => {
     try {
-      const data = await fetchCCSessions()
+      const data = await fetchCCSessions(provider)
       setSessions(data.sessions)
       setError(null)
     } catch (err) {
@@ -20,7 +21,7 @@ export function useCCSessions() {
     } finally {
       setLoading(false)
     }
-  }, [])
+  }, [provider])
 
   useEffect(() => {
     refresh()

--- a/frontend/src/features/config/CodexDiagnosticsCard.tsx
+++ b/frontend/src/features/config/CodexDiagnosticsCard.tsx
@@ -1,0 +1,157 @@
+import { AlertCircle, CheckCircle2, ChevronRight, CircleHelp, RefreshCw } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+import type { ProviderDoctorCheck, ProviderDoctorResponse } from '@/types/providers'
+
+interface CodexDiagnosticsCardProps {
+  doctor: ProviderDoctorResponse | null
+  loading: boolean
+  error: string | null
+  onRefresh: () => void
+}
+
+const SENSITIVE_KEY_PATTERN = /(token|secret|password|credential|api[_-]?key|auth|cookie|session)/i
+
+function redactSensitiveValues(value: unknown, parentKey = ''): unknown {
+  if (value === null || value === undefined) return value
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactSensitiveValues(item, parentKey))
+  }
+
+  if (typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, child]) => [
+        key,
+        SENSITIVE_KEY_PATTERN.test(key) || SENSITIVE_KEY_PATTERN.test(parentKey)
+          ? '[redacted]'
+          : redactSensitiveValues(child, key),
+      ]),
+    )
+  }
+
+  if (SENSITIVE_KEY_PATTERN.test(parentKey)) {
+    return '[redacted]'
+  }
+
+  return value
+}
+
+function getCheck(report: ProviderDoctorResponse['report'], id: string): ProviderDoctorCheck | null {
+  return report?.checks?.[id] ?? null
+}
+
+function statusBadgeVariant(status?: string | null): 'default' | 'secondary' | 'destructive' | 'outline' {
+  if (status === 'ok') return 'default'
+  if (status === 'error') return 'destructive'
+  if (status === 'warn') return 'secondary'
+  return 'outline'
+}
+
+function StatusIcon({ status }: { status?: string | null }) {
+  if (status === 'ok') return <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />
+  if (status === 'error') return <AlertCircle className="h-4 w-4 text-destructive" />
+  return <CircleHelp className="h-4 w-4 text-muted-foreground" />
+}
+
+function CheckRow({ label, check }: { label: string; check: ProviderDoctorCheck | null }) {
+  return (
+    <div className="flex items-start gap-2 rounded-md border p-3">
+      <StatusIcon status={check?.status} />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <p className="text-sm font-medium">{label}</p>
+          <Badge variant={statusBadgeVariant(check?.status)} className="shrink-0">
+            {check?.status ?? 'unknown'}
+          </Badge>
+        </div>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {check?.summary ?? 'No diagnostic check returned.'}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export function CodexDiagnosticsCard({ doctor, loading, error, onRefresh }: CodexDiagnosticsCardProps) {
+  const report = doctor?.report ?? null
+  const authCheck = getCheck(report, 'auth.credentials')
+  const configCheck = getCheck(report, 'config.load')
+  const installationCheck = getCheck(report, 'installation')
+  const safeJson = redactSensitiveValues(doctor)
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0">
+        <CardTitle>Codex Diagnostics</CardTitle>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          onClick={onRefresh}
+          disabled={loading}
+          title="Refresh diagnostics"
+        >
+          <RefreshCw className={cn('h-4 w-4', loading && 'animate-spin')} />
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-3 md:grid-cols-3">
+          <div>
+            <p className="text-xs text-muted-foreground">Overall</p>
+            <div className="mt-1 flex items-center gap-2">
+              <StatusIcon status={report?.overallStatus} />
+              <Badge variant={statusBadgeVariant(report?.overallStatus)}>
+                {report?.overallStatus ?? 'unknown'}
+              </Badge>
+            </div>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Codex Version</p>
+            <p className="mt-1 font-medium">{report?.codexVersion ?? 'Unknown'}</p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Doctor Exit</p>
+            <p className="mt-1 font-medium">{doctor?.exit_code ?? 'Not run'}</p>
+          </div>
+        </div>
+
+        {doctor?.parse_error && (
+          <p className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+            {doctor.parse_error}
+          </p>
+        )}
+
+        {error && (
+          <p className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+            {error}
+          </p>
+        )}
+
+        {doctor?.stderr && (
+          <p className="rounded-md border p-3 text-sm text-muted-foreground">
+            {doctor.stderr}
+          </p>
+        )}
+
+        <div className="grid gap-3 md:grid-cols-3">
+          <CheckRow label="Auth" check={authCheck} />
+          <CheckRow label="Config" check={configCheck} />
+          <CheckRow label="Install" check={installationCheck} />
+        </div>
+
+        <details className="group rounded-md border">
+          <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-sm font-medium">
+            <ChevronRight className="h-4 w-4 transition-transform group-open:rotate-90" />
+            Redacted doctor JSON
+          </summary>
+          <pre className="max-h-80 overflow-auto border-t bg-muted p-3 text-xs">
+            {JSON.stringify(safeJson, null, 2)}
+          </pre>
+        </details>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/features/config/CodexInventoryCard.tsx
+++ b/frontend/src/features/config/CodexInventoryCard.tsx
@@ -1,0 +1,143 @@
+import { ChevronRight, RefreshCw } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+import type { CodexMcpInventoryResponse, CodexPluginInventoryResponse } from '@/types/providers'
+
+interface CodexInventoryCardProps {
+  mcp: CodexMcpInventoryResponse | null
+  plugins: CodexPluginInventoryResponse | null
+  mcpError: string | null
+  pluginError: string | null
+  loading: boolean
+  onRefresh: () => void
+}
+
+function countMcpServers(servers: unknown): number | null {
+  if (!servers || typeof servers !== 'object') return null
+  if (Array.isArray(servers)) return servers.length
+  const objectValue = servers as Record<string, unknown>
+  if (objectValue.servers && typeof objectValue.servers === 'object') {
+    return Array.isArray(objectValue.servers)
+      ? objectValue.servers.length
+      : Object.keys(objectValue.servers as Record<string, unknown>).length
+  }
+  return Object.keys(objectValue).length
+}
+
+function InventoryError({ message }: { message: string | null }) {
+  if (!message) return null
+  return (
+    <p className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+      {message}
+    </p>
+  )
+}
+
+function RawDetails({ label, content }: { label: string; content: unknown }) {
+  return (
+    <details className="group rounded-md border">
+      <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-sm font-medium">
+        <ChevronRight className="h-4 w-4 transition-transform group-open:rotate-90" />
+        {label}
+      </summary>
+      <pre className="max-h-72 overflow-auto border-t bg-muted p-3 text-xs">
+        {typeof content === 'string' ? content || '(empty)' : JSON.stringify(content, null, 2)}
+      </pre>
+    </details>
+  )
+}
+
+export function CodexInventoryCard({
+  mcp,
+  plugins,
+  mcpError,
+  pluginError,
+  loading,
+  onRefresh,
+}: CodexInventoryCardProps) {
+  const mcpCount = countMcpServers(mcp?.servers)
+  const pluginCount = plugins?.plugins.length ?? null
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0">
+        <CardTitle>Codex Inventory</CardTitle>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          onClick={onRefresh}
+          disabled={loading}
+          title="Refresh inventory"
+        >
+          <RefreshCw className={cn('h-4 w-4', loading && 'animate-spin')} />
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-3 md:grid-cols-2">
+          <div className="rounded-md border p-3">
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-sm font-medium">MCP Servers</p>
+              <Badge variant={mcp?.exit_code === 0 ? 'default' : 'outline'}>
+                exit {mcp?.exit_code ?? 'n/a'}
+              </Badge>
+            </div>
+            <p className="mt-1 text-2xl font-semibold">{mcpCount ?? 'Unknown'}</p>
+            {mcp?.parse_error && (
+              <p className="mt-2 text-xs text-destructive">{mcp.parse_error}</p>
+            )}
+            {mcp?.stderr && (
+              <p className="mt-2 text-xs text-muted-foreground">{mcp.stderr}</p>
+            )}
+          </div>
+
+          <div className="rounded-md border p-3">
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-sm font-medium">Plugins</p>
+              <Badge variant={plugins?.exit_code === 0 ? 'default' : 'outline'}>
+                exit {plugins?.exit_code ?? 'n/a'}
+              </Badge>
+            </div>
+            <p className="mt-1 text-2xl font-semibold">{pluginCount ?? 'Unknown'}</p>
+            {plugins?.stderr && (
+              <p className="mt-2 text-xs text-muted-foreground">{plugins.stderr}</p>
+            )}
+          </div>
+        </div>
+
+        <InventoryError message={mcpError} />
+        <InventoryError message={pluginError} />
+
+        {plugins?.plugins && plugins.plugins.length > 0 && (
+          <div className="rounded-md border">
+            {plugins.plugins.map((plugin) => (
+              <div key={`${plugin.status ?? 'unknown'}:${plugin.name}`} className="border-b p-3 last:border-b-0">
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-sm font-medium">{plugin.name}</p>
+                  {plugin.status && <Badge variant="outline">{plugin.status}</Badge>}
+                </div>
+                {(plugin.version || plugin.path) && (
+                  <div className="mt-1 flex min-w-0 flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                    {plugin.version && <span>v{plugin.version}</span>}
+                    {plugin.path && (
+                      <code className="max-w-full truncate rounded bg-muted px-1.5 py-0.5 font-mono">
+                        {plugin.path}
+                      </code>
+                    )}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="grid gap-3 lg:grid-cols-2">
+          <RawDetails label="MCP JSON" content={mcp?.servers ?? null} />
+          <RawDetails label="Plugin output" content={plugins?.raw_stdout ?? ''} />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/features/config/CodexInventoryCard.tsx
+++ b/frontend/src/features/config/CodexInventoryCard.tsx
@@ -1,9 +1,26 @@
-import { ChevronRight, RefreshCw } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { ChevronRight, Plus, RefreshCw, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { addCodexMcpServer, removeCodexMcpServer } from '@/hooks/useProviders'
 import { cn } from '@/lib/utils'
-import type { CodexMcpInventoryResponse, CodexPluginInventoryResponse } from '@/types/providers'
+import type { CodexMcpAddRequest, CodexMcpInventoryResponse, CodexPluginInventoryResponse } from '@/types/providers'
 
 interface CodexInventoryCardProps {
   mcp: CodexMcpInventoryResponse | null
@@ -11,25 +28,78 @@ interface CodexInventoryCardProps {
   mcpError: string | null
   pluginError: string | null
   loading: boolean
-  onRefresh: () => void
+  onRefresh: () => void | Promise<void>
+}
+
+type McpMode = 'command' | 'url'
+
+interface McpServerRow {
+  name: string
+  details: unknown
+}
+
+function getMcpServerMap(servers: unknown): Record<string, unknown> | null {
+  if (!servers || typeof servers !== 'object' || Array.isArray(servers)) return null
+  const objectValue = servers as Record<string, unknown>
+  if (objectValue.servers && typeof objectValue.servers === 'object' && !Array.isArray(objectValue.servers)) {
+    return objectValue.servers as Record<string, unknown>
+  }
+  return objectValue
+}
+
+function getMcpServerRows(servers: unknown): McpServerRow[] {
+  if (Array.isArray(servers)) {
+    return servers.flatMap((server, index) => {
+      if (!server || typeof server !== 'object') return []
+      const objectValue = server as Record<string, unknown>
+      const name = typeof objectValue.name === 'string' ? objectValue.name : `server-${index + 1}`
+      return [{ name, details: server }]
+    })
+  }
+  const map = getMcpServerMap(servers)
+  if (!map) return []
+  return Object.entries(map).map(([name, details]) => ({ name, details }))
 }
 
 function countMcpServers(servers: unknown): number | null {
   if (!servers || typeof servers !== 'object') return null
   if (Array.isArray(servers)) return servers.length
-  const objectValue = servers as Record<string, unknown>
-  if (objectValue.servers && typeof objectValue.servers === 'object') {
-    return Array.isArray(objectValue.servers)
-      ? objectValue.servers.length
-      : Object.keys(objectValue.servers as Record<string, unknown>).length
+  const map = getMcpServerMap(servers)
+  return map ? Object.keys(map).length : null
+}
+
+function parseLines(value: string): string[] {
+  return value
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+function parseEnv(value: string): Record<string, string> {
+  const env: Record<string, string> = {}
+  for (const line of parseLines(value)) {
+    const separatorIndex = line.indexOf('=')
+    if (separatorIndex <= 0) {
+      throw new Error('Environment variables must use KEY=VALUE format')
+    }
+    env[line.slice(0, separatorIndex).trim()] = line.slice(separatorIndex + 1)
   }
-  return Object.keys(objectValue).length
+  return env
 }
 
 function InventoryError({ message }: { message: string | null }) {
   if (!message) return null
   return (
     <p className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+      {message}
+    </p>
+  )
+}
+
+function InventoryMessage({ message }: { message: string | null }) {
+  if (!message) return null
+  return (
+    <p className="rounded-md border border-primary/30 bg-primary/10 p-3 text-sm text-primary">
       {message}
     </p>
   )
@@ -57,8 +127,91 @@ export function CodexInventoryCard({
   loading,
   onRefresh,
 }: CodexInventoryCardProps) {
+  const [mode, setMode] = useState<McpMode>('command')
+  const [name, setName] = useState('')
+  const [command, setCommand] = useState('')
+  const [argsText, setArgsText] = useState('')
+  const [envText, setEnvText] = useState('')
+  const [url, setUrl] = useState('')
+  const [bearerTokenEnvVar, setBearerTokenEnvVar] = useState('')
+  const [mutationError, setMutationError] = useState<string | null>(null)
+  const [mutationMessage, setMutationMessage] = useState<string | null>(null)
+  const [mutating, setMutating] = useState(false)
+
+  const mcpRows = useMemo(() => getMcpServerRows(mcp?.servers), [mcp?.servers])
   const mcpCount = countMcpServers(mcp?.servers)
   const pluginCount = plugins?.plugins.length ?? null
+
+  const resetForm = () => {
+    setName('')
+    setCommand('')
+    setArgsText('')
+    setEnvText('')
+    setUrl('')
+    setBearerTokenEnvVar('')
+  }
+
+  const handleAddMcp = async () => {
+    setMutationError(null)
+    setMutationMessage(null)
+    try {
+      const trimmedName = name.trim()
+      if (!trimmedName) throw new Error('Server name is required')
+      const request: CodexMcpAddRequest = mode === 'url'
+        ? {
+            name: trimmedName,
+            url: url.trim(),
+            ...(bearerTokenEnvVar.trim() && { bearer_token_env_var: bearerTokenEnvVar.trim() }),
+          }
+        : {
+            name: trimmedName,
+            command: command.trim(),
+            args: parseLines(argsText),
+            env: parseEnv(envText),
+          }
+      if (mode === 'url' && !request.url) throw new Error('URL is required')
+      if (mode === 'command' && !request.command) throw new Error('Command is required')
+
+      setMutating(true)
+      const result = await addCodexMcpServer(request)
+      if (result.exit_code !== 0) {
+        throw new Error(result.stderr || result.stdout || `codex mcp add exited with ${result.exit_code}`)
+      }
+      const message = `MCP server "${trimmedName}" added`
+      setMutationMessage(message)
+      toast.success(message)
+      resetForm()
+      await onRefresh()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to add MCP server'
+      setMutationError(message)
+      toast.error(message)
+    } finally {
+      setMutating(false)
+    }
+  }
+
+  const handleRemoveMcp = async (serverName: string) => {
+    setMutationError(null)
+    setMutationMessage(null)
+    setMutating(true)
+    try {
+      const result = await removeCodexMcpServer(serverName)
+      if (result.exit_code !== 0) {
+        throw new Error(result.stderr || result.stdout || `codex mcp remove exited with ${result.exit_code}`)
+      }
+      const message = `MCP server "${serverName}" removed`
+      setMutationMessage(message)
+      toast.success(message)
+      await onRefresh()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to remove MCP server'
+      setMutationError(message)
+      toast.error(message)
+    } finally {
+      setMutating(false)
+    }
+  }
 
   return (
     <Card>
@@ -69,7 +222,7 @@ export function CodexInventoryCard({
           size="icon"
           className="h-8 w-8"
           onClick={onRefresh}
-          disabled={loading}
+          disabled={loading || mutating}
           title="Refresh inventory"
         >
           <RefreshCw className={cn('h-4 w-4', loading && 'animate-spin')} />
@@ -109,6 +262,154 @@ export function CodexInventoryCard({
 
         <InventoryError message={mcpError} />
         <InventoryError message={pluginError} />
+        <InventoryError message={mutationError} />
+        <InventoryMessage message={mutationMessage} />
+
+        <div className="rounded-md border p-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="text-sm font-medium">Add MCP Server</p>
+            <div className="flex rounded-md border p-0.5">
+              <Button
+                type="button"
+                variant={mode === 'command' ? 'secondary' : 'ghost'}
+                size="sm"
+                className="h-7"
+                onClick={() => setMode('command')}
+              >
+                Command
+              </Button>
+              <Button
+                type="button"
+                variant={mode === 'url' ? 'secondary' : 'ghost'}
+                size="sm"
+                className="h-7"
+                onClick={() => setMode('url')}
+              >
+                URL
+              </Button>
+            </div>
+          </div>
+          <div className="mt-3 grid gap-3 md:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="codex-mcp-name">Name</Label>
+              <Input
+                id="codex-mcp-name"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="linear"
+                disabled={mutating}
+              />
+            </div>
+            {mode === 'url' ? (
+              <>
+                <div className="space-y-1.5">
+                  <Label htmlFor="codex-mcp-url">URL</Label>
+                  <Input
+                    id="codex-mcp-url"
+                    value={url}
+                    onChange={(event) => setUrl(event.target.value)}
+                    placeholder="https://example.com/mcp"
+                    disabled={mutating}
+                  />
+                </div>
+                <div className="space-y-1.5 md:col-span-2">
+                  <Label htmlFor="codex-mcp-bearer-env">Bearer Token Env Var</Label>
+                  <Input
+                    id="codex-mcp-bearer-env"
+                    value={bearerTokenEnvVar}
+                    onChange={(event) => setBearerTokenEnvVar(event.target.value)}
+                    placeholder="MCP_TOKEN"
+                    disabled={mutating}
+                  />
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="space-y-1.5">
+                  <Label htmlFor="codex-mcp-command">Command</Label>
+                  <Input
+                    id="codex-mcp-command"
+                    value={command}
+                    onChange={(event) => setCommand(event.target.value)}
+                    placeholder="npx"
+                    disabled={mutating}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="codex-mcp-args">Arguments</Label>
+                  <Textarea
+                    id="codex-mcp-args"
+                    value={argsText}
+                    onChange={(event) => setArgsText(event.target.value)}
+                    placeholder={'-y\n@linear/mcp'}
+                    disabled={mutating}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="codex-mcp-env">Environment</Label>
+                  <Textarea
+                    id="codex-mcp-env"
+                    value={envText}
+                    onChange={(event) => setEnvText(event.target.value)}
+                    placeholder="LINEAR_API_KEY=value"
+                    disabled={mutating}
+                  />
+                </div>
+              </>
+            )}
+          </div>
+          <div className="mt-3 flex justify-end">
+            <Button onClick={handleAddMcp} disabled={mutating} className="gap-2">
+              <Plus className="h-4 w-4" />
+              Add Server
+            </Button>
+          </div>
+        </div>
+
+        {mcpRows.length > 0 && (
+          <div className="rounded-md border">
+            {mcpRows.map((server) => (
+              <div key={server.name} className="flex items-start justify-between gap-3 border-b p-3 last:border-b-0">
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium">{server.name}</p>
+                  <code className="mt-1 block max-w-full truncate rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
+                    {JSON.stringify(server.details)}
+                  </code>
+                </div>
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 shrink-0 text-destructive hover:text-destructive"
+                      disabled={mutating}
+                      title={`Remove ${server.name}`}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Remove MCP Server</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Remove "{server.name}" from Codex MCP configuration? This uses codex mcp remove and cannot be undone from this screen.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancel</AlertDialogCancel>
+                      <AlertDialogAction
+                        onClick={() => handleRemoveMcp(server.name)}
+                        className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                      >
+                        Remove
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </div>
+            ))}
+          </div>
+        )}
 
         {plugins?.plugins && plugins.plugins.length > 0 && (
           <div className="rounded-md border">

--- a/frontend/src/features/config/CodexSettingsEditor.tsx
+++ b/frontend/src/features/config/CodexSettingsEditor.tsx
@@ -1,0 +1,239 @@
+import { useMemo, useState } from 'react'
+import { Plus, Save } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
+import { updateCodexConfig } from '@/hooks/useProviders'
+import type { CodexConfigResponse, CodexConfigUpdateRequest } from '@/types/providers'
+
+interface CodexSettingsEditorProps {
+  config: CodexConfigResponse | null
+  onSaved: () => Promise<void> | void
+}
+
+const FEATURE_NAME_PATTERN = /^[A-Za-z0-9_-]+$/
+
+function optionalString(value: string): string | null {
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function optionalBoolean(current: boolean, original: boolean | undefined): boolean | null {
+  if (original !== undefined || current === true) return current
+  return null
+}
+
+function Field({
+  id,
+  label,
+  value,
+  placeholder,
+  onChange,
+}: {
+  id: string
+  label: string
+  value: string
+  placeholder?: string
+  onChange: (value: string) => void
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={id}>{label}</Label>
+      <Input
+        id={id}
+        value={value}
+        placeholder={placeholder}
+        onChange={(event) => onChange(event.target.value)}
+      />
+    </div>
+  )
+}
+
+function ToggleRow({
+  id,
+  label,
+  checked,
+  onChange,
+}: {
+  id: string
+  label: string
+  checked: boolean
+  onChange: (checked: boolean) => void
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-md border px-3 py-2">
+      <Label htmlFor={id} className="text-sm font-medium">
+        {label}
+      </Label>
+      <Switch id={id} checked={checked} onCheckedChange={onChange} />
+    </div>
+  )
+}
+
+export function CodexSettingsEditor({ config, onSaved }: CodexSettingsEditorProps) {
+  const summary = config?.summary
+  const initialFeatures = useMemo(() => summary?.features ?? {}, [summary?.features])
+  const [model, setModel] = useState(summary?.model ?? '')
+  const [reasoning, setReasoning] = useState(summary?.model_reasoning_effort ?? '')
+  const [profile, setProfile] = useState(summary?.profile ?? '')
+  const [sandboxMode, setSandboxMode] = useState(summary?.sandbox_mode ?? '')
+  const [approvalPolicy, setApprovalPolicy] = useState(summary?.approval_policy ?? '')
+  const [search, setSearch] = useState(summary?.search ?? false)
+  const [strictConfig, setStrictConfig] = useState(summary?.strict_config ?? false)
+  const [noAltScreen, setNoAltScreen] = useState(summary?.no_alt_screen ?? false)
+  const [features, setFeatures] = useState<Record<string, boolean>>(initialFeatures)
+  const [newFeature, setNewFeature] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const featureEntries = Object.entries(features).sort(([a], [b]) => a.localeCompare(b))
+  const canAddFeature = FEATURE_NAME_PATTERN.test(newFeature.trim()) && !(newFeature.trim() in features)
+
+  function setFeature(name: string, value: boolean) {
+    setFeatures((current) => ({ ...current, [name]: value }))
+  }
+
+  function addFeature() {
+    const name = newFeature.trim()
+    if (!FEATURE_NAME_PATTERN.test(name)) {
+      toast.error('Feature names can only contain letters, numbers, underscores, and hyphens')
+      return
+    }
+    if (name in features) {
+      toast.error(`Feature "${name}" already exists`)
+      return
+    }
+    setFeatures((current) => ({ ...current, [name]: true }))
+    setNewFeature('')
+  }
+
+  async function handleSave() {
+    setSubmitting(true)
+    try {
+      const request: CodexConfigUpdateRequest = {
+        settings: {
+          model: optionalString(model),
+          model_reasoning_effort: optionalString(reasoning),
+          profile: optionalString(profile),
+          sandbox_mode: optionalString(sandboxMode),
+          approval_policy: optionalString(approvalPolicy),
+          search: optionalBoolean(search, summary?.search),
+          strict_config: optionalBoolean(strictConfig, summary?.strict_config),
+          no_alt_screen: optionalBoolean(noAltScreen, summary?.no_alt_screen),
+        },
+        features,
+      }
+      await updateCodexConfig(request)
+      toast.success('Codex config saved')
+      await onSaved()
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to save Codex config')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {config?.parse_error && (
+        <Card className="border-destructive">
+          <CardContent className="pt-6">
+            <p className="text-sm text-destructive">{config.parse_error}</p>
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="grid gap-4 xl:grid-cols-3">
+        <Card>
+          <CardHeader>
+            <CardTitle>General</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <Field id="codex-model" label="Model" value={model} placeholder="default" onChange={setModel} />
+            <Field
+              id="codex-reasoning"
+              label="Reasoning Effort"
+              value={reasoning}
+              placeholder="default"
+              onChange={setReasoning}
+            />
+            <Field id="codex-profile" label="Profile" value={profile} placeholder="default" onChange={setProfile} />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Runtime</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <Field
+              id="codex-sandbox"
+              label="Sandbox Mode"
+              value={sandboxMode}
+              placeholder="default"
+              onChange={setSandboxMode}
+            />
+            <Field
+              id="codex-approval"
+              label="Approval Policy"
+              value={approvalPolicy}
+              placeholder="default"
+              onChange={setApprovalPolicy}
+            />
+            <ToggleRow id="codex-search" label="Search" checked={search} onChange={setSearch} />
+            <ToggleRow id="codex-strict-config" label="Strict Config" checked={strictConfig} onChange={setStrictConfig} />
+            <ToggleRow id="codex-no-alt-screen" label="No Alt Screen" checked={noAltScreen} onChange={setNoAltScreen} />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Features</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="flex gap-2">
+              <Input
+                value={newFeature}
+                placeholder="feature_name"
+                onChange={(event) => setNewFeature(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault()
+                    addFeature()
+                  }
+                }}
+              />
+              <Button type="button" variant="outline" size="icon" onClick={addFeature} disabled={!canAddFeature}>
+                <Plus className="h-4 w-4" />
+              </Button>
+            </div>
+            <div className="max-h-72 space-y-2 overflow-auto pr-1">
+              {featureEntries.length === 0 ? (
+                <p className="rounded-md border p-3 text-sm text-muted-foreground">No feature flags configured.</p>
+              ) : (
+                featureEntries.map(([name, enabled]) => (
+                  <ToggleRow
+                    key={name}
+                    id={`codex-feature-${name}`}
+                    label={name}
+                    checked={enabled}
+                    onChange={(checked) => setFeature(name, checked)}
+                  />
+                ))
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="flex justify-end">
+        <Button onClick={handleSave} disabled={submitting || Boolean(config?.parse_error)} className="gap-2">
+          <Save className="h-4 w-4" />
+          {submitting ? 'Saving...' : 'Save Codex Config'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/config/ConfigFileList.tsx
+++ b/frontend/src/features/config/ConfigFileList.tsx
@@ -10,8 +10,14 @@ interface ConfigFileListProps {
 }
 
 export function ConfigFileList({ files, selectedFile, onSelectFile }: ConfigFileListProps) {
-  const userFiles = files.filter(f => f.scope === 'user' && f.exists)
-  const projectFiles = files.filter(f => f.scope === 'project' && f.exists)
+  const existingFiles = files.filter((file) => file.exists)
+  const groups = [
+    { scope: 'user', title: 'User Config Files' },
+    { scope: 'project', title: 'Project Config Files' },
+    { scope: 'profile', title: 'Profile Config Files' },
+    { scope: 'rules', title: 'Rules Files' },
+    { scope: 'managed', title: 'Managed Config Files' },
+  ] as const
 
   const FileItem = ({ file }: { file: ConfigFile }) => (
     <button
@@ -37,29 +43,22 @@ export function ConfigFileList({ files, selectedFile, onSelectFile }: ConfigFile
 
   return (
     <div className="space-y-4">
-      {userFiles.length > 0 && (
-        <div>
-          <h3 className="text-sm font-semibold mb-2">User Config Files</h3>
-          <div className="space-y-1">
-            {userFiles.map(file => (
-              <FileItem key={file.path} file={file} />
-            ))}
+      {groups.map(({ scope, title }) => {
+        const scopedFiles = existingFiles.filter((file) => file.scope === scope)
+        if (scopedFiles.length === 0) return null
+        return (
+          <div key={scope}>
+            <h3 className="text-sm font-semibold mb-2">{title}</h3>
+            <div className="space-y-1">
+              {scopedFiles.map((file) => (
+                <FileItem key={file.path} file={file} />
+              ))}
+            </div>
           </div>
-        </div>
-      )}
+        )
+      })}
 
-      {projectFiles.length > 0 && (
-        <div>
-          <h3 className="text-sm font-semibold mb-2">Project Config Files</h3>
-          <div className="space-y-1">
-            {projectFiles.map(file => (
-              <FileItem key={file.path} file={file} />
-            ))}
-          </div>
-        </div>
-      )}
-
-      {files.length === 0 && (
+      {existingFiles.length === 0 && (
         <Card className="p-4">
           <p className="text-sm text-muted-foreground text-center">
             No configuration files found

--- a/frontend/src/features/config/ConfigFileViewer.tsx
+++ b/frontend/src/features/config/ConfigFileViewer.tsx
@@ -6,9 +6,10 @@ import { JsonViewer } from '@/components/shared/JsonViewer'
 
 interface ConfigFileViewerProps {
   filePath: string | null
+  rawEndpoint?: string
 }
 
-export function ConfigFileViewer({ filePath }: ConfigFileViewerProps) {
+export function ConfigFileViewer({ filePath, rawEndpoint = 'config/raw' }: ConfigFileViewerProps) {
   const [content, setContent] = useState<RawFileContent | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -24,7 +25,7 @@ export function ConfigFileViewer({ filePath }: ConfigFileViewerProps) {
       setError(null)
 
       try {
-        const result = await api.get<RawFileContent>(`config/raw?path=${encodeURIComponent(filePath)}`)
+        const result = await api.get<RawFileContent>(`${rawEndpoint}?path=${encodeURIComponent(filePath)}`)
         setContent(result)
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load file')
@@ -34,7 +35,7 @@ export function ConfigFileViewer({ filePath }: ConfigFileViewerProps) {
     }
 
     fetchContent()
-  }, [filePath])
+  }, [filePath, rawEndpoint])
 
   if (!filePath) {
     return (

--- a/frontend/src/features/config/ConfigViewerPage.tsx
+++ b/frontend/src/features/config/ConfigViewerPage.tsx
@@ -10,11 +10,29 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { apiClient, buildEndpoint } from '@/lib/api'
 import { useProjectContext } from '@/contexts/ProjectContext'
+import { useProviderContext } from '@/contexts/ProviderContext'
 import { toast } from 'sonner'
+
+interface CodexConfigResponse {
+  provider: 'codex-cli'
+  path: string
+  exists: boolean
+  parse_error: string | null
+  summary: {
+    model?: string
+    model_reasoning_effort?: string
+    profile?: string
+    projects: Record<string, { trust_level?: string }>
+    profiles: Record<string, unknown>
+    features: Record<string, boolean>
+  }
+}
 
 export function ConfigViewerPage() {
   const { activeProject } = useProjectContext()
+  const { selectedProviderId, selectedProvider } = useProviderContext()
   const [data, setData] = useState<ConfigFileListResponse | null>(null)
+  const [codexConfig, setCodexConfig] = useState<CodexConfigResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [selectedFile, setSelectedFile] = useState<string | null>(null)
@@ -24,9 +42,20 @@ export function ConfigViewerPage() {
     setLoading(true)
     setError(null)
     try {
-      const endpoint = buildEndpoint('config/files', { project_path: activeProject?.path })
-      const response = await apiClient<ConfigFileListResponse>(endpoint)
-      setData(response)
+      if (selectedProviderId === 'codex-cli') {
+        const [files, config] = await Promise.all([
+          apiClient<ConfigFileListResponse>('codex-config/files'),
+          apiClient<CodexConfigResponse>('codex-config'),
+        ])
+        setData(files)
+        setCodexConfig(config)
+        if (activeTab === 'scopes') setActiveTab('editor')
+      } else {
+        const endpoint = buildEndpoint('config/files', { project_path: activeProject?.path })
+        const response = await apiClient<ConfigFileListResponse>(endpoint)
+        setData(response)
+        setCodexConfig(null)
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to load config files'
       setError(message)
@@ -34,11 +63,15 @@ export function ConfigViewerPage() {
     } finally {
       setLoading(false)
     }
-  }, [activeProject?.path])
+  }, [activeProject?.path, selectedProviderId, activeTab])
 
   useEffect(() => {
     fetchData()
   }, [fetchData])
+
+  useEffect(() => {
+    setSelectedFile(null)
+  }, [selectedProviderId])
 
   const handleOverrideInLocal = async (key: string, value: ConfigValue) => {
     const parts = key.split('.')
@@ -76,7 +109,7 @@ export function ConfigViewerPage() {
             Configuration
           </h1>
           <p className="text-muted-foreground">
-            View and edit Claude Code configuration
+            View {selectedProvider?.display_name ?? 'agent'} configuration
           </p>
         </div>
         <RefreshButton onClick={fetchData} loading={loading} />
@@ -86,12 +119,14 @@ export function ConfigViewerPage() {
         <TabsList className="w-fit">
           <TabsTrigger value="editor" className="flex items-center gap-2">
             <Edit className="h-4 w-4" />
-            Settings Editor
+            {selectedProviderId === 'codex-cli' ? 'Overview' : 'Settings Editor'}
           </TabsTrigger>
-          <TabsTrigger value="scopes" className="flex items-center gap-2">
-            <Shield className="h-4 w-4" />
-            Scope Resolver
-          </TabsTrigger>
+          {selectedProviderId === 'claude-code' && (
+            <TabsTrigger value="scopes" className="flex items-center gap-2">
+              <Shield className="h-4 w-4" />
+              Scope Resolver
+            </TabsTrigger>
+          )}
           <TabsTrigger value="viewer" className="flex items-center gap-2">
             <Eye className="h-4 w-4" />
             Raw Viewer
@@ -99,7 +134,39 @@ export function ConfigViewerPage() {
         </TabsList>
 
         <TabsContent value="editor" className="flex-1 overflow-auto mt-4">
-          <SettingsEditor onSave={fetchData} />
+          {selectedProviderId === 'codex-cli' ? (
+            <Card>
+              <CardHeader>
+                <CardTitle>Codex Config</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm">
+                {!codexConfig?.exists && (
+                  <p className="text-muted-foreground">No ~/.codex/config.toml file found.</p>
+                )}
+                {codexConfig?.parse_error && (
+                  <p className="text-destructive">{codexConfig.parse_error}</p>
+                )}
+                {codexConfig && (
+                  <div className="grid gap-3 md:grid-cols-3">
+                    <div>
+                      <p className="text-xs text-muted-foreground">Model</p>
+                      <p className="font-medium">{codexConfig.summary.model ?? 'Default'}</p>
+                    </div>
+                    <div>
+                      <p className="text-xs text-muted-foreground">Reasoning</p>
+                      <p className="font-medium">{codexConfig.summary.model_reasoning_effort ?? 'Default'}</p>
+                    </div>
+                    <div>
+                      <p className="text-xs text-muted-foreground">Trusted Projects</p>
+                      <p className="font-medium">{Object.keys(codexConfig.summary.projects).length}</p>
+                    </div>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          ) : (
+            <SettingsEditor onSave={fetchData} />
+          )}
         </TabsContent>
 
         <TabsContent value="scopes" className="flex-1 overflow-auto mt-4">
@@ -140,7 +207,10 @@ export function ConfigViewerPage() {
             </div>
 
             <div className="col-span-8 overflow-y-auto">
-              <ConfigFileViewer filePath={selectedFile} />
+              <ConfigFileViewer
+                filePath={selectedFile}
+                rawEndpoint={selectedProviderId === 'codex-cli' ? 'codex-config/file' : 'config/raw'}
+              />
             </div>
           </div>
         </TabsContent>

--- a/frontend/src/features/config/ConfigViewerPage.tsx
+++ b/frontend/src/features/config/ConfigViewerPage.tsx
@@ -5,6 +5,7 @@ import { RefreshButton } from '@/components/shared/RefreshButton'
 import { ConfigFileList } from './ConfigFileList'
 import { ConfigFileViewer } from './ConfigFileViewer'
 import { CodexDiagnosticsCard } from './CodexDiagnosticsCard'
+import { CodexSettingsEditor } from './CodexSettingsEditor'
 import { SettingsEditor } from './settings'
 import { ScopeResolver } from './ScopeResolver'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -13,23 +14,8 @@ import { apiClient, buildEndpoint } from '@/lib/api'
 import { useProjectContext } from '@/contexts/ProjectContext'
 import { useProviderContext } from '@/contexts/ProviderContext'
 import { fetchProviderDoctor } from '@/hooks/useProviders'
-import type { ProviderDoctorResponse } from '@/types/providers'
+import type { CodexConfigResponse, ProviderDoctorResponse } from '@/types/providers'
 import { toast } from 'sonner'
-
-interface CodexConfigResponse {
-  provider: 'codex-cli'
-  path: string
-  exists: boolean
-  parse_error: string | null
-  summary: {
-    model?: string
-    model_reasoning_effort?: string
-    profile?: string
-    projects: Record<string, { trust_level?: string }>
-    profiles: Record<string, unknown>
-    features: Record<string, boolean>
-  }
-}
 
 export function ConfigViewerPage() {
   const { activeProject } = useProjectContext()
@@ -155,35 +141,18 @@ export function ConfigViewerPage() {
         <TabsContent value="editor" className="flex-1 overflow-auto mt-4">
           {selectedProviderId === 'codex-cli' ? (
             <div className="space-y-4">
-              <Card>
-                <CardHeader>
-                  <CardTitle>Codex Config</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-3 text-sm">
-                  {!codexConfig?.exists && (
-                    <p className="text-muted-foreground">No ~/.codex/config.toml file found.</p>
-                  )}
-                  {codexConfig?.parse_error && (
-                    <p className="text-destructive">{codexConfig.parse_error}</p>
-                  )}
-                  {codexConfig && (
-                    <div className="grid gap-3 md:grid-cols-3">
-                      <div>
-                        <p className="text-xs text-muted-foreground">Model</p>
-                        <p className="font-medium">{codexConfig.summary.model ?? 'Default'}</p>
-                      </div>
-                      <div>
-                        <p className="text-xs text-muted-foreground">Reasoning</p>
-                        <p className="font-medium">{codexConfig.summary.model_reasoning_effort ?? 'Default'}</p>
-                      </div>
-                      <div>
-                        <p className="text-xs text-muted-foreground">Trusted Projects</p>
-                        <p className="font-medium">{Object.keys(codexConfig.summary.projects).length}</p>
-                      </div>
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
+              {!codexConfig?.exists && (
+                <Card>
+                  <CardContent className="pt-6">
+                    <p className="text-sm text-muted-foreground">No ~/.codex/config.toml file found. Saving will create it.</p>
+                  </CardContent>
+                </Card>
+              )}
+              <CodexSettingsEditor
+                key={JSON.stringify(codexConfig?.summary ?? {})}
+                config={codexConfig}
+                onSaved={fetchData}
+              />
               <CodexDiagnosticsCard
                 doctor={codexDoctor}
                 loading={loading}

--- a/frontend/src/features/config/ConfigViewerPage.tsx
+++ b/frontend/src/features/config/ConfigViewerPage.tsx
@@ -5,6 +5,7 @@ import { RefreshButton } from '@/components/shared/RefreshButton'
 import { ConfigFileList } from './ConfigFileList'
 import { ConfigFileViewer } from './ConfigFileViewer'
 import { CodexDiagnosticsCard } from './CodexDiagnosticsCard'
+import { CodexInventoryCard } from './CodexInventoryCard'
 import { CodexSettingsEditor } from './CodexSettingsEditor'
 import { SettingsEditor } from './settings'
 import { ScopeResolver } from './ScopeResolver'
@@ -13,8 +14,13 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { apiClient, buildEndpoint } from '@/lib/api'
 import { useProjectContext } from '@/contexts/ProjectContext'
 import { useProviderContext } from '@/contexts/ProviderContext'
-import { fetchProviderDoctor } from '@/hooks/useProviders'
-import type { CodexConfigResponse, ProviderDoctorResponse } from '@/types/providers'
+import { fetchCodexMcpInventory, fetchCodexPluginInventory, fetchProviderDoctor } from '@/hooks/useProviders'
+import type {
+  CodexConfigResponse,
+  CodexMcpInventoryResponse,
+  CodexPluginInventoryResponse,
+  ProviderDoctorResponse,
+} from '@/types/providers'
 import { toast } from 'sonner'
 
 export function ConfigViewerPage() {
@@ -24,6 +30,10 @@ export function ConfigViewerPage() {
   const [codexConfig, setCodexConfig] = useState<CodexConfigResponse | null>(null)
   const [codexDoctor, setCodexDoctor] = useState<ProviderDoctorResponse | null>(null)
   const [codexDoctorError, setCodexDoctorError] = useState<string | null>(null)
+  const [codexMcpInventory, setCodexMcpInventory] = useState<CodexMcpInventoryResponse | null>(null)
+  const [codexPluginInventory, setCodexPluginInventory] = useState<CodexPluginInventoryResponse | null>(null)
+  const [codexMcpError, setCodexMcpError] = useState<string | null>(null)
+  const [codexPluginError, setCodexPluginError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [selectedFile, setSelectedFile] = useState<string | null>(null)
@@ -42,16 +52,34 @@ export function ConfigViewerPage() {
             doctor: null,
             error: err instanceof Error ? err.message : 'Failed to load Codex diagnostics',
           }))
+        const mcpPromise = fetchCodexMcpInventory()
+          .then((inventory) => ({ inventory, error: null }))
+          .catch((err) => ({
+            inventory: null,
+            error: err instanceof Error ? err.message : 'Failed to load Codex MCP inventory',
+          }))
+        const pluginsPromise = fetchCodexPluginInventory()
+          .then((inventory) => ({ inventory, error: null }))
+          .catch((err) => ({
+            inventory: null,
+            error: err instanceof Error ? err.message : 'Failed to load Codex plugin inventory',
+          }))
 
-        const [files, config, doctorResult] = await Promise.all([
+        const [files, config, doctorResult, mcpResult, pluginResult] = await Promise.all([
           filesPromise,
           configPromise,
           doctorPromise,
+          mcpPromise,
+          pluginsPromise,
         ])
         setData(files)
         setCodexConfig(config)
         setCodexDoctor(doctorResult.doctor)
         setCodexDoctorError(doctorResult.error)
+        setCodexMcpInventory(mcpResult.inventory)
+        setCodexMcpError(mcpResult.error)
+        setCodexPluginInventory(pluginResult.inventory)
+        setCodexPluginError(pluginResult.error)
         if (activeTab === 'scopes') setActiveTab('editor')
       } else {
         const endpoint = buildEndpoint('config/files', { project_path: activeProject?.path })
@@ -60,6 +88,10 @@ export function ConfigViewerPage() {
         setCodexConfig(null)
         setCodexDoctor(null)
         setCodexDoctorError(null)
+        setCodexMcpInventory(null)
+        setCodexPluginInventory(null)
+        setCodexMcpError(null)
+        setCodexPluginError(null)
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to load config files'
@@ -157,6 +189,14 @@ export function ConfigViewerPage() {
                 doctor={codexDoctor}
                 loading={loading}
                 error={codexDoctorError}
+                onRefresh={fetchData}
+              />
+              <CodexInventoryCard
+                mcp={codexMcpInventory}
+                plugins={codexPluginInventory}
+                mcpError={codexMcpError}
+                pluginError={codexPluginError}
+                loading={loading}
                 onRefresh={fetchData}
               />
             </div>

--- a/frontend/src/features/config/ConfigViewerPage.tsx
+++ b/frontend/src/features/config/ConfigViewerPage.tsx
@@ -4,6 +4,7 @@ import type { ConfigFileListResponse, ConfigValue } from '@/types/config'
 import { RefreshButton } from '@/components/shared/RefreshButton'
 import { ConfigFileList } from './ConfigFileList'
 import { ConfigFileViewer } from './ConfigFileViewer'
+import { CodexDiagnosticsCard } from './CodexDiagnosticsCard'
 import { SettingsEditor } from './settings'
 import { ScopeResolver } from './ScopeResolver'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -11,6 +12,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { apiClient, buildEndpoint } from '@/lib/api'
 import { useProjectContext } from '@/contexts/ProjectContext'
 import { useProviderContext } from '@/contexts/ProviderContext'
+import { fetchProviderDoctor } from '@/hooks/useProviders'
+import type { ProviderDoctorResponse } from '@/types/providers'
 import { toast } from 'sonner'
 
 interface CodexConfigResponse {
@@ -33,6 +36,8 @@ export function ConfigViewerPage() {
   const { selectedProviderId, selectedProvider } = useProviderContext()
   const [data, setData] = useState<ConfigFileListResponse | null>(null)
   const [codexConfig, setCodexConfig] = useState<CodexConfigResponse | null>(null)
+  const [codexDoctor, setCodexDoctor] = useState<ProviderDoctorResponse | null>(null)
+  const [codexDoctorError, setCodexDoctorError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [selectedFile, setSelectedFile] = useState<string | null>(null)
@@ -43,18 +48,32 @@ export function ConfigViewerPage() {
     setError(null)
     try {
       if (selectedProviderId === 'codex-cli') {
-        const [files, config] = await Promise.all([
-          apiClient<ConfigFileListResponse>('codex-config/files'),
-          apiClient<CodexConfigResponse>('codex-config'),
+        const filesPromise = apiClient<ConfigFileListResponse>('codex-config/files')
+        const configPromise = apiClient<CodexConfigResponse>('codex-config')
+        const doctorPromise = fetchProviderDoctor('codex-cli')
+          .then((doctor) => ({ doctor, error: null }))
+          .catch((err) => ({
+            doctor: null,
+            error: err instanceof Error ? err.message : 'Failed to load Codex diagnostics',
+          }))
+
+        const [files, config, doctorResult] = await Promise.all([
+          filesPromise,
+          configPromise,
+          doctorPromise,
         ])
         setData(files)
         setCodexConfig(config)
+        setCodexDoctor(doctorResult.doctor)
+        setCodexDoctorError(doctorResult.error)
         if (activeTab === 'scopes') setActiveTab('editor')
       } else {
         const endpoint = buildEndpoint('config/files', { project_path: activeProject?.path })
         const response = await apiClient<ConfigFileListResponse>(endpoint)
         setData(response)
         setCodexConfig(null)
+        setCodexDoctor(null)
+        setCodexDoctorError(null)
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to load config files'
@@ -135,35 +154,43 @@ export function ConfigViewerPage() {
 
         <TabsContent value="editor" className="flex-1 overflow-auto mt-4">
           {selectedProviderId === 'codex-cli' ? (
-            <Card>
-              <CardHeader>
-                <CardTitle>Codex Config</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3 text-sm">
-                {!codexConfig?.exists && (
-                  <p className="text-muted-foreground">No ~/.codex/config.toml file found.</p>
-                )}
-                {codexConfig?.parse_error && (
-                  <p className="text-destructive">{codexConfig.parse_error}</p>
-                )}
-                {codexConfig && (
-                  <div className="grid gap-3 md:grid-cols-3">
-                    <div>
-                      <p className="text-xs text-muted-foreground">Model</p>
-                      <p className="font-medium">{codexConfig.summary.model ?? 'Default'}</p>
+            <div className="space-y-4">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Codex Config</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm">
+                  {!codexConfig?.exists && (
+                    <p className="text-muted-foreground">No ~/.codex/config.toml file found.</p>
+                  )}
+                  {codexConfig?.parse_error && (
+                    <p className="text-destructive">{codexConfig.parse_error}</p>
+                  )}
+                  {codexConfig && (
+                    <div className="grid gap-3 md:grid-cols-3">
+                      <div>
+                        <p className="text-xs text-muted-foreground">Model</p>
+                        <p className="font-medium">{codexConfig.summary.model ?? 'Default'}</p>
+                      </div>
+                      <div>
+                        <p className="text-xs text-muted-foreground">Reasoning</p>
+                        <p className="font-medium">{codexConfig.summary.model_reasoning_effort ?? 'Default'}</p>
+                      </div>
+                      <div>
+                        <p className="text-xs text-muted-foreground">Trusted Projects</p>
+                        <p className="font-medium">{Object.keys(codexConfig.summary.projects).length}</p>
+                      </div>
                     </div>
-                    <div>
-                      <p className="text-xs text-muted-foreground">Reasoning</p>
-                      <p className="font-medium">{codexConfig.summary.model_reasoning_effort ?? 'Default'}</p>
-                    </div>
-                    <div>
-                      <p className="text-xs text-muted-foreground">Trusted Projects</p>
-                      <p className="font-medium">{Object.keys(codexConfig.summary.projects).length}</p>
-                    </div>
-                  </div>
-                )}
-              </CardContent>
-            </Card>
+                  )}
+                </CardContent>
+              </Card>
+              <CodexDiagnosticsCard
+                doctor={codexDoctor}
+                loading={loading}
+                error={codexDoctorError}
+                onRefresh={fetchData}
+              />
+            </div>
           ) : (
             <SettingsEditor onSave={fetchData} />
           )}

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -1,17 +1,21 @@
-import { LayoutDashboard } from 'lucide-react'
+import { AlertCircle, Bot, CheckCircle2, LayoutDashboard, Terminal } from 'lucide-react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { RefreshButton } from '@/components/shared/RefreshButton'
 import { useNavigate } from 'react-router-dom'
 import { Progress } from '@/components/ui/progress'
+import { Badge } from '@/components/ui/badge'
 import { useDashboard } from '@/contexts/DashboardContext'
 import { useProjectContext } from '@/contexts/ProjectContext'
+import { useProviderContext } from '@/contexts/ProviderContext'
 import { getRelativeTime } from '@/features/usage/utils'
 
 export function DashboardPage() {
   const { stats, loading, error, lastFetched, refreshDashboard } = useDashboard({ autoFetch: true })
   const { projects } = useProjectContext()
+  const { providers, selectedProviderId, setSelectedProviderId } = useProviderContext()
   const navigate = useNavigate()
+  const installedProviderCount = providers.filter((provider) => provider.installed).length
 
   return (
     <div className="space-y-6">
@@ -22,7 +26,7 @@ export function DashboardPage() {
             Dashboard
           </h1>
           <p className="text-muted-foreground">
-            Overview of your Claude Code configuration
+            Overview of your local agent workspace
           </p>
         </div>
         <div className="flex items-center gap-3">
@@ -66,6 +70,79 @@ export function DashboardPage() {
           {/* Order matches sidebar navigation */}
 
           {/* Tier 1: Overview & Setup */}
+          <Card className="md:col-span-2 lg:col-span-3">
+            <CardHeader>
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <CardTitle className="flex items-center gap-2">
+                    <Bot className="h-5 w-5" />
+                    Agent Providers
+                  </CardTitle>
+                  <CardDescription>
+                    Claude Code and Codex CLI availability on this machine
+                  </CardDescription>
+                </div>
+                <Badge variant="outline">
+                  {installedProviderCount}/{providers.length} installed
+                </Badge>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="grid gap-3 md:grid-cols-2">
+                {providers.map((provider) => {
+                  const isSelected = provider.id === selectedProviderId
+                  return (
+                    <button
+                      key={provider.id}
+                      type="button"
+                      onClick={() => setSelectedProviderId(provider.id)}
+                      className={`rounded-md border p-4 text-left transition-colors hover:bg-accent ${
+                        isSelected ? 'border-primary bg-primary/5' : 'border-border'
+                      }`}
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="flex items-center gap-2">
+                            <Terminal className="h-4 w-4 shrink-0" />
+                            <p className="font-medium">{provider.display_name}</p>
+                            {isSelected && <Badge variant="secondary">Selected</Badge>}
+                          </div>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {provider.binary_path ?? provider.config_paths.home ?? 'Binary not found'}
+                          </p>
+                        </div>
+                        <Badge
+                          variant={provider.installed ? 'outline' : 'destructive'}
+                          className={provider.installed ? 'text-green-600 dark:text-green-400' : undefined}
+                        >
+                          {provider.installed ? (
+                            <CheckCircle2 className="mr-1 h-3 w-3" />
+                          ) : (
+                            <AlertCircle className="mr-1 h-3 w-3" />
+                          )}
+                          {provider.installed ? provider.version ?? 'Installed' : 'Missing'}
+                        </Badge>
+                      </div>
+                      <div className="mt-3 flex flex-wrap gap-1.5">
+                        {Object.entries(provider.capabilities)
+                          .filter(([, enabled]) => enabled)
+                          .slice(0, 7)
+                          .map(([capability]) => (
+                            <span
+                              key={capability}
+                              className="rounded border bg-background px-1.5 py-0.5 text-[11px] text-muted-foreground"
+                            >
+                              {capability}
+                            </span>
+                          ))}
+                      </div>
+                    </button>
+                  )
+                })}
+              </div>
+            </CardContent>
+          </Card>
+
           <Card>
             <CardHeader className="pb-2">
               <CardDescription>Projects</CardDescription>
@@ -93,55 +170,55 @@ export function DashboardPage() {
 
           <Card>
             <CardHeader className="pb-2">
-              <CardDescription>Commands</CardDescription>
+              <CardDescription>Claude Commands</CardDescription>
               <CardTitle className="text-3xl">{stats.commandCount}</CardTitle>
             </CardHeader>
             <CardContent>
               <p className="text-xs text-muted-foreground">
-                Slash commands available
+                Claude slash commands available
               </p>
             </CardContent>
           </Card>
 
           <Card>
             <CardHeader className="pb-2">
-              <CardDescription>Plugins</CardDescription>
+              <CardDescription>Claude Plugins</CardDescription>
               <CardTitle className="text-3xl">{stats.pluginCount}</CardTitle>
             </CardHeader>
             <CardContent>
               <p className="text-xs text-muted-foreground">
-                Installed plugins
+                Installed Claude plugins
               </p>
             </CardContent>
           </Card>
 
           <Card>
             <CardHeader className="pb-2">
-              <CardDescription>Hooks</CardDescription>
+              <CardDescription>Claude Hooks</CardDescription>
               <CardTitle className="text-3xl">{stats.hookCount}</CardTitle>
             </CardHeader>
             <CardContent>
               <p className="text-xs text-muted-foreground">
-                Automation hooks configured
+                Claude automation hooks configured
               </p>
             </CardContent>
           </Card>
 
           <Card>
             <CardHeader className="pb-2">
-              <CardDescription>Permissions</CardDescription>
+              <CardDescription>Claude Permissions</CardDescription>
               <CardTitle className="text-3xl">{stats.permissionCount}</CardTitle>
             </CardHeader>
             <CardContent>
               <p className="text-xs text-muted-foreground">
-                Permission rules
+                Claude permission rules
               </p>
             </CardContent>
           </Card>
 
           <Card>
             <CardHeader className="pb-2">
-              <CardDescription>Agents</CardDescription>
+              <CardDescription>Claude Agents</CardDescription>
               <CardTitle className="text-3xl">{stats.agentCount}</CardTitle>
             </CardHeader>
             <CardContent>
@@ -153,7 +230,7 @@ export function DashboardPage() {
 
           <Card>
             <CardHeader className="pb-2">
-              <CardDescription>Skills</CardDescription>
+              <CardDescription>Claude Skills</CardDescription>
               <CardTitle className="text-3xl">{stats.skillCount}</CardTitle>
             </CardHeader>
             <CardContent>
@@ -166,7 +243,7 @@ export function DashboardPage() {
           {/* Tier 3: Customization */}
           <Card>
             <CardHeader className="pb-2">
-              <CardDescription>Output Styles</CardDescription>
+              <CardDescription>Claude Output Styles</CardDescription>
               <CardTitle className="text-3xl">{stats.outputStyleCount}</CardTitle>
             </CardHeader>
             <CardContent>
@@ -179,7 +256,7 @@ export function DashboardPage() {
           {/* Tier 4: Monitoring */}
           <Card>
             <CardHeader className="pb-2">
-              <CardDescription>Sessions</CardDescription>
+              <CardDescription>Claude Session History</CardDescription>
               <CardTitle className="text-3xl">{stats.sessionCount}</CardTitle>
             </CardHeader>
             <CardContent>
@@ -219,7 +296,7 @@ export function DashboardPage() {
 
           <Card>
             <CardHeader className="pb-2">
-              <CardDescription>Context Window</CardDescription>
+              <CardDescription>Claude Context Window</CardDescription>
               <CardTitle className="text-3xl">
                 {stats.contextActiveCount > 0 ? `${stats.contextHighestPct.toFixed(0)}%` : '--'}
               </CardTitle>
@@ -260,7 +337,7 @@ export function DashboardPage() {
         <Card>
           <CardHeader>
             <CardTitle>Quick Status</CardTitle>
-            <CardDescription>Configuration health indicators</CardDescription>
+            <CardDescription>Claude Code configuration health indicators</CardDescription>
           </CardHeader>
           <CardContent>
             <div className="space-y-2">

--- a/frontend/src/hooks/useProviders.ts
+++ b/frontend/src/hooks/useProviders.ts
@@ -4,7 +4,9 @@ import type {
   AgentProviderId,
   AgentProviderStatus,
   CodexConfigUpdateRequest,
+  CodexMcpAddRequest,
   CodexMcpInventoryResponse,
+  CodexMcpMutationResponse,
   CodexPluginInventoryResponse,
   ProviderDoctorResponse,
   ProvidersResponse,
@@ -51,6 +53,19 @@ export async function updateCodexConfig(request: CodexConfigUpdateRequest): Prom
 
 export async function fetchCodexMcpInventory(): Promise<CodexMcpInventoryResponse> {
   return apiClient<CodexMcpInventoryResponse>('providers/codex-cli/mcp')
+}
+
+export async function addCodexMcpServer(request: CodexMcpAddRequest): Promise<CodexMcpMutationResponse> {
+  return apiClient<CodexMcpMutationResponse>('providers/codex-cli/mcp', {
+    method: 'POST',
+    body: JSON.stringify(request),
+  })
+}
+
+export async function removeCodexMcpServer(name: string): Promise<CodexMcpMutationResponse> {
+  return apiClient<CodexMcpMutationResponse>(`providers/codex-cli/mcp/${encodeURIComponent(name)}`, {
+    method: 'DELETE',
+  })
 }
 
 export async function fetchCodexPluginInventory(): Promise<CodexPluginInventoryResponse> {

--- a/frontend/src/hooks/useProviders.ts
+++ b/frontend/src/hooks/useProviders.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { apiClient } from '@/lib/api'
-import type { AgentProviderStatus, ProvidersResponse } from '@/types/providers'
+import type { AgentProviderId, AgentProviderStatus, ProviderDoctorResponse, ProvidersResponse } from '@/types/providers'
 
 const POLL_INTERVAL_MS = 60_000
 
@@ -30,3 +30,6 @@ export function useProviders() {
   return { providers, loading, error, refresh }
 }
 
+export async function fetchProviderDoctor(providerId: AgentProviderId): Promise<ProviderDoctorResponse> {
+  return apiClient<ProviderDoctorResponse>(`providers/${providerId}/doctor`)
+}

--- a/frontend/src/hooks/useProviders.ts
+++ b/frontend/src/hooks/useProviders.ts
@@ -4,6 +4,8 @@ import type {
   AgentProviderId,
   AgentProviderStatus,
   CodexConfigUpdateRequest,
+  CodexMcpInventoryResponse,
+  CodexPluginInventoryResponse,
   ProviderDoctorResponse,
   ProvidersResponse,
 } from '@/types/providers'
@@ -45,4 +47,12 @@ export async function updateCodexConfig(request: CodexConfigUpdateRequest): Prom
     method: 'PATCH',
     body: JSON.stringify(request),
   })
+}
+
+export async function fetchCodexMcpInventory(): Promise<CodexMcpInventoryResponse> {
+  return apiClient<CodexMcpInventoryResponse>('providers/codex-cli/mcp')
+}
+
+export async function fetchCodexPluginInventory(): Promise<CodexPluginInventoryResponse> {
+  return apiClient<CodexPluginInventoryResponse>('providers/codex-cli/plugins')
 }

--- a/frontend/src/hooks/useProviders.ts
+++ b/frontend/src/hooks/useProviders.ts
@@ -1,0 +1,32 @@
+import { useCallback, useEffect, useState } from 'react'
+import { apiClient } from '@/lib/api'
+import type { AgentProviderStatus, ProvidersResponse } from '@/types/providers'
+
+const POLL_INTERVAL_MS = 60_000
+
+export function useProviders() {
+  const [providers, setProviders] = useState<AgentProviderStatus[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await apiClient<ProvidersResponse>('providers')
+      setProviders(data.providers)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load providers')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    refresh()
+    const timer = setInterval(refresh, POLL_INTERVAL_MS)
+    return () => clearInterval(timer)
+  }, [refresh])
+
+  return { providers, loading, error, refresh }
+}
+

--- a/frontend/src/hooks/useProviders.ts
+++ b/frontend/src/hooks/useProviders.ts
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useState } from 'react'
 import { apiClient } from '@/lib/api'
-import type { AgentProviderId, AgentProviderStatus, ProviderDoctorResponse, ProvidersResponse } from '@/types/providers'
+import type {
+  AgentProviderId,
+  AgentProviderStatus,
+  CodexConfigUpdateRequest,
+  ProviderDoctorResponse,
+  ProvidersResponse,
+} from '@/types/providers'
 
 const POLL_INTERVAL_MS = 60_000
 
@@ -32,4 +38,11 @@ export function useProviders() {
 
 export async function fetchProviderDoctor(providerId: AgentProviderId): Promise<ProviderDoctorResponse> {
   return apiClient<ProviderDoctorResponse>(`providers/${providerId}/doctor`)
+}
+
+export async function updateCodexConfig(request: CodexConfigUpdateRequest): Promise<unknown> {
+  return apiClient('codex-config', {
+    method: 'PATCH',
+    body: JSON.stringify(request),
+  })
 }

--- a/frontend/src/hooks/useSystemStatus.ts
+++ b/frontend/src/hooks/useSystemStatus.ts
@@ -5,12 +5,14 @@ import type { SystemStatusResponse } from '@/types/status'
 interface SystemStatus {
   claudeCodeVersion: string | null
   activeSessions: number
+  providers: SystemStatusResponse['providers']
 }
 
 function parseStatus(res: SystemStatusResponse): SystemStatus {
   return {
     claudeCodeVersion: res.claude_code_version,
     activeSessions: res.active_sessions,
+    providers: res.providers ?? {},
   }
 }
 

--- a/frontend/src/types/backup.ts
+++ b/frontend/src/types/backup.ts
@@ -1,6 +1,6 @@
 // Backup TypeScript types matching backend schemas
 
-export type BackupScope = "full" | "user" | "project";
+export type BackupScope = "full" | "user" | "project" | "codex";
 
 export interface Backup {
   id: number;
@@ -76,6 +76,7 @@ export interface BackupManifestContents {
   mcp_servers: BackupMCPServerInfo[];
   agents: string[];
   commands: string[];
+  provider_inventory?: Record<string, unknown>;
 }
 
 export interface BackupManifest {
@@ -222,6 +223,11 @@ export const BACKUP_SCOPES = [
     value: "project" as BackupScope,
     label: "Project",
     description: "Settings in .claude/",
+  },
+  {
+    value: "codex" as BackupScope,
+    label: "Codex",
+    description: "Redacted Codex config, profiles, rules, and inventory",
   },
 ];
 

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -2,9 +2,10 @@ export type ConfigValue = string | number | boolean | null | ConfigValue[] | { [
 
 export interface ConfigFile {
   path: string
-  scope: 'user' | 'project' | 'managed'
+  scope: 'user' | 'project' | 'managed' | 'profile' | 'rules'
   exists: boolean
   content?: Record<string, ConfigValue>
+  provider?: string
 }
 
 export interface ConfigFileListResponse {

--- a/frontend/src/types/providers.ts
+++ b/frontend/src/types/providers.ts
@@ -1,0 +1,35 @@
+export type AgentProviderId = 'claude-code' | 'codex-cli'
+
+export interface AgentProviderCapabilities {
+  sessions: boolean
+  spawn: boolean
+  resume: boolean
+  fork: boolean
+  mcp: boolean
+  plugins: boolean
+  commands: boolean
+  agents: boolean
+  skills: boolean
+  hooks: boolean
+  memory: boolean
+  usage: boolean
+  context: boolean
+  doctor: boolean
+}
+
+export interface AgentProviderStatus {
+  id: AgentProviderId
+  display_name: string
+  binary_name: string
+  installed: boolean
+  binary_path: string | null
+  version: string | null
+  capabilities: AgentProviderCapabilities
+  config_paths: Record<string, string>
+}
+
+export interface ProvidersResponse {
+  providers: AgentProviderStatus[]
+  count: number
+}
+

--- a/frontend/src/types/providers.ts
+++ b/frontend/src/types/providers.ts
@@ -99,6 +99,24 @@ export interface CodexMcpInventoryResponse {
   raw_stdout: string
 }
 
+export interface CodexMcpAddRequest {
+  name: string
+  command?: string
+  args?: string[]
+  env?: Record<string, string>
+  url?: string
+  bearer_token_env_var?: string
+}
+
+export interface CodexMcpMutationResponse {
+  provider: 'codex-cli'
+  provider_display_name: string
+  name: string
+  stdout: string
+  stderr: string
+  exit_code: number
+}
+
 export interface CodexPluginInventoryRow {
   name: string
   status?: string

--- a/frontend/src/types/providers.ts
+++ b/frontend/src/types/providers.ts
@@ -61,3 +61,30 @@ export interface ProviderDoctorResponse {
   parse_error: string | null
   stderr: string
 }
+
+export interface CodexConfigSummary {
+  model?: string
+  model_reasoning_effort?: string
+  profile?: string
+  sandbox_mode?: string
+  approval_policy?: string
+  search?: boolean
+  strict_config?: boolean
+  no_alt_screen?: boolean
+  projects: Record<string, { trust_level?: string }>
+  profiles: Record<string, unknown>
+  features: Record<string, boolean>
+}
+
+export interface CodexConfigResponse {
+  provider: 'codex-cli'
+  path: string
+  exists: boolean
+  parse_error: string | null
+  summary: CodexConfigSummary
+}
+
+export interface CodexConfigUpdateRequest {
+  settings?: Record<string, string | boolean | null>
+  features?: Record<string, boolean | null>
+}

--- a/frontend/src/types/providers.ts
+++ b/frontend/src/types/providers.ts
@@ -88,3 +88,29 @@ export interface CodexConfigUpdateRequest {
   settings?: Record<string, string | boolean | null>
   features?: Record<string, boolean | null>
 }
+
+export interface CodexMcpInventoryResponse {
+  provider: 'codex-cli'
+  provider_display_name: string
+  exit_code: number
+  servers: unknown
+  parse_error: string | null
+  stderr: string
+  raw_stdout: string
+}
+
+export interface CodexPluginInventoryRow {
+  name: string
+  status?: string
+  version?: string
+  path?: string
+}
+
+export interface CodexPluginInventoryResponse {
+  provider: 'codex-cli'
+  provider_display_name: string
+  exit_code: number
+  plugins: CodexPluginInventoryRow[]
+  stderr: string
+  raw_stdout: string
+}

--- a/frontend/src/types/providers.ts
+++ b/frontend/src/types/providers.ts
@@ -33,3 +33,31 @@ export interface ProvidersResponse {
   count: number
 }
 
+export type ProviderDoctorStatus = 'ok' | 'warn' | 'error' | 'unknown' | string
+
+export interface ProviderDoctorCheck {
+  id: string
+  category: string
+  status: ProviderDoctorStatus
+  summary: string
+  details?: Record<string, unknown>
+  remediation?: string | null
+  durationMs?: number
+}
+
+export interface ProviderDoctorReport {
+  schemaVersion?: number
+  generatedAt?: string
+  overallStatus?: ProviderDoctorStatus
+  codexVersion?: string
+  checks?: Record<string, ProviderDoctorCheck>
+}
+
+export interface ProviderDoctorResponse {
+  provider: AgentProviderId
+  provider_display_name: string
+  exit_code: number
+  report: ProviderDoctorReport | null
+  parse_error: string | null
+  stderr: string
+}

--- a/frontend/src/types/status.ts
+++ b/frontend/src/types/status.ts
@@ -1,4 +1,7 @@
+import type { AgentProviderStatus } from './providers'
+
 export interface SystemStatusResponse {
   claude_code_version: string | null
   active_sessions: number
+  providers?: Record<string, AgentProviderStatus>
 }


### PR DESCRIPTION
## Summary
- Add provider-aware Claude Code/Codex CLI registry, status, CLI executor, and Agent Bridge routes
- Add Codex tmux discovery/spawn/resume/fork support, editable TOML settings, diagnostics, MCP mutation, plugin inventory, and export-only backups
- Rework provider-aware UI surfaces, sidebar/dashboard/header polish, and docs for Agent Bridge/Codex support
- Harden Codex redaction and raw file access before merge

## Verification
- backend/venv/bin/python -m pytest
- npm run build (frontend)
- npm run build (docs)
- git diff --check