### PR TITLE
Add safe Codex plugin mutations

### DIFF
--- a/backend/app/api/v1/providers.py
+++ b/backend/app/api/v1/providers.py
@@ -206,9 +206,12 @@ def _build_codex_mcp_add_args(request: CodexMcpAddRequest) -> list[str]:
 def _build_codex_plugin_args(action: str, name: str, marketplace: str | None = None) -> list[str]:
     if action not in {"add", "remove"}:
         raise HTTPException(status_code=400, detail="Codex plugin action is not supported")
-    safe_name = _validate_plugin_selector(name)
+    try:
+        safe_name = _validate_plugin_selector(name)
+        safe_marketplace = _validate_plugin_marketplace(marketplace) if marketplace else None
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     if marketplace:
-        safe_marketplace = _validate_plugin_marketplace(marketplace)
         if "@" in safe_name:
             raise HTTPException(
                 status_code=400,
@@ -491,7 +494,10 @@ def remove_provider_plugin(provider_id: str, plugin_name: str, marketplace: str 
 @router.post("/providers/{provider_id}/plugins/{plugin_name}/enable")
 def enable_provider_plugin(provider_id: str, plugin_name: str):
     _require_codex_provider(provider_id)
-    _validate_plugin_selector(plugin_name)
+    try:
+        _validate_plugin_selector(plugin_name)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     raise HTTPException(
         status_code=400,
         detail=CODEX_PLUGIN_MUTATION_CAPABILITIES["enable"]["reason"],
@@ -501,7 +507,10 @@ def enable_provider_plugin(provider_id: str, plugin_name: str):
 @router.post("/providers/{provider_id}/plugins/{plugin_name}/disable")
 def disable_provider_plugin(provider_id: str, plugin_name: str):
     _require_codex_provider(provider_id)
-    _validate_plugin_selector(plugin_name)
+    try:
+        _validate_plugin_selector(plugin_name)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     raise HTTPException(
         status_code=400,
         detail=CODEX_PLUGIN_MUTATION_CAPABILITIES["disable"]["reason"],

--- a/backend/app/api/v1/providers.py
+++ b/backend/app/api/v1/providers.py
@@ -26,6 +26,29 @@ ENV_KEY_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 MAX_MCP_ARGS = 64
 MAX_MCP_ENV_VARS = 64
 MAX_MCP_STRING_LENGTH = 4096
+PLUGIN_SELECTOR_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}(?:@[A-Za-z0-9][A-Za-z0-9_.-]{0,127})?$")
+
+
+CODEX_PLUGIN_MUTATION_CAPABILITIES = {
+    "install": {
+        "state": "supported",
+        "command": "codex plugin add",
+        "reason": "Supported by the installed Codex CLI plugin command surface.",
+    },
+    "remove": {
+        "state": "supported",
+        "command": "codex plugin remove",
+        "reason": "Supported by the installed Codex CLI plugin command surface.",
+    },
+    "enable": {
+        "state": "unsupported",
+        "reason": "The installed Codex CLI does not expose plugin enable commands.",
+    },
+    "disable": {
+        "state": "unsupported",
+        "reason": "The installed Codex CLI does not expose plugin disable commands.",
+    },
+}
 
 
 class CodexMcpAddRequest(BaseModel):
@@ -62,6 +85,23 @@ class CodexMcpAddRequest(BaseModel):
                 raise ValueError(f"Invalid environment variable name: {key}")
             safe_env[key] = _validate_cli_string(env_value)
         return safe_env
+
+
+class CodexPluginMutationRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=256)
+    marketplace: str | None = Field(default=None, max_length=128)
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        return _validate_plugin_selector(value)
+
+    @field_validator("marketplace")
+    @classmethod
+    def validate_marketplace(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _validate_plugin_marketplace(value)
 
 
 @router.get("/providers")
@@ -107,6 +147,20 @@ def _validate_cli_string(value: str) -> str:
     return value
 
 
+def _validate_plugin_selector(value: str) -> str:
+    value = value.strip()
+    if not PLUGIN_SELECTOR_PATTERN.fullmatch(value):
+        raise ValueError("Plugin selector must be PLUGIN or PLUGIN@MARKETPLACE using letters, numbers, '.', '_', or '-'")
+    return value
+
+
+def _validate_plugin_marketplace(value: str) -> str:
+    value = value.strip()
+    if not value or "@" in value or not PLUGIN_SELECTOR_PATTERN.fullmatch(value):
+        raise ValueError("Marketplace must use letters, numbers, '.', '_', or '-'")
+    return value
+
+
 def _redact_cli_result(result: CLIResult) -> dict[str, Any]:
     return {
         "stdout": _redact_value(result.stdout),
@@ -147,6 +201,21 @@ def _build_codex_mcp_add_args(request: CodexMcpAddRequest) -> list[str]:
     args.extend([request.name, "--", request.command or ""])
     args.extend(request.args)
     return args
+
+
+def _build_codex_plugin_args(action: str, name: str, marketplace: str | None = None) -> list[str]:
+    if action not in {"add", "remove"}:
+        raise HTTPException(status_code=400, detail="Codex plugin action is not supported")
+    safe_name = _validate_plugin_selector(name)
+    if marketplace:
+        safe_marketplace = _validate_plugin_marketplace(marketplace)
+        if "@" in safe_name:
+            raise HTTPException(
+                status_code=400,
+                detail="Provide marketplace either in the plugin selector or marketplace field, not both",
+            )
+        return [action, safe_name, "--marketplace", safe_marketplace]
+    return [action, safe_name]
 
 
 def _redact_value(value: Any, parent_key: str = "") -> Any:
@@ -377,6 +446,63 @@ def get_provider_plugin_inventory(provider_id: str):
         "provider_display_name": provider.display_name,
         "exit_code": result.exit_code,
         "plugins": _redact_value(_parse_plugin_rows(result.stdout)),
+        "mutation_capabilities": CODEX_PLUGIN_MUTATION_CAPABILITIES,
         "stderr": _redact_value(result.stderr),
         "raw_stdout": safe_stdout,
     }
+
+
+@router.post("/providers/{provider_id}/plugins")
+def install_provider_plugin(provider_id: str, request: CodexPluginMutationRequest):
+    plugin_args = _build_codex_plugin_args("add", request.name, request.marketplace)
+    provider = _require_codex_provider(provider_id)
+    executor = ProviderCLIExecutor(provider.id)
+    if not executor.binary_path:
+        raise HTTPException(status_code=500, detail=f"{provider.display_name} binary not found in PATH.")
+
+    result = executor.execute("plugin", plugin_args, timeout=60)
+    return {
+        "provider": provider.id,
+        "provider_display_name": provider.display_name,
+        "name": request.name,
+        "action": "install",
+        **_redact_cli_result(result),
+    }
+
+
+@router.delete("/providers/{provider_id}/plugins/{plugin_name}")
+def remove_provider_plugin(provider_id: str, plugin_name: str, marketplace: str | None = None):
+    plugin_args = _build_codex_plugin_args("remove", plugin_name, marketplace)
+    provider = _require_codex_provider(provider_id)
+    executor = ProviderCLIExecutor(provider.id)
+    if not executor.binary_path:
+        raise HTTPException(status_code=500, detail=f"{provider.display_name} binary not found in PATH.")
+
+    result = executor.execute("plugin", plugin_args, timeout=60)
+    return {
+        "provider": provider.id,
+        "provider_display_name": provider.display_name,
+        "name": plugin_name,
+        "action": "remove",
+        **_redact_cli_result(result),
+    }
+
+
+@router.post("/providers/{provider_id}/plugins/{plugin_name}/enable")
+def enable_provider_plugin(provider_id: str, plugin_name: str):
+    _require_codex_provider(provider_id)
+    _validate_plugin_selector(plugin_name)
+    raise HTTPException(
+        status_code=400,
+        detail=CODEX_PLUGIN_MUTATION_CAPABILITIES["enable"]["reason"],
+    )
+
+
+@router.post("/providers/{provider_id}/plugins/{plugin_name}/disable")
+def disable_provider_plugin(provider_id: str, plugin_name: str):
+    _require_codex_provider(provider_id)
+    _validate_plugin_selector(plugin_name)
+    raise HTTPException(
+        status_code=400,
+        detail=CODEX_PLUGIN_MUTATION_CAPABILITIES["disable"]["reason"],
+    )

--- a/backend/tests/test_provider_inventory_api.py
+++ b/backend/tests/test_provider_inventory_api.py
@@ -306,6 +306,11 @@ def test_codex_plugin_mutation_rejects_unsafe_selectors():
 
     assert exc_info.value.status_code == 400
 
+    with pytest.raises(providers_api.HTTPException) as remove_exc:
+        providers_api.remove_provider_plugin("codex-cli", "..bad")
+
+    assert remove_exc.value.status_code == 400
+
 
 def test_codex_plugin_enable_disable_are_explicitly_unsupported():
     from app.api.v1 import providers as providers_api
@@ -319,3 +324,17 @@ def test_codex_plugin_enable_disable_are_explicitly_unsupported():
     assert "does not expose plugin enable" in enable_exc.value.detail
     assert disable_exc.value.status_code == 400
     assert "does not expose plugin disable" in disable_exc.value.detail
+
+
+def test_codex_plugin_enable_disable_reject_unsafe_selectors():
+    from app.api.v1 import providers as providers_api
+
+    with pytest.raises(providers_api.HTTPException) as enable_exc:
+        providers_api.enable_provider_plugin("codex-cli", "..bad")
+    with pytest.raises(providers_api.HTTPException) as disable_exc:
+        providers_api.disable_provider_plugin("codex-cli", "..bad")
+
+    assert enable_exc.value.status_code == 400
+    assert "Plugin selector" in enable_exc.value.detail
+    assert disable_exc.value.status_code == 400
+    assert "Plugin selector" in disable_exc.value.detail

--- a/backend/tests/test_provider_inventory_api.py
+++ b/backend/tests/test_provider_inventory_api.py
@@ -110,6 +110,10 @@ def test_codex_plugin_inventory_returns_text_and_best_effort_rows(monkeypatch):
     ]
     assert "version" not in response["plugins"][0]
     assert all("marketplace.json" not in plugin["name"] for plugin in response["plugins"])
+    assert response["mutation_capabilities"]["install"]["state"] == "supported"
+    assert response["mutation_capabilities"]["remove"]["state"] == "supported"
+    assert response["mutation_capabilities"]["enable"]["state"] == "unsupported"
+    assert response["mutation_capabilities"]["disable"]["state"] == "unsupported"
 
 
 def test_codex_mcp_add_uses_cli_command_args_and_env(monkeypatch):
@@ -212,3 +216,106 @@ def test_codex_mcp_remove_uses_cli_remove(monkeypatch):
 
     assert calls == [("mcp", ["remove", "linear"], 30)]
     assert response["exit_code"] == 0
+
+
+def test_codex_plugin_install_uses_cli_add_with_marketplace(monkeypatch):
+    from app.api.v1 import providers as providers_api
+
+    calls = []
+
+    class FakeExecutor:
+        binary_path = "/usr/bin/codex"
+
+        def execute(self, command, args, timeout=30):
+            calls.append((command, args, timeout))
+            return SimpleNamespace(stdout="installed auth_token=secret-value", stderr="", exit_code=0)
+
+    monkeypatch.setattr(providers_api, "ProviderCLIExecutor", lambda provider_id: FakeExecutor())
+
+    response = providers_api.install_provider_plugin(
+        "codex-cli",
+        providers_api.CodexPluginMutationRequest(name="linear", marketplace="openai-curated"),
+    )
+
+    assert calls == [("plugin", ["add", "linear", "--marketplace", "openai-curated"], 60)]
+    assert response["action"] == "install"
+    assert response["exit_code"] == 0
+    assert "secret-value" not in response["stdout"]
+
+
+def test_codex_plugin_install_accepts_selector(monkeypatch):
+    from app.api.v1 import providers as providers_api
+
+    calls = []
+
+    class FakeExecutor:
+        binary_path = "/usr/bin/codex"
+
+        def execute(self, command, args, timeout=30):
+            calls.append((command, args, timeout))
+            return SimpleNamespace(stdout="installed", stderr="", exit_code=0)
+
+    monkeypatch.setattr(providers_api, "ProviderCLIExecutor", lambda provider_id: FakeExecutor())
+
+    providers_api.install_provider_plugin(
+        "codex-cli",
+        providers_api.CodexPluginMutationRequest(name="linear@openai-curated"),
+    )
+
+    assert calls == [("plugin", ["add", "linear@openai-curated"], 60)]
+
+
+def test_codex_plugin_remove_uses_cli_remove(monkeypatch):
+    from app.api.v1 import providers as providers_api
+
+    calls = []
+
+    class FakeExecutor:
+        binary_path = "/usr/bin/codex"
+
+        def execute(self, command, args, timeout=30):
+            calls.append((command, args, timeout))
+            return SimpleNamespace(stdout="removed", stderr="token=secret-value", exit_code=0)
+
+    monkeypatch.setattr(providers_api, "ProviderCLIExecutor", lambda provider_id: FakeExecutor())
+
+    response = providers_api.remove_provider_plugin(
+        "codex-cli",
+        "linear",
+        marketplace="openai-curated",
+    )
+
+    assert calls == [("plugin", ["remove", "linear", "--marketplace", "openai-curated"], 60)]
+    assert response["action"] == "remove"
+    assert "secret-value" not in response["stderr"]
+
+
+def test_codex_plugin_mutation_rejects_unsafe_selectors():
+    from app.api.v1 import providers as providers_api
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        providers_api.CodexPluginMutationRequest(name="../bad")
+
+    request = providers_api.CodexPluginMutationRequest(
+        name="linear@openai-curated",
+        marketplace="other",
+    )
+    with pytest.raises(providers_api.HTTPException) as exc_info:
+        providers_api.install_provider_plugin("codex-cli", request)
+
+    assert exc_info.value.status_code == 400
+
+
+def test_codex_plugin_enable_disable_are_explicitly_unsupported():
+    from app.api.v1 import providers as providers_api
+
+    with pytest.raises(providers_api.HTTPException) as enable_exc:
+        providers_api.enable_provider_plugin("codex-cli", "linear@openai-curated")
+    with pytest.raises(providers_api.HTTPException) as disable_exc:
+        providers_api.disable_provider_plugin("codex-cli", "linear@openai-curated")
+
+    assert enable_exc.value.status_code == 400
+    assert "does not expose plugin enable" in enable_exc.value.detail
+    assert disable_exc.value.status_code == 400
+    assert "does not expose plugin disable" in disable_exc.value.detail

--- a/frontend/src/features/config/CodexInventoryCard.tsx
+++ b/frontend/src/features/config/CodexInventoryCard.tsx
@@ -18,7 +18,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
-import { addCodexMcpServer, removeCodexMcpServer } from '@/hooks/useProviders'
+import { addCodexMcpServer, installCodexPlugin, removeCodexMcpServer, removeCodexPlugin } from '@/hooks/useProviders'
 import { cn } from '@/lib/utils'
 import type { CodexMcpAddRequest, CodexMcpInventoryResponse, CodexPluginInventoryResponse } from '@/types/providers'
 
@@ -134,6 +134,8 @@ export function CodexInventoryCard({
   const [envText, setEnvText] = useState('')
   const [url, setUrl] = useState('')
   const [bearerTokenEnvVar, setBearerTokenEnvVar] = useState('')
+  const [pluginName, setPluginName] = useState('')
+  const [pluginMarketplace, setPluginMarketplace] = useState('')
   const [mutationError, setMutationError] = useState<string | null>(null)
   const [mutationMessage, setMutationMessage] = useState<string | null>(null)
   const [mutating, setMutating] = useState(false)
@@ -141,6 +143,13 @@ export function CodexInventoryCard({
   const mcpRows = useMemo(() => getMcpServerRows(mcp?.servers), [mcp?.servers])
   const mcpCount = countMcpServers(mcp?.servers)
   const pluginCount = plugins?.plugins.length ?? null
+  const pluginCapabilities = plugins?.mutation_capabilities
+  const canInstallPlugins = pluginCapabilities?.install.state === 'supported'
+  const canRemovePlugins = pluginCapabilities?.remove.state === 'supported'
+  const pluginToggleUnsupported = [
+    pluginCapabilities?.enable.reason,
+    pluginCapabilities?.disable.reason,
+  ].filter(Boolean).join(' ')
 
   const resetForm = () => {
     setName('')
@@ -149,6 +158,11 @@ export function CodexInventoryCard({
     setEnvText('')
     setUrl('')
     setBearerTokenEnvVar('')
+  }
+
+  const resetPluginForm = () => {
+    setPluginName('')
+    setPluginMarketplace('')
   }
 
   const handleAddMcp = async () => {
@@ -213,6 +227,68 @@ export function CodexInventoryCard({
     }
   }
 
+  const handleInstallPlugin = async () => {
+    setMutationError(null)
+    setMutationMessage(null)
+    try {
+      const trimmedName = pluginName.trim()
+      const trimmedMarketplace = pluginMarketplace.trim()
+      if (!trimmedName) throw new Error('Plugin name is required')
+      if (!canInstallPlugins) {
+        throw new Error(pluginCapabilities?.install.reason || 'Codex plugin install is not supported')
+      }
+
+      setMutating(true)
+      const result = await installCodexPlugin({
+        name: trimmedName,
+        ...(trimmedMarketplace && { marketplace: trimmedMarketplace }),
+      })
+      if (result.exit_code !== 0) {
+        throw new Error(result.stderr || result.stdout || `codex plugin add exited with ${result.exit_code}`)
+      }
+      const message = `Plugin "${trimmedName}" installed`
+      setMutationMessage(message)
+      toast.success(message)
+      resetPluginForm()
+      await onRefresh()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to install Codex plugin'
+      setMutationError(message)
+      toast.error(message)
+    } finally {
+      setMutating(false)
+    }
+  }
+
+  const handleRemovePlugin = async (nameToRemove: string) => {
+    setMutationError(null)
+    setMutationMessage(null)
+    if (!canRemovePlugins) {
+      const message = pluginCapabilities?.remove.reason || 'Codex plugin remove is not supported'
+      setMutationError(message)
+      toast.error(message)
+      return
+    }
+
+    setMutating(true)
+    try {
+      const result = await removeCodexPlugin(nameToRemove)
+      if (result.exit_code !== 0) {
+        throw new Error(result.stderr || result.stdout || `codex plugin remove exited with ${result.exit_code}`)
+      }
+      const message = `Plugin "${nameToRemove}" removed`
+      setMutationMessage(message)
+      toast.success(message)
+      await onRefresh()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to remove Codex plugin'
+      setMutationError(message)
+      toast.error(message)
+    } finally {
+      setMutating(false)
+    }
+  }
+
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0">
@@ -254,6 +330,14 @@ export function CodexInventoryCard({
               </Badge>
             </div>
             <p className="mt-1 text-2xl font-semibold">{pluginCount ?? 'Unknown'}</p>
+            {pluginCapabilities && (
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                <Badge variant={canInstallPlugins ? 'default' : 'outline'}>install</Badge>
+                <Badge variant={canRemovePlugins ? 'default' : 'outline'}>remove</Badge>
+                <Badge variant="outline">enable unsupported</Badge>
+                <Badge variant="outline">disable unsupported</Badge>
+              </div>
+            )}
             {plugins?.stderr && (
               <p className="mt-2 text-xs text-muted-foreground">{plugins.stderr}</p>
             )}
@@ -366,6 +450,48 @@ export function CodexInventoryCard({
           </div>
         </div>
 
+        <div className="rounded-md border p-3">
+          <div className="flex flex-wrap items-start justify-between gap-2">
+            <div>
+              <p className="text-sm font-medium">Install Plugin</p>
+              {pluginToggleUnsupported && (
+                <p className="mt-1 text-xs text-muted-foreground">{pluginToggleUnsupported}</p>
+              )}
+            </div>
+            {pluginCapabilities?.install.command && (
+              <Badge variant="outline">{pluginCapabilities.install.command}</Badge>
+            )}
+          </div>
+          <div className="mt-3 grid gap-3 md:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="codex-plugin-name">Plugin</Label>
+              <Input
+                id="codex-plugin-name"
+                value={pluginName}
+                onChange={(event) => setPluginName(event.target.value)}
+                placeholder="linear or linear@openai-curated"
+                disabled={mutating || !canInstallPlugins}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="codex-plugin-marketplace">Marketplace</Label>
+              <Input
+                id="codex-plugin-marketplace"
+                value={pluginMarketplace}
+                onChange={(event) => setPluginMarketplace(event.target.value)}
+                placeholder="openai-curated"
+                disabled={mutating || !canInstallPlugins}
+              />
+            </div>
+          </div>
+          <div className="mt-3 flex justify-end">
+            <Button onClick={handleInstallPlugin} disabled={mutating || !canInstallPlugins} className="gap-2">
+              <Plus className="h-4 w-4" />
+              Install Plugin
+            </Button>
+          </div>
+        </div>
+
         {mcpRows.length > 0 && (
           <div className="rounded-md border">
             {mcpRows.map((server) => (
@@ -415,20 +541,56 @@ export function CodexInventoryCard({
           <div className="rounded-md border">
             {plugins.plugins.map((plugin) => (
               <div key={`${plugin.status ?? 'unknown'}:${plugin.name}`} className="border-b p-3 last:border-b-0">
-                <div className="flex items-center justify-between gap-2">
-                  <p className="text-sm font-medium">{plugin.name}</p>
-                  {plugin.status && <Badge variant="outline">{plugin.status}</Badge>}
-                </div>
-                {(plugin.version || plugin.path) && (
-                  <div className="mt-1 flex min-w-0 flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                    {plugin.version && <span>v{plugin.version}</span>}
-                    {plugin.path && (
-                      <code className="max-w-full truncate rounded bg-muted px-1.5 py-0.5 font-mono">
-                        {plugin.path}
-                      </code>
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <p className="truncate text-sm font-medium">{plugin.name}</p>
+                      {plugin.status && <Badge variant="outline">{plugin.status}</Badge>}
+                    </div>
+                    {(plugin.version || plugin.path) && (
+                      <div className="mt-1 flex min-w-0 flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                        {plugin.version && <span>v{plugin.version}</span>}
+                        {plugin.path && (
+                          <code className="max-w-full truncate rounded bg-muted px-1.5 py-0.5 font-mono">
+                            {plugin.path}
+                          </code>
+                        )}
+                      </div>
                     )}
                   </div>
-                )}
+                  {plugin.status === 'installed' && (
+                    <AlertDialog>
+                      <AlertDialogTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-8 w-8 shrink-0 text-destructive hover:text-destructive"
+                          disabled={mutating || !canRemovePlugins}
+                          title={`Remove ${plugin.name}`}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>Remove Codex Plugin</AlertDialogTitle>
+                          <AlertDialogDescription>
+                            Remove "{plugin.name}" using codex plugin remove? This updates Codex local plugin config and cache.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>Cancel</AlertDialogCancel>
+                          <AlertDialogAction
+                            onClick={() => handleRemovePlugin(plugin.name)}
+                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                          >
+                            Remove
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
+                  )}
+                </div>
               </div>
             ))}
           </div>

--- a/frontend/src/hooks/useProviders.ts
+++ b/frontend/src/hooks/useProviders.ts
@@ -8,6 +8,8 @@ import type {
   CodexMcpInventoryResponse,
   CodexMcpMutationResponse,
   CodexPluginInventoryResponse,
+  CodexPluginMutationRequest,
+  CodexPluginMutationResponse,
   ProviderDoctorResponse,
   ProvidersResponse,
 } from '@/types/providers'
@@ -70,4 +72,17 @@ export async function removeCodexMcpServer(name: string): Promise<CodexMcpMutati
 
 export async function fetchCodexPluginInventory(): Promise<CodexPluginInventoryResponse> {
   return apiClient<CodexPluginInventoryResponse>('providers/codex-cli/plugins')
+}
+
+export async function installCodexPlugin(request: CodexPluginMutationRequest): Promise<CodexPluginMutationResponse> {
+  return apiClient<CodexPluginMutationResponse>('providers/codex-cli/plugins', {
+    method: 'POST',
+    body: JSON.stringify(request),
+  })
+}
+
+export async function removeCodexPlugin(name: string): Promise<CodexPluginMutationResponse> {
+  return apiClient<CodexPluginMutationResponse>(`providers/codex-cli/plugins/${encodeURIComponent(name)}`, {
+    method: 'DELETE',
+  })
 }

--- a/frontend/src/types/providers.ts
+++ b/frontend/src/types/providers.ts
@@ -124,11 +124,38 @@ export interface CodexPluginInventoryRow {
   path?: string
 }
 
+export interface CodexPluginMutationCapability {
+  state: 'supported' | 'unsupported'
+  command?: string
+  reason: string
+}
+
 export interface CodexPluginInventoryResponse {
   provider: 'codex-cli'
   provider_display_name: string
   exit_code: number
   plugins: CodexPluginInventoryRow[]
+  mutation_capabilities: {
+    install: CodexPluginMutationCapability
+    remove: CodexPluginMutationCapability
+    enable: CodexPluginMutationCapability
+    disable: CodexPluginMutationCapability
+  }
   stderr: string
   raw_stdout: string
+}
+
+export interface CodexPluginMutationRequest {
+  name: string
+  marketplace?: string
+}
+
+export interface CodexPluginMutationResponse {
+  provider: 'codex-cli'
+  provider_display_name: string
+  name: string
+  action: 'install' | 'remove'
+  stdout: string
+  stderr: string
+  exit_code: number
 }


### PR DESCRIPTION
## Summary
- Add CLI-backed Codex plugin install/remove endpoints with strict selector validation and redacted output
- Report enable/disable as explicit unsupported capabilities because the installed Codex CLI does not expose plugin toggle commands
- Add Codex inventory UI controls for supported plugin install/remove only

Refs #142

## Test plan
- [x] backend venv pytest: backend/tests/test_provider_inventory_api.py backend/tests/test_provider_cli_executor.py backend/tests/test_providers.py
- [x] backend app import
- [x] focused frontend ESLint for changed provider/config files
- [x] npm run build
- [x] git diff --check