### PR TITLE
Improve mixed-provider Agent Bridge UX

### DIFF
--- a/backend/app/services/providers/base.py
+++ b/backend/app/services/providers/base.py
@@ -101,6 +101,15 @@ class AgentProvider(ABC):
     def get_capabilities(self) -> dict[str, bool]:
         """Return provider feature support flags."""
 
+    def get_capability_details(self) -> dict[str, dict[str, str]]:
+        """Return richer capability metadata for UI/action state."""
+        return {
+            name: {
+                "state": "write_capable" if enabled else "unsupported",
+            }
+            for name, enabled in self.get_capabilities().items()
+        }
+
     @abstractmethod
     def get_config_paths(self, project_path: str | None = None) -> dict[str, Any]:
         """Return important config paths for this provider."""
@@ -149,6 +158,6 @@ class AgentProvider(ABC):
             "binary_path": binary_path,
             "version": version,
             "capabilities": self.get_capabilities(),
+            "capability_details": self.get_capability_details(),
             "config_paths": self.get_config_paths(),
         }
-

--- a/backend/app/services/providers/claude_code.py
+++ b/backend/app/services/providers/claude_code.py
@@ -36,6 +36,19 @@ class ClaudeCodeProvider(AgentProvider):
             "doctor": False,
         }
 
+    def get_capability_details(self) -> dict[str, dict[str, str]]:
+        details = super().get_capability_details()
+        details.update({
+            "sessions": {"state": "write_capable", "label": "tmux sessions"},
+            "spawn": {"state": "write_capable", "label": "new sessions"},
+            "resume": {"state": "write_capable", "label": "resume transcript"},
+            "fork": {"state": "unsupported", "reason": "Claude Code fork mode is not exposed"},
+            "mcp": {"state": "write_capable", "label": "MCP servers"},
+            "plugins": {"state": "write_capable", "label": "plugins"},
+            "doctor": {"state": "unsupported", "reason": "Claude Code does not expose provider doctor diagnostics"},
+        })
+        return details
+
     def get_config_paths(self, project_path: str | None = None) -> dict:
         paths = ClaudePathUtils()
         result = {

--- a/backend/app/services/providers/codex_cli.py
+++ b/backend/app/services/providers/codex_cli.py
@@ -41,6 +41,26 @@ class CodexCliProvider(AgentProvider):
             "doctor": True,
         }
 
