### PR TITLE
Centralize provider capability matrix

### DIFF
--- a/backend/app/api/v1/providers.py
+++ b/backend/app/api/v1/providers.py
@@ -78,6 +78,20 @@ def get_provider_status(provider_id: str):
         raise HTTPException(status_code=404, detail=str(exc))
 
 
+@router.get("/providers/{provider_id}/capabilities")
+def get_provider_capabilities(provider_id: str):
+    try:
+        provider = get_provider(provider_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    return {
+        "provider": provider.id,
+        "provider_display_name": provider.display_name,
+        "capabilities": provider.get_capabilities(),
+        "capability_matrix": provider.get_capability_matrix(),
+    }
+
+
 def _require_codex_provider(provider_id: str):
     try:
         provider = get_provider(provider_id)

--- a/backend/app/services/providers/base.py
+++ b/backend/app/services/providers/base.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from app.services.providers.capabilities import capability_flags, normalize_capability_matrix
+
 
 _MAX_TREE_DEPTH = 4
 
@@ -97,9 +99,13 @@ class AgentProvider(ABC):
     binary_name: str
     version_args: tuple[str, ...] = ("--version",)
 
-    @abstractmethod
     def get_capabilities(self) -> dict[str, bool]:
-        """Return provider feature support flags."""
+        """Return backward-compatible provider feature support flags."""
+        return capability_flags(self.id)
+
+    def get_capability_matrix(self) -> dict[str, dict[str, Any]]:
+        """Return detailed provider capability metadata."""
+        return normalize_capability_matrix(self.id)
 
     @abstractmethod
     def get_config_paths(self, project_path: str | None = None) -> dict[str, Any]:
@@ -149,6 +155,6 @@ class AgentProvider(ABC):
             "binary_path": binary_path,
             "version": version,
             "capabilities": self.get_capabilities(),
+            "capability_matrix": self.get_capability_matrix(),
             "config_paths": self.get_config_paths(),
         }
-

--- a/backend/app/services/providers/capabilities.py
+++ b/backend/app/services/providers/capabilities.py
@@ -1,0 +1,100 @@
+"""Central provider capability matrix."""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+
+CAPABILITY_KEYS = (
+    "config",
+    "sessions",
+    "spawn",
+    "resume",
+    "fork",
+    "mcp",
+    "plugins",
+    "permissions",
+    "commands",
+    "agents",
+    "skills",
+    "hooks",
+    "memory",
+    "output_styles",
+    "statusline",
+    "usage",
+    "context",
+    "doctor",
+    "backup",
+)
+SUPPORTED_STATES = {"supported", "read_only", "write_capable"}
+
+
+def capability(state: str, label: str, reason: str | None = None) -> dict[str, str]:
+    result = {"state": state, "label": label}
+    if reason:
+        result["reason"] = reason
+    return result
+
+
+PROVIDER_CAPABILITY_MATRIX: dict[str, dict[str, dict[str, str]]] = {
+    "claude-code": {
+        "config": capability("write_capable", "Configuration", "Claude Code JSON settings can be viewed and edited."),
+        "sessions": capability("read_only", "Session History", "Claude Code transcript history is available."),
+        "spawn": capability("write_capable", "Spawn Sessions", "Agent Bridge can launch Claude Code sessions."),
+        "resume": capability("write_capable", "Resume Sessions", "Claude Code resume is available."),
+        "fork": capability("unsupported", "Fork Sessions", "Claude Code fork mode is not exposed."),
+        "mcp": capability("write_capable", "MCP Servers", "Claude Code MCP servers can be managed."),
+        "plugins": capability("write_capable", "Plugins", "Claude Code plugins can be managed."),
+        "permissions": capability("write_capable", "Permissions", "Claude Code trust and permissions can be managed."),
+        "commands": capability("write_capable", "Commands", "Claude Code slash commands can be managed."),
+        "agents": capability("write_capable", "Agents", "Claude Code agents can be managed."),
+        "skills": capability("write_capable", "Skills", "Claude Code skills can be managed."),
+        "hooks": capability("write_capable", "Hooks", "Claude Code hooks can be managed."),
+        "memory": capability("write_capable", "Memory", "Claude Code memory files can be viewed and edited."),
+        "output_styles": capability("write_capable", "Output Styles", "Claude Code output styles can be managed."),
+        "statusline": capability("write_capable", "Status Line", "Claude Code status line settings can be managed."),
+        "usage": capability("read_only", "Usage", "Claude Code usage data is available read-only."),
+        "context": capability("read_only", "Context", "Claude Code context diagnostics are available read-only."),
+        "doctor": capability("unsupported", "Doctor", "Claude Code does not expose provider doctor diagnostics."),
+        "backup": capability("write_capable", "Backup", "Claude Code backup and restore workflows are available."),
+    },
+    "codex-cli": {
+        "config": capability("write_capable", "Configuration", "Safe Codex TOML settings can be viewed and edited."),
+        "sessions": capability("write_capable", "Agent Bridge Sessions", "Agent Bridge can discover and launch Codex sessions."),
+        "spawn": capability("write_capable", "Spawn Sessions", "Agent Bridge can launch Codex sessions."),
+        "resume": capability("write_capable", "Resume Sessions", "Codex resume is available."),
+        "fork": capability("write_capable", "Fork Sessions", "Codex fork is available."),
+        "mcp": capability("write_capable", "MCP Servers", "Codex MCP servers can be managed through the Codex CLI."),
+        "plugins": capability("read_only", "Plugins", "Codex plugin inventory is available read-only in this build."),
+        "permissions": capability("unsupported", "Permissions", "Codex trust and permissions use different config semantics."),
+        "commands": capability("unsupported", "Commands", "Codex does not expose Claude Code slash commands."),
+        "agents": capability("unsupported", "Agents", "Codex does not expose Claude Code agents."),
+        "skills": capability("unsupported", "Skills", "Codex skills are not surfaced in this build."),
+        "hooks": capability("unsupported", "Hooks", "Codex does not expose Claude Code hooks."),
+        "memory": capability("unsupported", "Memory", "Codex memory files are not surfaced in this build."),
+        "output_styles": capability("unsupported", "Output Styles", "Codex does not expose Claude Code output styles."),
+        "statusline": capability("unsupported", "Status Line", "Codex does not expose Claude Code status line settings."),
+        "usage": capability("unsupported", "Usage", "Codex usage data is not available with stable local semantics."),
+        "context": capability("unsupported", "Context", "Codex context diagnostics are not available with stable local semantics."),
+        "doctor": capability("read_only", "Doctor", "Codex doctor diagnostics are available read-only."),
+        "backup": capability("read_only", "Backup", "Codex export-only backups are available."),
+    },
+}
+
+
+def normalize_capability_matrix(provider_id: str) -> dict[str, dict[str, Any]]:
+    matrix = deepcopy(PROVIDER_CAPABILITY_MATRIX.get(provider_id, {}))
+    for key in CAPABILITY_KEYS:
+        matrix.setdefault(
+            key,
+            capability("unknown", key.replace("_", " ").title(), "Capability has not been classified."),
+        )
+    return matrix
+
+
+def capability_flags(provider_id: str) -> dict[str, bool]:
+    matrix = normalize_capability_matrix(provider_id)
+    return {
+        key: detail.get("state") in SUPPORTED_STATES
+        for key, detail in matrix.items()
+    }

