### PR TITLE
Add Codex history diagnostics

### DIFF
--- a/backend/app/api/v1/providers.py
+++ b/backend/app/api/v1/providers.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from app.models.schemas import CLIExecuteRequest, CLIResult
 from app.services.cli_executor import ProviderCLIExecutor
+from app.services.codex_history_service import CodexHistoryService
 from app.services.providers import get_provider, get_providers
 
 router = APIRouter()
@@ -379,4 +380,15 @@ def get_provider_plugin_inventory(provider_id: str):
         "plugins": _redact_value(_parse_plugin_rows(result.stdout)),
         "stderr": _redact_value(result.stderr),
         "raw_stdout": safe_stdout,
+    }
+
+
+@router.get("/providers/{provider_id}/history-diagnostics")
+def get_provider_history_diagnostics(provider_id: str):
+    provider = _require_codex_provider(provider_id)
+    diagnostics = CodexHistoryService().get_diagnostics()
+    return {
+        "provider": provider.id,
+        "provider_display_name": provider.display_name,
+        **diagnostics,
     }

--- a/backend/app/services/codex_history_service.py
+++ b/backend/app/services/codex_history_service.py
@@ -1,0 +1,246 @@
+"""Read-only diagnostics for Codex history and model cache files."""
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from app.services.providers.codex_cli import get_codex_home
+
+
+class CodexHistoryService:
+    """Summarize generated Codex files without exposing prompt text."""
+
+    def __init__(
+        self,
+        codex_home: Path | None = None,
+        *,
+        max_history_rows: int = 50_000,
+        max_model_cache_bytes: int = 5 * 1024 * 1024,
+    ):
+        self.codex_home = codex_home or get_codex_home()
+        self.max_history_rows = max_history_rows
+        self.max_model_cache_bytes = max_model_cache_bytes
+
+    @property
+    def history_file(self) -> Path:
+        return self.codex_home / "history.jsonl"
+
+    @property
+    def models_cache_file(self) -> Path:
+        return self.codex_home / "models_cache.json"
+
+    def get_diagnostics(self) -> dict[str, Any]:
+        return {
+            "provider": "codex-cli",
+            "decision": {
+                "surface": "diagnostics_only",
+                "reason": (
+                    "Codex history currently exposes session_id, ts, and sensitive prompt text. "
+                    "Claude Deck summarizes structure only until stable non-sensitive history "
+                    "metadata is available."
+                ),
+            },
+            "history": self.summarize_history(),
+            "models_cache": self.summarize_models_cache(),
+        }
+
+    def summarize_history(self) -> dict[str, Any]:
+        path = self.history_file
+        summary: dict[str, Any] = {
+            "path": str(path),
+            "exists": path.exists(),
+            "size_bytes": None,
+            "max_rows": self.max_history_rows,
+            "rows_read": 0,
+            "valid_rows": 0,
+            "invalid_rows": 0,
+            "truncated": False,
+            "observed_keys": [],
+            "sensitive_fields_omitted": [],
+            "session_id_rows": 0,
+            "unique_session_count": 0,
+            "ts_rows": 0,
+            "first_ts": None,
+            "last_ts": None,
+            "text_rows": 0,
+            "latest_session_summaries": [],
+            "read_error": None,
+        }
+        if not path.exists():
+            return summary
+
+        try:
+            summary["size_bytes"] = path.stat().st_size
+            observed_keys: set[str] = set()
+            session_ids: set[str] = set()
+            sessions: dict[str, dict[str, Any]] = {}
+            first_key: float | None = None
+            last_key: float | None = None
+
+            with path.open("r", encoding="utf-8", errors="replace") as file:
+                for raw_line in file:
+                    if not raw_line.strip():
+                        continue
+                    if summary["rows_read"] >= self.max_history_rows:
+                        summary["truncated"] = True
+                        break
+
+                    summary["rows_read"] += 1
+                    try:
+                        row = json.loads(raw_line)
+                    except json.JSONDecodeError:
+                        summary["invalid_rows"] += 1
+                        continue
+
+                    if not isinstance(row, dict):
+                        summary["invalid_rows"] += 1
+                        continue
+
+                    summary["valid_rows"] += 1
+                    observed_keys.update(str(key) for key in row.keys())
+                    if isinstance(row.get("text"), str):
+                        summary["text_rows"] += 1
+
+                    session_id = row.get("session_id")
+                    if isinstance(session_id, str) and session_id:
+                        summary["session_id_rows"] += 1
+                        session_ids.add(session_id)
+
+                    ts = row.get("ts")
+                    ts_key = self._timestamp_key(ts)
+                    if ts_key is not None:
+                        summary["ts_rows"] += 1
+                        if first_key is None or ts_key < first_key:
+                            first_key = ts_key
+                            summary["first_ts"] = ts
+                        if last_key is None or ts_key > last_key:
+                            last_key = ts_key
+                            summary["last_ts"] = ts
+
+                    if isinstance(session_id, str) and session_id:
+                        session = sessions.setdefault(
+                            session_id,
+                            {
+                                "session_id_hash": self._hash_session_id(session_id),
+                                "message_count": 0,
+                                "first_ts": None,
+                                "last_ts": None,
+                                "_first_key": None,
+                                "_last_key": None,
+                            },
+                        )
+                        session["message_count"] += 1
+                        if ts_key is not None:
+                            if session["_first_key"] is None or ts_key < session["_first_key"]:
+                                session["_first_key"] = ts_key
+                                session["first_ts"] = ts
+                            if session["_last_key"] is None or ts_key > session["_last_key"]:
+                                session["_last_key"] = ts_key
+                                session["last_ts"] = ts
+
+            summary["observed_keys"] = sorted(observed_keys)
+            if "text" in observed_keys:
+                summary["sensitive_fields_omitted"] = ["text"]
+            summary["unique_session_count"] = len(session_ids)
+            latest_sessions = sorted(
+                sessions.values(),
+                key=lambda item: item["_last_key"] if item["_last_key"] is not None else -1,
+                reverse=True,
+            )
+            summary["latest_session_summaries"] = [
+                {
+                    "session_id_hash": session["session_id_hash"],
+                    "message_count": session["message_count"],
+                    "first_ts": session["first_ts"],
+                    "last_ts": session["last_ts"],
+                }
+                for session in latest_sessions[:10]
+            ]
+        except OSError as exc:
+            summary["read_error"] = str(exc)
+
+        return summary
+
+    def summarize_models_cache(self) -> dict[str, Any]:
+        path = self.models_cache_file
+        summary: dict[str, Any] = {
+            "path": str(path),
+            "exists": path.exists(),
+            "size_bytes": None,
+            "max_bytes": self.max_model_cache_bytes,
+            "too_large": False,
+            "parse_error": None,
+            "root_keys": [],
+            "fetched_at": None,
+            "client_version": None,
+            "etag_present": False,
+            "models_shape": None,
+            "model_count": None,
+            "raw_fields_omitted": [],
+        }
+        if not path.exists():
+            return summary
+
+        try:
+            size = path.stat().st_size
+            summary["size_bytes"] = size
+            if size > self.max_model_cache_bytes:
+                summary["too_large"] = True
+                summary["parse_error"] = "models_cache.json exceeds diagnostics read limit"
+                return summary
+
+            with path.open("r", encoding="utf-8") as file:
+                data = json.load(file)
+        except json.JSONDecodeError as exc:
+            summary["parse_error"] = str(exc)
+            return summary
+        except OSError as exc:
+            summary["parse_error"] = str(exc)
+            return summary
+
+        if not isinstance(data, dict):
+            summary["parse_error"] = "models_cache.json root is not an object"
+            return summary
+
+        summary["root_keys"] = sorted(str(key) for key in data.keys())
+        summary["fetched_at"] = data.get("fetched_at") if isinstance(data.get("fetched_at"), str) else None
+        summary["client_version"] = (
+            data.get("client_version") if isinstance(data.get("client_version"), str) else None
+        )
+        summary["etag_present"] = bool(data.get("etag"))
+        models = data.get("models")
+        if isinstance(models, list):
+            summary["models_shape"] = "list"
+            summary["model_count"] = len(models)
+        elif isinstance(models, dict):
+            summary["models_shape"] = "object"
+            summary["model_count"] = len(models)
+        elif models is not None:
+            summary["models_shape"] = type(models).__name__
+        omitted = [key for key in ("etag", "models") if key in data]
+        summary["raw_fields_omitted"] = omitted
+        return summary
+
+    @staticmethod
+    def _hash_session_id(session_id: str) -> str:
+        return hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:16]
+
+    @staticmethod
+    def _timestamp_key(value: Any) -> float | None:
+        if isinstance(value, bool) or value is None:
+            return None
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, str):
+            try:
+                return float(value)
+            except ValueError:
+                pass
+            try:
+                return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+            except ValueError:
+                return None
+        return None

