### PR TITLE
Add Codex profile resolution diagnostics

### DIFF
--- a/backend/app/services/codex_config_service.py
+++ b/backend/app/services/codex_config_service.py
@@ -5,6 +5,7 @@ import shutil
 import tempfile
 import tomllib
 import re
+import copy
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -27,6 +28,7 @@ SAFE_SCALAR_FIELDS = {
     "no_alt_screen": bool,
 }
 SENSITIVE_KEY_PATTERN = re.compile(r"(token|secret|password|credential|api[_-]?key|auth|cookie|session)", re.I)
+PROFILE_V2_KEYS = ("profile-v2", "profile_v2")
 
 
 class CodexConfigService:
@@ -73,6 +75,184 @@ class CodexConfigService:
             return "[redacted]"
         return value
 
+    def _profile_name_from_file(self, path: Path) -> str:
+        suffix = ".config.toml"
+        return path.name[:-len(suffix)] if path.name.endswith(suffix) else path.stem
+
+    def _get_profile_files(self) -> list[Path]:
+        if not self.codex_home.exists():
+            return []
+        return sorted(self.codex_home.glob("*.config.toml"))
+
+    def _get_profile_v2_reference(self, config: dict[str, Any]) -> str | None:
+        for key in PROFILE_V2_KEYS:
+            value = config.get(key)
+            if isinstance(value, str) and value:
+                return value
+        return None
+
+    def _summarize_config(self, config: dict[str, Any]) -> dict[str, Any]:
+        projects = config.get("projects", {}) if isinstance(config.get("projects"), dict) else {}
+        profiles = config.get("profiles", {}) if isinstance(config.get("profiles"), dict) else {}
+        features = config.get("features", {}) if isinstance(config.get("features"), dict) else {}
+        summary = {
+            "model": config.get("model"),
+            "model_reasoning_effort": config.get("model_reasoning_effort"),
+            "profile": config.get("profile"),
+            "profile_v2": self._get_profile_v2_reference(config),
+            "sandbox_mode": config.get("sandbox_mode"),
+            "approval_policy": config.get("approval_policy"),
+            "search": config.get("search"),
+            "strict_config": config.get("strict_config"),
+            "no_alt_screen": config.get("no_alt_screen"),
+            "projects": self._redact_summary_value(projects),
+            "profiles": self._redact_summary_value(profiles),
+            "features": self._redact_summary_value(features),
+        }
+        return {key: value for key, value in summary.items() if value is not None}
+
+    def _safe_overlay_summary(self, config: dict[str, Any]) -> dict[str, Any]:
+        summary: dict[str, Any] = {}
+        for key in SAFE_SCALAR_FIELDS:
+            if key in config:
+                summary[key] = self._redact_summary_value(config[key], key)
+        profile_v2 = self._get_profile_v2_reference(config)
+        if profile_v2 is not None:
+            summary["profile_v2"] = self._redact_summary_value(profile_v2, "profile_v2")
+        features = config.get("features")
+        if isinstance(features, dict):
+            summary["features"] = self._redact_summary_value(features, "features")
+        return summary
+
+    def _flatten_safe_summary(self, summary: dict[str, Any]) -> dict[str, Any]:
+        flattened: dict[str, Any] = {}
+        for key, value in summary.items():
+            if key == "features" and isinstance(value, dict):
+                for feature_key, feature_value in value.items():
+                    flattened[f"features.{feature_key}"] = feature_value
+            elif key not in {"projects", "profiles"}:
+                flattened[key] = value
+        return flattened
+
+    def _get_overrides(self, base: dict[str, Any], overlay: dict[str, Any]) -> list[dict[str, Any]]:
+        base_flat = self._flatten_safe_summary(base)
+        overlay_flat = self._flatten_safe_summary(overlay)
+        overrides: list[dict[str, Any]] = []
+        for key, value in sorted(overlay_flat.items()):
+            base_value = base_flat.get(key)
+            if base_value != value:
+                overrides.append({
+                    "key": key,
+                    "base": base_value,
+                    "value": value,
+                })
+        return overrides
+
+    def _merge_safe_summary(self, base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+        merged = copy.deepcopy(base)
+        for key, value in overlay.items():
+            if key == "features" and isinstance(value, dict):
+                current = merged.get("features") if isinstance(merged.get("features"), dict) else {}
+                merged["features"] = {**current, **value}
+            elif key not in {"projects", "profiles"}:
+                merged[key] = value
+        return merged
+
+    def _build_profile_source(
+        self,
+        *,
+        name: str,
+        source: str,
+        path: Path | None,
+        exists: bool,
+        config: dict[str, Any],
+        parse_error: str | None,
+        base_summary: dict[str, Any],
+    ) -> dict[str, Any]:
+        summary = self._safe_overlay_summary(config) if not parse_error else {}
+        return {
+            "name": name,
+            "source": source,
+            "path": str(path) if path else None,
+            "exists": exists,
+            "parse_error": parse_error,
+            "summary": summary,
+            "overrides": self._get_overrides(base_summary, summary),
+        }
+
+    def resolve_profiles(self, config: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Resolve Codex profile references without exposing raw TOML or secrets."""
+        config = config if config is not None else self.parse_toml_file(self.config_file)[0]
+        base_summary = self._safe_overlay_summary(config)
+        active_profile = config.get("profile") if isinstance(config.get("profile"), str) else None
+        active_profile_v2 = self._get_profile_v2_reference(config)
+        inline_profiles = config.get("profiles", {}) if isinstance(config.get("profiles"), dict) else {}
+
+        sources: list[dict[str, Any]] = []
+        for name, profile_config in sorted(inline_profiles.items()):
+            if not isinstance(name, str) or not isinstance(profile_config, dict):
+                continue
+            sources.append(self._build_profile_source(
+                name=name,
+                source="inline",
+                path=self.config_file,
+                exists=True,
+                config=profile_config,
+                parse_error=None,
+                base_summary=base_summary,
+            ))
+
+        for profile_file in self._get_profile_files():
+            profile_config, parse_error = self.parse_toml_file(profile_file)
+            sources.append(self._build_profile_source(
+                name=self._profile_name_from_file(profile_file),
+                source="file",
+                path=profile_file,
+                exists=profile_file.exists(),
+                config=profile_config,
+                parse_error=parse_error,
+                base_summary=base_summary,
+            ))
+
+        source_names = {(source["name"], source["source"]) for source in sources}
+        missing: list[dict[str, Any]] = []
+        for reference_type, reference in (("profile", active_profile), ("profile_v2", active_profile_v2)):
+            if not reference:
+                continue
+            if (reference, "inline") not in source_names and (reference, "file") not in source_names:
+                missing.append({
+                    "name": reference,
+                    "reference": reference_type,
+                    "expected_file": str(self.codex_home / f"{reference}.config.toml"),
+                })
+
+        active_sources = [
+            source for source in sources
+            if source["name"] in {active_profile, active_profile_v2} and not source["parse_error"]
+        ]
+        effective_summary = copy.deepcopy(base_summary)
+        for source in active_sources:
+            effective_summary = self._merge_safe_summary(effective_summary, source["summary"])
+
+        return {
+            "active_profile": active_profile,
+            "active_profile_v2": active_profile_v2,
+            "resolution_order": ["config.toml", "inline profile", "*.config.toml profile file"],
+            "base_summary": base_summary,
+            "profiles": sources,
+            "active_sources": active_sources,
+            "missing_references": missing,
+            "malformed_profiles": [
+                {
+                    "name": source["name"],
+                    "path": source["path"],
+                    "parse_error": source["parse_error"],
+                }
+                for source in sources if source["parse_error"]
+            ],
+            "effective_summary": effective_summary,
+        }
+
     def get_all_config_files(self) -> list[dict[str, Any]]:
         files: list[dict[str, Any]] = []
         user_config = self.config_file
@@ -85,7 +265,7 @@ class CodexConfigService:
         })
 
         if self.codex_home.exists():
-            for profile in sorted(self.codex_home.glob("*.config.toml")):
+            for profile in self._get_profile_files():
                 files.append({
                     "path": str(profile),
                     "scope": "profile",
@@ -118,28 +298,14 @@ class CodexConfigService:
 
     def get_config(self) -> dict[str, Any]:
         config, parse_error = self.parse_toml_file(self.config_file)
-        projects = config.get("projects", {}) if isinstance(config.get("projects"), dict) else {}
-        profiles = config.get("profiles", {}) if isinstance(config.get("profiles"), dict) else {}
-        features = config.get("features", {}) if isinstance(config.get("features"), dict) else {}
 
         return {
             "provider": "codex-cli",
             "path": str(self.config_file),
             "exists": self.config_file.exists(),
             "parse_error": parse_error,
-            "summary": {
-                "model": config.get("model"),
-                "model_reasoning_effort": config.get("model_reasoning_effort"),
-                "profile": config.get("profile"),
-                "sandbox_mode": config.get("sandbox_mode"),
-                "approval_policy": config.get("approval_policy"),
-                "search": config.get("search"),
-                "strict_config": config.get("strict_config"),
-                "no_alt_screen": config.get("no_alt_screen"),
-                "projects": self._redact_summary_value(projects),
-                "profiles": self._redact_summary_value(profiles),
-                "features": self._redact_summary_value(features),
-            },
+            "summary": self._summarize_config(config),
+            "profile_resolution": self.resolve_profiles(config) if not parse_error else None,
         }
 
     def get_file_content(self, file_path: str) -> dict[str, Any]:

--- a/backend/app/services/codex_config_service.py
+++ b/backend/app/services/codex_config_service.py
@@ -28,6 +28,7 @@ SAFE_SCALAR_FIELDS = {
     "no_alt_screen": bool,
 }
 SENSITIVE_KEY_PATTERN = re.compile(r"(token|secret|password|credential|api[_-]?key|auth|cookie|session)", re.I)
+PROFILE_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
 PROFILE_V2_KEYS = ("profile-v2", "profile_v2")
 
 
@@ -78,6 +79,9 @@ class CodexConfigService:
     def _profile_name_from_file(self, path: Path) -> str:
         suffix = ".config.toml"
         return path.name[:-len(suffix)] if path.name.endswith(suffix) else path.stem
+
+    def _is_safe_profile_name(self, name: str) -> bool:
+        return bool(PROFILE_NAME_PATTERN.fullmatch(name))
 
     def _get_profile_files(self) -> list[Path]:
         if not self.codex_home.exists():
@@ -220,11 +224,15 @@ class CodexConfigService:
             if not reference:
                 continue
             if (reference, "inline") not in source_names and (reference, "file") not in source_names:
-                missing.append({
+                entry = {
                     "name": reference,
                     "reference": reference_type,
-                    "expected_file": str(self.codex_home / f"{reference}.config.toml"),
-                })
+                    "expected_file": None,
+                    "unsafe_reference": not self._is_safe_profile_name(reference),
+                }
+                if self._is_safe_profile_name(reference):
+                    entry["expected_file"] = str(self.codex_home / f"{reference}.config.toml")
+                missing.append(entry)
 
         active_sources = [
             source for source in sources

--- a/backend/tests/test_codex_config_service.py
+++ b/backend/tests/test_codex_config_service.py
@@ -159,6 +159,7 @@ def test_codex_profile_resolution_reports_missing_and_malformed_profiles(tmp_pat
             "name": "missing",
             "reference": "profile",
             "expected_file": str(tmp_path / "missing.config.toml"),
+            "unsafe_reference": False,
         }
     ]
     assert resolution["malformed_profiles"][0]["name"] == "broken"
@@ -187,6 +188,33 @@ def test_codex_profile_resolution_handles_default_config_without_profile(tmp_pat
     assert resolution["missing_references"] == []
     assert resolution["effective_summary"]["model"] == "base-model"
     assert resolution["effective_summary"]["features"]["search"] is True
+
+
+def test_codex_profile_resolution_does_not_build_paths_for_unsafe_references(tmp_path):
+    from app.services.codex_config_service import CodexConfigService
+
+    (tmp_path / "config.toml").write_text(
+        '\n'.join([
+            'profile = "../outside"',
+            'profile_v2 = "safe-profile"',
+        ]),
+        encoding="utf-8",
+    )
+
+    missing = CodexConfigService(codex_home=tmp_path).get_config()["profile_resolution"]["missing_references"]
+
+    assert missing[0] == {
+        "name": "../outside",
+        "reference": "profile",
+        "expected_file": None,
+        "unsafe_reference": True,
+    }
+    assert missing[1] == {
+        "name": "safe-profile",
+        "reference": "profile_v2",
+        "expected_file": str(tmp_path / "safe-profile.config.toml"),
+        "unsafe_reference": False,
+    }
 
 
 def test_codex_raw_view_rejects_auth_and_allows_safe_files(tmp_path):

--- a/backend/tests/test_codex_config_service.py
+++ b/backend/tests/test_codex_config_service.py
@@ -75,6 +75,120 @@ def test_codex_config_summary_omits_full_config_and_secrets(tmp_path):
     assert "mcp_servers" not in serialized
 
 
+def test_codex_profile_resolution_merges_active_inline_and_file_profiles(tmp_path):
+    from app.services.codex_config_service import CodexConfigService
+
+    (tmp_path / "config.toml").write_text(
+        '\n'.join([
+            'model = "base-model"',
+            'profile = "work"',
+            'profile-v2 = "work"',
+            'approval_policy = "ask"',
+            '',
+            '[features]',
+            'search = false',
+            '',
+            '[profiles.work]',
+            'approval_policy = "on-request"',
+            '',
+            '[profiles.work.features]',
+            'search = true',
+            '',
+            '[profiles.work.env]',
+            'API_TOKEN = "secret-inline-token"',
+        ]),
+        encoding="utf-8",
+    )
+    (tmp_path / "work.config.toml").write_text(
+        '\n'.join([
+            'model = "profile-model"',
+            'sandbox_mode = "workspace-write"',
+            'authToken = "secret-file-token"',
+            '',
+            '[features]',
+            'shell_tool = true',
+        ]),
+        encoding="utf-8",
+    )
+
+    data = CodexConfigService(codex_home=tmp_path).get_config()
+    resolution = data["profile_resolution"]
+    serialized = str(resolution)
+
+    assert data["summary"]["profile"] == "work"
+    assert data["summary"]["profile_v2"] == "work"
+    assert resolution["active_profile"] == "work"
+    assert resolution["active_profile_v2"] == "work"
+    assert [source["source"] for source in resolution["active_sources"]] == ["inline", "file"]
+    assert resolution["effective_summary"]["model"] == "profile-model"
+    assert resolution["effective_summary"]["approval_policy"] == "on-request"
+    assert resolution["effective_summary"]["sandbox_mode"] == "workspace-write"
+    assert resolution["effective_summary"]["features"]["search"] is True
+    assert resolution["effective_summary"]["features"]["shell_tool"] is True
+    assert any(
+        override["key"] == "approval_policy"
+        for source in resolution["profiles"]
+        if source["source"] == "inline"
+        for override in source["overrides"]
+    )
+    assert "secret-inline-token" not in serialized
+    assert "secret-file-token" not in serialized
+    assert "authToken" not in serialized
+
+
+def test_codex_profile_resolution_reports_missing_and_malformed_profiles(tmp_path):
+    from app.services.codex_config_service import CodexConfigService
+
+    (tmp_path / "config.toml").write_text(
+        '\n'.join([
+            'model = "base-model"',
+            'profile = "missing"',
+            'profile_v2 = "broken"',
+        ]),
+        encoding="utf-8",
+    )
+    (tmp_path / "broken.config.toml").write_text("model = [", encoding="utf-8")
+
+    data = CodexConfigService(codex_home=tmp_path).get_config()
+    resolution = data["profile_resolution"]
+
+    assert resolution["active_profile"] == "missing"
+    assert resolution["active_profile_v2"] == "broken"
+    assert resolution["missing_references"] == [
+        {
+            "name": "missing",
+            "reference": "profile",
+            "expected_file": str(tmp_path / "missing.config.toml"),
+        }
+    ]
+    assert resolution["malformed_profiles"][0]["name"] == "broken"
+    assert resolution["malformed_profiles"][0]["parse_error"]
+    assert resolution["effective_summary"]["model"] == "base-model"
+
+
+def test_codex_profile_resolution_handles_default_config_without_profile(tmp_path):
+    from app.services.codex_config_service import CodexConfigService
+
+    (tmp_path / "config.toml").write_text(
+        '\n'.join([
+            'model = "base-model"',
+            '',
+            '[features]',
+            'search = true',
+        ]),
+        encoding="utf-8",
+    )
+
+    resolution = CodexConfigService(codex_home=tmp_path).get_config()["profile_resolution"]
+
+    assert resolution["active_profile"] is None
+    assert resolution["active_profile_v2"] is None
+    assert resolution["profiles"] == []
+    assert resolution["missing_references"] == []
+    assert resolution["effective_summary"]["model"] == "base-model"
+    assert resolution["effective_summary"]["features"]["search"] is True
+
+
 def test_codex_raw_view_rejects_auth_and_allows_safe_files(tmp_path):
     from app.services.codex_config_service import CodexConfigService
 

--- a/frontend/src/features/config/CodexProfileResolverCard.tsx
+++ b/frontend/src/features/config/CodexProfileResolverCard.tsx
@@ -76,7 +76,8 @@ export function CodexProfileResolverCard({ resolution }: CodexProfileResolverCar
                 key={`${missing.reference}:${missing.name}`}
                 className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive"
               >
-                Missing {missing.reference} profile "{missing.name}" at {missing.expected_file}
+                Missing {missing.reference} profile "{missing.name}"
+                {missing.expected_file ? ` at ${missing.expected_file}` : ' with an unsafe file reference'}
               </p>
             ))}
             {resolution.malformed_profiles.map((profile) => (

--- a/frontend/src/features/config/CodexProfileResolverCard.tsx
+++ b/frontend/src/features/config/CodexProfileResolverCard.tsx
@@ -1,0 +1,118 @@
+import { ChevronRight } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import type { CodexProfileResolution, CodexProfileSource } from '@/types/providers'
+
+interface CodexProfileResolverCardProps {
+  resolution: CodexProfileResolution | null | undefined
+}
+
+function formatValue(value: unknown): string {
+  if (value === undefined) return 'unset'
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  return JSON.stringify(value)
+}
+
+function ProfileSourceRow({ source }: { source: CodexProfileSource }) {
+  return (
+    <div className="rounded-md border p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium">{source.name}</p>
+          {source.path && (
+            <code className="mt-1 block max-w-full truncate rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
+              {source.path}
+            </code>
+          )}
+        </div>
+        <Badge variant={source.parse_error ? 'destructive' : 'outline'}>{source.source}</Badge>
+      </div>
+      {source.parse_error ? (
+        <p className="mt-2 text-xs text-destructive">{source.parse_error}</p>
+      ) : source.overrides.length > 0 ? (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {source.overrides.map((override) => (
+            <Badge key={override.key} variant="secondary">
+              {override.key}: {formatValue(override.base)} {'->'} {formatValue(override.value)}
+            </Badge>
+          ))}
+        </div>
+      ) : (
+        <p className="mt-2 text-xs text-muted-foreground">No safe setting overrides detected.</p>
+      )}
+    </div>
+  )
+}
+
+export function CodexProfileResolverCard({ resolution }: CodexProfileResolverCardProps) {
+  if (!resolution) return null
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Profile Resolution</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-3 md:grid-cols-3">
+          <div className="rounded-md border p-3">
+            <p className="text-sm font-medium">Active Profile</p>
+            <p className="mt-1 truncate text-2xl font-semibold">{resolution.active_profile ?? 'Default'}</p>
+          </div>
+          <div className="rounded-md border p-3">
+            <p className="text-sm font-medium">Profile v2</p>
+            <p className="mt-1 truncate text-2xl font-semibold">{resolution.active_profile_v2 ?? 'Unset'}</p>
+          </div>
+          <div className="rounded-md border p-3">
+            <p className="text-sm font-medium">Profiles Found</p>
+            <p className="mt-1 text-2xl font-semibold">{resolution.profiles.length}</p>
+          </div>
+        </div>
+
+        {(resolution.missing_references.length > 0 || resolution.malformed_profiles.length > 0) && (
+          <div className="space-y-2">
+            {resolution.missing_references.map((missing) => (
+              <p
+                key={`${missing.reference}:${missing.name}`}
+                className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive"
+              >
+                Missing {missing.reference} profile "{missing.name}" at {missing.expected_file}
+              </p>
+            ))}
+            {resolution.malformed_profiles.map((profile) => (
+              <p
+                key={`${profile.name}:${profile.path}`}
+                className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive"
+              >
+                Malformed profile "{profile.name}": {profile.parse_error}
+              </p>
+            ))}
+          </div>
+        )}
+
+        {resolution.active_sources.length > 0 ? (
+          <div className="space-y-2">
+            <p className="text-sm font-medium">Active Sources</p>
+            {resolution.active_sources.map((source) => (
+              <ProfileSourceRow key={`${source.source}:${source.name}:${source.path ?? ''}`} source={source} />
+            ))}
+          </div>
+        ) : (
+          <p className="rounded-md border p-3 text-sm text-muted-foreground">
+            No active profile overrides are applied.
+          </p>
+        )}
+
+        <details className="group rounded-md border">
+          <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-sm font-medium">
+            <ChevronRight className="h-4 w-4 transition-transform group-open:rotate-90" />
+            Effective safe summary
+          </summary>
+          <pre className="max-h-72 overflow-auto border-t bg-muted p-3 text-xs">
+            {JSON.stringify(resolution.effective_summary, null, 2)}
+          </pre>
+        </details>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/features/config/ConfigViewerPage.tsx
+++ b/frontend/src/features/config/ConfigViewerPage.tsx
@@ -6,6 +6,7 @@ import { ConfigFileList } from './ConfigFileList'
 import { ConfigFileViewer } from './ConfigFileViewer'
 import { CodexDiagnosticsCard } from './CodexDiagnosticsCard'
 import { CodexInventoryCard } from './CodexInventoryCard'
+import { CodexProfileResolverCard } from './CodexProfileResolverCard'
 import { CodexSettingsEditor } from './CodexSettingsEditor'
 import { SettingsEditor } from './settings'
 import { ScopeResolver } from './ScopeResolver'
@@ -185,6 +186,7 @@ export function ConfigViewerPage() {
                 config={codexConfig}
                 onSaved={fetchData}
               />
+              <CodexProfileResolverCard resolution={codexConfig?.profile_resolution} />
               <CodexDiagnosticsCard
                 doctor={codexDoctor}
                 loading={loading}

--- a/frontend/src/types/providers.ts
+++ b/frontend/src/types/providers.ts
@@ -96,7 +96,8 @@ export interface CodexProfileSource {
 export interface CodexMissingProfileReference {
   name: string
   reference: 'profile' | 'profile_v2' | string
-  expected_file: string
+  expected_file: string | null
+  unsafe_reference: boolean
 }
 
 export interface CodexMalformedProfile {

--- a/frontend/src/types/providers.ts
+++ b/frontend/src/types/providers.ts
@@ -66,6 +66,7 @@ export interface CodexConfigSummary {
   model?: string
   model_reasoning_effort?: string
   profile?: string
+  profile_v2?: string
   sandbox_mode?: string
   approval_policy?: string
   search?: boolean
@@ -76,12 +77,53 @@ export interface CodexConfigSummary {
   features: Record<string, boolean>
 }
 
+export interface CodexProfileOverride {
+  key: string
+  base?: unknown
+  value: unknown
+}
+
+export interface CodexProfileSource {
+  name: string
+  source: 'inline' | 'file' | string
+  path: string | null
+  exists: boolean
+  parse_error: string | null
+  summary: Record<string, unknown>
+  overrides: CodexProfileOverride[]
+}
+
+export interface CodexMissingProfileReference {
+  name: string
+  reference: 'profile' | 'profile_v2' | string
+  expected_file: string
+}
+
+export interface CodexMalformedProfile {
+  name: string
+  path: string | null
+  parse_error: string
+}
+
+export interface CodexProfileResolution {
+  active_profile: string | null
+  active_profile_v2: string | null
+  resolution_order: string[]
+  base_summary: Record<string, unknown>
+  profiles: CodexProfileSource[]
+  active_sources: CodexProfileSource[]
+  missing_references: CodexMissingProfileReference[]
+  malformed_profiles: CodexMalformedProfile[]
+  effective_summary: Record<string, unknown>
+}
+
 export interface CodexConfigResponse {
   provider: 'codex-cli'
   path: string
   exists: boolean
   parse_error: string | null
   summary: CodexConfigSummary
+  profile_resolution: CodexProfileResolution | null
 }
 
 export interface CodexConfigUpdateRequest {


### PR DESCRIPTION
## Summary
- Add read-only Codex profile resolver diagnostics for active profile and profile-v2 references
- Summarize inline profiles and *.config.toml profile files with safe redacted overrides, missing references, malformed files, and effective safe settings
- Add a compact Codex config UI card for profile resolution without raw TOML editing

Refs #142

## Test plan
- [x] backend venv pytest: backend/tests/test_codex_config_service.py
- [x] backend app import
- [x] focused frontend ESLint for changed config/provider files
- [x] npm run build
- [x] git diff --check