--- a/backend/app/services/providers/claude_code.py
+++ b/backend/app/services/providers/claude_code.py
@@ -18,24 +18,6 @@ class ClaudeCodeProvider(AgentProvider):
     display_name = "Claude Code"
     binary_name = "claude"
 
-    def get_capabilities(self) -> dict[str, bool]:
-        return {
-            "sessions": True,
-            "spawn": True,
-            "resume": True,
-            "fork": False,
-            "mcp": True,
-            "plugins": True,
-            "commands": True,
-            "agents": True,
-            "skills": True,
-            "hooks": True,
-            "memory": True,
-            "usage": True,
-            "context": True,
-            "doctor": False,
-        }
-
     def get_config_paths(self, project_path: str | None = None) -> dict:
         paths = ClaudePathUtils()
         result = {

--- a/backend/app/services/providers/codex_cli.py
+++ b/backend/app/services/providers/codex_cli.py
@@ -23,24 +23,6 @@ class CodexCliProvider(AgentProvider):
     binary_name = "codex"
     version_args = ("--version",)
 
-    def get_capabilities(self) -> dict[str, bool]:
-        return {
-            "sessions": True,
-            "spawn": True,
-            "resume": True,
-            "fork": True,
-            "mcp": True,
-            "plugins": True,
-            "commands": False,
-            "agents": False,
-            "skills": False,
-            "hooks": False,
-            "memory": False,
-            "usage": False,
-            "context": False,
-            "doctor": True,
-        }
-
     def get_config_paths(self, project_path: str | None = None) -> dict:
         home = get_codex_home()
         return {

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -13,6 +13,34 @@ def test_provider_registry_contains_initial_providers():
     assert get_provider("codex-cli").binary_name == "codex"
 
 
+def test_provider_status_includes_central_capability_matrix():
+    from app.services.providers import get_provider
+
+    claude = get_provider("claude-code").get_status()
+    codex = get_provider("codex-cli").get_status()
+
+    assert claude["capabilities"]["plugins"] is True
+    assert claude["capabilities"]["fork"] is False
+    assert claude["capability_matrix"]["plugins"]["state"] == "write_capable"
+    assert claude["capability_matrix"]["doctor"]["state"] == "unsupported"
+    assert codex["capabilities"]["plugins"] is True
+    assert codex["capability_matrix"]["plugins"]["state"] == "read_only"
+    assert codex["capability_matrix"]["mcp"]["state"] == "write_capable"
+    assert codex["capability_matrix"]["usage"]["state"] == "unsupported"
+    assert codex["capability_matrix"]["doctor"]["state"] == "read_only"
+
+
+def test_provider_capabilities_api_returns_matrix():
+    from app.api.v1 import providers as providers_api
+
+    response = providers_api.get_provider_capabilities("codex-cli")
+
+    assert response["provider"] == "codex-cli"
+    assert response["capabilities"]["config"] is True
+    assert response["capability_matrix"]["config"]["state"] == "write_capable"
+    assert response["capability_matrix"]["commands"]["state"] == "unsupported"
+
+
 def test_codex_process_detection_matches_interactive_binary():
     from app.services.providers import get_provider
 
@@ -31,4 +59,3 @@ def test_codex_process_detection_matches_node_wrapper_descendant():
     with patch("app.services.providers.base.subprocess.run") as run:
         run.return_value = SimpleNamespace(stdout="456 /usr/local/bin/codex\n")
         assert provider.is_process_match("node", "123") is True
-

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -10,7 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import type { AgentProviderId } from '@/types/providers'
+import type { AgentProviderCapabilities, AgentProviderId, AgentProviderStatus } from '@/types/providers'
 import {
   LayoutDashboard,
   Settings,
@@ -41,7 +41,7 @@ type NavItem = {
   name: string
   href: string
   icon: LucideIcon
-  providerSupport?: AgentProviderId[]
+  capability?: keyof AgentProviderCapabilities
 }
 
 type NavGroup = {
@@ -55,7 +55,7 @@ const commonNavigation: NavGroup[] = [
     items: [
       { name: 'Dashboard', href: '/', icon: LayoutDashboard },
       { name: 'Projects', href: '/projects', icon: FolderOpen },
-      { name: 'Agent Bridge', href: '/agent-bridge', icon: MonitorPlay },
+      { name: 'Agent Bridge', href: '/agent-bridge', icon: MonitorPlay, capability: 'sessions' },
     ],
   },
   {
@@ -63,7 +63,7 @@ const commonNavigation: NavGroup[] = [
     items: [
       { name: 'Presence', href: '/presence', icon: Radio },
       { name: 'Plans', href: '/plans', icon: ClipboardList },
-      { name: 'Backup', href: '/backup', icon: Archive },
+      { name: 'Backup', href: '/backup', icon: Archive, capability: 'backup' },
     ],
   },
 ]
@@ -73,30 +73,30 @@ const providerNavigation: Record<AgentProviderId, NavGroup[]> = {
     {
       name: 'Claude Code',
       items: [
-        { name: 'Config', href: '/config', icon: Settings },
-        { name: 'Sessions', href: '/sessions', icon: MessageSquare },
-        { name: 'MCP Servers', href: '/mcp', icon: Server },
-        { name: 'Plugins', href: '/plugins', icon: Package },
-        { name: 'Permissions / Trust', href: '/permissions', icon: Shield },
+        { name: 'Config', href: '/config', icon: Settings, capability: 'config' },
+        { name: 'Sessions', href: '/sessions', icon: MessageSquare, capability: 'sessions' },
+        { name: 'MCP Servers', href: '/mcp', icon: Server, capability: 'mcp' },
+        { name: 'Plugins', href: '/plugins', icon: Package, capability: 'plugins' },
+        { name: 'Permissions / Trust', href: '/permissions', icon: Shield, capability: 'permissions' },
       ],
     },
     {
       name: 'Claude Tools',
       items: [
-        { name: 'Commands', href: '/commands', icon: Terminal },
-        { name: 'Hooks', href: '/hooks', icon: Webhook },
-        { name: 'Agents', href: '/agents', icon: Bot },
-        { name: 'Skills', href: '/skills', icon: Sparkles },
-        { name: 'Memory', href: '/memory', icon: Brain },
-        { name: 'Output Styles', href: '/output-styles', icon: Paintbrush },
-        { name: 'Status Line', href: '/statusline', icon: Activity },
+        { name: 'Commands', href: '/commands', icon: Terminal, capability: 'commands' },
+        { name: 'Hooks', href: '/hooks', icon: Webhook, capability: 'hooks' },
+        { name: 'Agents', href: '/agents', icon: Bot, capability: 'agents' },
+        { name: 'Skills', href: '/skills', icon: Sparkles, capability: 'skills' },
+        { name: 'Memory', href: '/memory', icon: Brain, capability: 'memory' },
+        { name: 'Output Styles', href: '/output-styles', icon: Paintbrush, capability: 'output_styles' },
+        { name: 'Status Line', href: '/statusline', icon: Activity, capability: 'statusline' },
       ],
     },
     {
       name: 'Claude Metrics',
       items: [
-        { name: 'Context', href: '/context', icon: Gauge },
-        { name: 'Usage', href: '/usage', icon: BarChart3 },
+        { name: 'Context', href: '/context', icon: Gauge, capability: 'context' },
+        { name: 'Usage', href: '/usage', icon: BarChart3, capability: 'usage' },
       ],
     },
   ],
@@ -104,7 +104,7 @@ const providerNavigation: Record<AgentProviderId, NavGroup[]> = {
     {
       name: 'Codex',
       items: [
-        { name: 'Config', href: '/config', icon: Settings },
+        { name: 'Config', href: '/config', icon: Settings, capability: 'config' },
       ],
     },
   ],
@@ -117,16 +117,21 @@ function getNavigation(providerId: AgentProviderId): NavGroup[] {
   ]
 }
 
-function supportsProvider(item: NavItem, providerId: AgentProviderId) {
-  return !item.providerSupport || item.providerSupport.includes(providerId)
+const visibleCapabilityStates = new Set(['supported', 'read_only', 'write_capable'])
+
+function supportsProvider(item: NavItem, provider: AgentProviderStatus | null) {
+  if (!item.capability || !provider) return true
+  const detail = provider.capability_matrix?.[item.capability]
+  if (detail) return visibleCapabilityStates.has(detail.state)
+  return Boolean(provider.capabilities?.[item.capability])
 }
 
-function NavGroupSection({ group, collapsed, selectedProviderId }: {
+function NavGroupSection({ group, collapsed, selectedProvider }: {
   group: NavGroup
   collapsed: boolean
-  selectedProviderId: AgentProviderId
+  selectedProvider: AgentProviderStatus | null
 }) {
-  const visibleItems = group.items.filter((item) => supportsProvider(item, selectedProviderId))
+  const visibleItems = group.items.filter((item) => supportsProvider(item, selectedProvider))
   if (visibleItems.length === 0) return null
 
   return (
@@ -162,7 +167,7 @@ function NavGroupSection({ group, collapsed, selectedProviderId }: {
 
 export function Sidebar() {
   const { collapsed, setCollapsed } = useSidebar()
-  const { providers, selectedProviderId, setSelectedProviderId } = useProviderContext()
+  const { providers, selectedProviderId, selectedProvider, setSelectedProviderId } = useProviderContext()
   const visibleGroups = getNavigation(selectedProviderId)
 
   return (
@@ -199,7 +204,7 @@ export function Sidebar() {
             key={group.name}
             group={group}
             collapsed={collapsed}
-            selectedProviderId={selectedProviderId}
+            selectedProvider={selectedProvider}
           />
         ))}
       </nav>

--- a/frontend/src/types/providers.ts
+++ b/frontend/src/types/providers.ts
@@ -1,20 +1,33 @@
 export type AgentProviderId = 'claude-code' | 'codex-cli'
 
 export interface AgentProviderCapabilities {
+  config: boolean
   sessions: boolean
   spawn: boolean
   resume: boolean
   fork: boolean
   mcp: boolean
   plugins: boolean
+  permissions: boolean
   commands: boolean
   agents: boolean
   skills: boolean
   hooks: boolean
   memory: boolean
+  output_styles: boolean
+  statusline: boolean
   usage: boolean
   context: boolean
   doctor: boolean
+  backup: boolean
+}
+
+export type AgentProviderCapabilityState = 'supported' | 'read_only' | 'write_capable' | 'unsupported' | 'unknown'
+
+export interface AgentProviderCapabilityDetail {
+  state: AgentProviderCapabilityState
+  label: string
+  reason?: string
 }
 
 export interface AgentProviderStatus {
@@ -25,6 +38,7 @@ export interface AgentProviderStatus {
   binary_path: string | null
   version: string | null
   capabilities: AgentProviderCapabilities
+  capability_matrix: Partial<Record<keyof AgentProviderCapabilities, AgentProviderCapabilityDetail>>
   config_paths: Record<string, string>
 }
 


### PR DESCRIPTION
## Summary
- Add a centralized provider capability matrix for Claude Code and Codex
- Keep legacy boolean capabilities derived from richer supported/read-only/write-capable/unsupported states
- Expose capability_matrix in provider status and a focused provider capabilities endpoint
- Use capability metadata to drive provider-sensitive sidebar visibility

Refs #142

## Test plan
- [x] backend venv pytest: backend/tests/test_providers.py backend/tests/test_provider_doctor_api.py backend/tests/test_provider_inventory_api.py
- [x] backend app import
- [x] focused frontend ESLint for sidebar/provider types
- [x] npm run build
- [x] git diff --check