--- a/backend/tests/test_codex_history_service.py
+++ b/backend/tests/test_codex_history_service.py
@@ -1,0 +1,133 @@
+"""Tests for read-only Codex history and model cache diagnostics."""
+
+import json
+
+
+def test_codex_history_diagnostics_omit_history_text_and_summarize_sessions(tmp_path):
+    from app.services.codex_history_service import CodexHistoryService
+
+    text_sentinel = "TEXT_FIELD_SENTINEL_SHOULD_NOT_RETURN"
+    rows = [
+        {"session_id": "session-a", "ts": 100, "text": text_sentinel},
+        {"session_id": "session-a", "ts": 110, "text": "TEXT_FIELD_SENTINEL_TWO"},
+        {"session_id": "session-b", "ts": 120, "text": "TEXT_FIELD_SENTINEL_THREE"},
+    ]
+    (tmp_path / "history.jsonl").write_text(
+        "\n".join(json.dumps(row) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "models_cache.json").write_text(
+        json.dumps({
+            "fetched_at": "2026-05-26T12:00:00Z",
+            "etag": "opaque-cache-validator",
+            "client_version": "0.133.0",
+            "models": [{"id": "gpt-5"}],
+        }),
+        encoding="utf-8",
+    )
+
+    diagnostics = CodexHistoryService(codex_home=tmp_path).get_diagnostics()
+    serialized = json.dumps(diagnostics)
+
+    assert diagnostics["decision"]["surface"] == "diagnostics_only"
+    assert diagnostics["history"]["valid_rows"] == 3
+    assert diagnostics["history"]["unique_session_count"] == 2
+    assert diagnostics["history"]["first_ts"] == 100
+    assert diagnostics["history"]["last_ts"] == 120
+    assert diagnostics["history"]["sensitive_fields_omitted"] == ["text"]
+    assert diagnostics["history"]["latest_session_summaries"][0]["session_id_hash"]
+    assert "session-a" not in serialized
+    assert text_sentinel not in serialized
+    assert "TEXT_FIELD_SENTINEL_TWO" not in serialized
+    assert diagnostics["models_cache"]["model_count"] == 1
+    assert diagnostics["models_cache"]["etag_present"] is True
+    assert "opaque-cache-validator" not in serialized
+    assert "gpt-5" not in serialized
+
+
+def test_codex_history_diagnostics_handle_missing_files(tmp_path):
+    from app.services.codex_history_service import CodexHistoryService
+
+    diagnostics = CodexHistoryService(codex_home=tmp_path).get_diagnostics()
+
+    assert diagnostics["history"]["exists"] is False
+    assert diagnostics["history"]["valid_rows"] == 0
+    assert diagnostics["models_cache"]["exists"] is False
+    assert diagnostics["models_cache"]["model_count"] is None
+
+
+def test_codex_history_diagnostics_handle_malformed_files(tmp_path):
+    from app.services.codex_history_service import CodexHistoryService
+
+    (tmp_path / "history.jsonl").write_text(
+        '{"session_id":"ok","ts":1,"text":"TEXT_FIELD_SENTINEL"}\n'
+        "{not-json}\n"
+        '["not", "object"]\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "models_cache.json").write_text("{not-json}", encoding="utf-8")
+
+    diagnostics = CodexHistoryService(codex_home=tmp_path).get_diagnostics()
+
+    assert diagnostics["history"]["valid_rows"] == 1
+    assert diagnostics["history"]["invalid_rows"] == 2
+    assert diagnostics["models_cache"]["parse_error"]
+
+
+def test_codex_history_diagnostics_truncate_large_history_and_cache(tmp_path):
+    from app.services.codex_history_service import CodexHistoryService
+
+    rows = [
+        {"session_id": f"session-{index}", "ts": index, "text": f"TEXT_FIELD_SENTINEL_{index}"}
+        for index in range(5)
+    ]
+    (tmp_path / "history.jsonl").write_text(
+        "\n".join(json.dumps(row) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "models_cache.json").write_text(
+        json.dumps({"models": [{"id": "model-a"}]}),
+        encoding="utf-8",
+    )
+
+    diagnostics = CodexHistoryService(
+        codex_home=tmp_path,
+        max_history_rows=3,
+        max_model_cache_bytes=5,
+    ).get_diagnostics()
+    serialized = json.dumps(diagnostics)
+
+    assert diagnostics["history"]["rows_read"] == 3
+    assert diagnostics["history"]["truncated"] is True
+    assert diagnostics["models_cache"]["too_large"] is True
+    assert diagnostics["models_cache"]["parse_error"] == "models_cache.json exceeds diagnostics read limit"
+    assert "TEXT_FIELD_SENTINEL_4" not in serialized
+    assert "model-a" not in serialized
+
+
+def test_provider_history_diagnostics_endpoint_is_codex_only(monkeypatch, tmp_path):
+    from app.api.v1 import providers as providers_api
+    from app.services.codex_history_service import CodexHistoryService
+
+    (tmp_path / "history.jsonl").write_text(
+        json.dumps({"session_id": "session-a", "ts": 1, "text": "TEXT_FIELD_SENTINEL"}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        providers_api,
+        "CodexHistoryService",
+        lambda: CodexHistoryService(codex_home=tmp_path),
+    )
+
+    response = providers_api.get_provider_history_diagnostics("codex-cli")
+
+    assert response["provider"] == "codex-cli"
+    assert response["provider_display_name"] == "Codex"
+    assert response["history"]["valid_rows"] == 1
+
+    try:
+        providers_api.get_provider_history_diagnostics("claude-code")
+    except providers_api.HTTPException as exc:
+        assert exc.status_code == 400
+    else:
+        raise AssertionError("Expected Claude Code history diagnostics to be rejected")

--- a/docs/plans/2026-05-26-codex-history-investigation.md
+++ b/docs/plans/2026-05-26-codex-history-investigation.md
@@ -1,0 +1,32 @@
+# Codex History and Model Cache Investigation
+
+**Date:** 2026-05-26  
+**Status:** Decision recorded  
+**Scope:** Codex CLI generated `history.jsonl` and `models_cache.json`
+
+## Decision
+
+Use a diagnostics-only backend surface for now. Do not add a product Codex Sessions page yet.
+
+Local inspection shows `history.jsonl` rows with `session_id`, `ts`, and `text`. The session id and timestamp are useful, but `text` is prompt content and must be treated as sensitive. There is not enough non-sensitive metadata yet to provide a useful history UI comparable to Claude Code transcripts without exposing prompt bodies or inventing unsupported semantics.
+
+Local inspection shows `models_cache.json` root keys including `fetched_at`, `etag`, `client_version`, and `models`. This is useful for diagnostics, but the raw model cache is generated data and should not be exposed wholesale.
+
+## Implemented Surface
+
+Add a read-only Codex diagnostics endpoint that summarizes:
+
+- History file existence, size, row counts, observed keys, timestamp range, session counts, and hashed session identifiers.
+- Model cache existence, size, root keys, fetch/client metadata, cache validator presence, model container shape, and model count.
+
+The endpoint intentionally omits:
+
+- Raw history rows.
+- Prompt text.
+- Raw session ids.
+- Raw model cache JSON.
+- Cache validator values.
+
+## Follow-Up Criteria
+
+A product Codex Sessions page should wait until Codex exposes stable, non-sensitive local metadata for project paths, message roles, model choices per session, and safe summaries. Until then, Claude-only transcript pages should remain Claude-only and Codex should use diagnostics-only history/cache reporting.

--- a/docs/plans/2026-05-26-codex-history-investigation.md
+++ b/docs/plans/2026-05-26-codex-history-investigation.md
@@ -1,7 +1,7 @@
 # Codex History and Model Cache Investigation
 
-**Date:** 2026-05-26  
-**Status:** Decision recorded  
+**Date:** 2026-05-26
+**Status:** Decision recorded
 **Scope:** Codex CLI generated `history.jsonl` and `models_cache.json`
 
 ## Decision


### PR DESCRIPTION
## Summary
- Add a read-only Codex history/model-cache diagnostics service
- Expose `GET /api/v1/providers/codex-cli/history-diagnostics`
- Summarize history/cache shape, counts, timestamp ranges, and hashed session identifiers without returning prompt text, raw session ids, raw rows, or raw model payloads
- Record the decision to keep Codex history diagnostics-only until stable non-sensitive metadata exists

## Related
- Continues v2 roadmap #142 after PR #143

## Verification
- `/home/joni/repos/claude-deck/backend/venv/bin/python -m pytest backend/tests/test_codex_history_service.py backend/tests/test_provider_inventory_api.py backend/tests/test_providers.py`
- `/home/joni/repos/claude-deck/backend/venv/bin/python - <<'PY' ... import app.main ... PY`
- `git diff --check`