+    def get_capability_details(self) -> dict[str, dict[str, str]]:
+        details = super().get_capability_details()
+        details.update({
+            "sessions": {"state": "write_capable", "label": "tmux sessions"},
+            "spawn": {"state": "write_capable", "label": "new sessions"},
+            "resume": {"state": "write_capable", "label": "resume session"},
+            "fork": {"state": "write_capable", "label": "fork session"},
+            "mcp": {"state": "write_capable", "label": "MCP servers"},
+            "plugins": {"state": "read_only", "label": "plugin inventory"},
+            "commands": {"state": "unsupported", "reason": "Codex command files are not modeled yet"},
+            "agents": {"state": "unsupported", "reason": "Codex agent files are not modeled yet"},
+            "skills": {"state": "unsupported", "reason": "Codex skills are not modeled yet"},
+            "hooks": {"state": "unsupported", "reason": "Codex hooks are not modeled yet"},
+            "memory": {"state": "unsupported", "reason": "Codex memory is not modeled yet"},
+            "usage": {"state": "unsupported", "reason": "Codex usage data is not available yet"},
+            "context": {"state": "unsupported", "reason": "Codex context metrics are not available yet"},
+            "doctor": {"state": "read_only", "label": "doctor diagnostics"},
+        })
+        return details
+
     def get_config_paths(self, project_path: str | None = None) -> dict:
         home = get_codex_home()
         return {

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -13,6 +13,22 @@ def test_provider_registry_contains_initial_providers():
     assert get_provider("codex-cli").binary_name == "codex"
 
 
+def test_provider_status_includes_capability_details():
+    from app.services.providers import get_provider
+
+    claude_status = get_provider("claude-code").get_status()
+    codex_status = get_provider("codex-cli").get_status()
+
+    assert claude_status["capabilities"]["spawn"] is True
+    assert claude_status["capability_details"]["spawn"]["state"] == "write_capable"
+    assert claude_status["capability_details"]["fork"]["state"] == "unsupported"
+
+    assert codex_status["capabilities"]["plugins"] is True
+    assert codex_status["capability_details"]["plugins"]["state"] == "read_only"
+    assert codex_status["capability_details"]["doctor"]["state"] == "read_only"
+    assert codex_status["capability_details"]["usage"]["state"] == "unsupported"
+
+
 def test_codex_process_detection_matches_interactive_binary():
     from app.services.providers import get_provider
 
@@ -31,4 +47,3 @@ def test_codex_process_detection_matches_node_wrapper_descendant():
     with patch("app.services.providers.base.subprocess.run") as run:
         run.return_value = SimpleNamespace(stdout="456 /usr/local/bin/codex\n")
         assert provider.is_process_match("node", "123") is True
-

--- a/frontend/src/features/cc-bridge/CCBridgePage.tsx
+++ b/frontend/src/features/cc-bridge/CCBridgePage.tsx
@@ -7,10 +7,17 @@ import { TerminalView } from './TerminalView'
 import { NewSessionDialog } from './NewSessionDialog'
 import { KillSessionDialog } from './KillSessionDialog'
 import type { CCSession } from './types'
-import type { AgentProviderId } from '@/types/providers'
+import { useProviderContext } from '@/contexts/ProviderContext'
+import type { AgentProviderId, AgentProviderStatus } from '@/types/providers'
 
 const MAX_GRID_PANES = 4
 type ProviderFilter = 'all' | AgentProviderId
+
+const PROVIDER_FILTERS: { value: ProviderFilter; label: string }[] = [
+  { value: 'all', label: 'All agents' },
+  { value: 'claude-code', label: 'Claude Code' },
+  { value: 'codex-cli', label: 'Codex' },
+]
 
 function addTarget(prev: string[], target: string): string[] {
   if (prev.includes(target)) return prev
@@ -20,9 +27,8 @@ function addTarget(prev: string[], target: string): string[] {
 
 export function CCBridgePage() {
   const [providerFilter, setProviderFilter] = useState<ProviderFilter>('all')
-  const { sessions, loading, error, refresh } = useCCSessions(
-    providerFilter === 'all' ? undefined : providerFilter,
-  )
+  const { providers, selectedProviderId } = useProviderContext()
+  const { sessions, loading, error, refresh } = useCCSessions()
   const [activeTargets, setActiveTargets] = useState<string[]>([])
   const [fullscreenTarget, setFullscreenTarget] = useState<string | null>(null)
   const [focusedTarget, setFocusedTarget] = useState<string | null>(null)
@@ -30,6 +36,42 @@ export function CCBridgePage() {
   const [killSession, setKillSession] = useState<CCSession | null>(null)
 
   const isFullscreen = fullscreenTarget !== null
+  const visibleSessions = providerFilter === 'all'
+    ? sessions
+    : sessions.filter((session) => session.provider === providerFilter)
+
+  const providersById = providers.reduce<Partial<Record<AgentProviderId, AgentProviderStatus>>>((acc, provider) => {
+    acc[provider.id] = provider
+    return acc
+  }, {})
+
+  const canProviderSpawn = (provider: AgentProviderStatus | undefined) => (
+    Boolean(provider?.installed)
+    && provider?.capability_details?.spawn?.state !== 'unsupported'
+    && provider?.capability_details?.spawn?.state !== 'read_only'
+    && provider?.capabilities.spawn === true
+  )
+
+  const selectedFilterProvider = providerFilter === 'all' ? null : providersById[providerFilter]
+  const canCreateSession = providerFilter === 'all'
+    ? providers.some(canProviderSpawn)
+    : canProviderSpawn(selectedFilterProvider ?? undefined)
+  const createDisabledReason = providerFilter === 'all'
+    ? 'No installed provider can launch sessions.'
+    : !selectedFilterProvider
+      ? 'Provider metadata is not available.'
+      : !selectedFilterProvider.installed
+        ? `${selectedFilterProvider.display_name} is not installed.`
+        : selectedFilterProvider.capability_details?.spawn?.reason
+          ?? `${selectedFilterProvider.display_name} cannot launch sessions from Agent Bridge.`
+
+  const filterCounts: Record<ProviderFilter, number> = {
+    all: sessions.length,
+    'claude-code': sessions.filter((session) => session.provider === 'claude-code').length,
+    'codex-cli': sessions.filter((session) => session.provider === 'codex-cli').length,
+  }
+
+  const initialDialogProvider = providerFilter === 'all' ? selectedProviderId : providerFilter
 
   useEffect(() => {
     if (!isFullscreen) return
@@ -84,11 +126,7 @@ export function CCBridgePage() {
             </span>
           </div>
           <div className="ml-auto flex rounded-md bg-background border p-0.5 shrink-0">
-            {[
-              ['all', 'All agents'],
-              ['claude-code', 'Claude Code'],
-              ['codex-cli', 'Codex'],
-            ].map(([value, label]) => (
+            {PROVIDER_FILTERS.map(({ value, label }) => (
               <button
                 key={value}
                 type="button"
@@ -98,9 +136,9 @@ export function CCBridgePage() {
                     ? 'bg-primary text-primary-foreground'
                     : 'text-muted-foreground hover:text-foreground'
                 )}
-                onClick={() => setProviderFilter(value as ProviderFilter)}
+                onClick={() => setProviderFilter(value)}
               >
-                {label}
+                {label} <span className="opacity-70">({filterCounts[value]})</span>
               </button>
             ))}
           </div>
@@ -111,7 +149,7 @@ export function CCBridgePage() {
         {!isFullscreen && (
           <div className="w-52 border-r shrink-0">
             <SessionList
-              sessions={sessions}
+              sessions={visibleSessions}
               loading={loading}
               error={error}
               activeTargets={activeTargets}
@@ -120,6 +158,8 @@ export function CCBridgePage() {
               onNewSession={() => setNewSessionOpen(true)}
               onKillSession={setKillSession}
               providerFilter={providerFilter}
+              canCreateSession={canCreateSession}
+              createDisabledReason={canCreateSession ? null : createDisabledReason}
             />
           </div>
         )}
@@ -176,6 +216,7 @@ export function CCBridgePage() {
         open={newSessionOpen}
         onOpenChange={setNewSessionOpen}
         onSpawned={handleSpawned}
+        initialProvider={initialDialogProvider}
       />
 
       <KillSessionDialog

--- a/frontend/src/features/cc-bridge/NewSessionDialog.tsx
+++ b/frontend/src/features/cc-bridge/NewSessionDialog.tsx
@@ -35,6 +35,7 @@ interface NewSessionDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   onSpawned: (tmuxTarget: string) => void
+  initialProvider?: AgentProviderId
 }
 
 const MODE_OPTIONS: { value: Mode; label: string }[] = [
@@ -49,9 +50,10 @@ const CODEX_MODE_OPTIONS: { value: Mode; label: string }[] = [
   { value: 'fork', label: 'Fork' },
 ]
 
-export function NewSessionDialog({ open, onOpenChange, onSpawned }: NewSessionDialogProps) {
+export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvider }: NewSessionDialogProps) {
   const { providers, selectedProviderId } = useProviderContext()
-  const [provider, setProvider] = useState<AgentProviderId>(selectedProviderId)
+  const defaultProvider = initialProvider ?? selectedProviderId
+  const [provider, setProvider] = useState<AgentProviderId>(defaultProvider)
   const [directory, setDirectory] = useState('')
   const [mode, setMode] = useState<Mode>('plain')
   const [worktreeName, setWorktreeName] = useState('')
@@ -94,7 +96,7 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned }: NewSessionDi
   useEffect(() => {
     if (!open) {
       setDirectory('')
-      setProvider(selectedProviderId)
+      setProvider(defaultProvider)
       setMode('plain')
       setWorktreeName('')
       setSkipPermissions(false)
@@ -113,7 +115,7 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned }: NewSessionDi
       setRecentSessions([])
       setSubmitting(false)
     }
-  }, [open, selectedProviderId])
+  }, [open, defaultProvider])
 
   const canLaunch = (() => {
     if (submitting) return false

--- a/frontend/src/features/cc-bridge/SessionList.tsx
+++ b/frontend/src/features/cc-bridge/SessionList.tsx
@@ -17,6 +17,8 @@ interface SessionListProps {
   onNewSession: () => void
   onKillSession: (session: CCSession) => void
   providerFilter: ProviderFilter
+  canCreateSession: boolean
+  createDisabledReason: string | null
 }
 
 export function SessionList({
@@ -29,10 +31,16 @@ export function SessionList({
   onNewSession,
   onKillSession,
   providerFilter,
+  canCreateSession,
+  createDisabledReason,
 }: SessionListProps) {
   const emptyName = providerFilter === 'all'
     ? 'agent'
     : providerFilter === 'codex-cli' ? 'Codex' : 'Claude Code'
+  const emptyHint = createDisabledReason
+    ?? (providerFilter === 'all'
+      ? 'Launch or start a supported CLI in tmux.'
+      : `Launch ${emptyName} from Agent Bridge or start it in tmux.`)
 
   return (
     <div className="flex flex-col h-full">
@@ -41,7 +49,14 @@ export function SessionList({
           Sessions ({sessions.length})
         </span>
         <div className="flex items-center gap-0.5">
-          <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onNewSession} title="New session">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={onNewSession}
+            disabled={!canCreateSession}
+            title={createDisabledReason ?? 'New session'}
+          >
             <Plus className="h-3.5 w-3.5" />
           </Button>
           <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onRefresh} title="Refresh">
@@ -65,7 +80,7 @@ export function SessionList({
           <div className="flex flex-col items-center justify-center py-8 text-muted-foreground">
             <MonitorX className="h-8 w-8 mb-2" />
             <p className="text-sm">No {emptyName} sessions found</p>
-            <p className="text-xs mt-1">Start a supported CLI in tmux</p>
+            <p className="text-xs mt-1 text-center px-3">{emptyHint}</p>
           </div>
         )}
 

--- a/frontend/src/types/providers.ts
+++ b/frontend/src/types/providers.ts
@@ -17,6 +17,14 @@ export interface AgentProviderCapabilities {
   doctor: boolean
 }
 
+export type AgentProviderCapabilityState = 'supported' | 'read_only' | 'write_capable' | 'unsupported' | 'unknown'
+
+export interface AgentProviderCapabilityDetail {
+  state: AgentProviderCapabilityState
+  label?: string
+  reason?: string
+}
+
 export interface AgentProviderStatus {
   id: AgentProviderId
   display_name: string
@@ -25,6 +33,7 @@ export interface AgentProviderStatus {
   binary_path: string | null
   version: string | null
   capabilities: AgentProviderCapabilities
+  capability_details?: Partial<Record<keyof AgentProviderCapabilities, AgentProviderCapabilityDetail>>
   config_paths: Record<string, string>
 }
 


### PR DESCRIPTION
## Summary
- Add non-breaking provider `capability_details` metadata for richer UI action states
- Keep Agent Bridge session discovery mixed by default and filter client-side with All / Claude Code / Codex counts
- Disable new-session actions with provider-aware reasons when a selected provider cannot spawn sessions
- Seed the new-session dialog from the selected Agent Bridge provider filter

## Related
- Starts the first implementation slice from #142
- Follows the v2 planning PR #141

## Verification
- `PYTHONPATH=backend /home/joni/repos/claude-deck/backend/venv/bin/python -m pytest backend/tests/test_providers.py backend/tests/test_agent_bridge_discovery.py`
- `PYTHONPATH=backend /home/joni/repos/claude-deck/backend/venv/bin/python - <<'PY' ... import app.main ... PY`
- `npx eslint src/features/cc-bridge/CCBridgePage.tsx src/features/cc-bridge/SessionList.tsx src/features/cc-bridge/NewSessionDialog.tsx src/types/providers.ts`
- `npm run build` in `frontend/`
- `git diff --check`