### PR TITLE
Add Codex usage context diagnostics

### DIFF
--- a/backend/app/api/v1/providers.py
+++ b/backend/app/api/v1/providers.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from app.models.schemas import CLIExecuteRequest, CLIResult
 from app.services.cli_executor import ProviderCLIExecutor
+from app.services.codex_usage_context_service import CodexUsageContextService
 from app.services.providers import get_provider, get_providers
 
 router = APIRouter()
@@ -84,7 +85,7 @@ def _require_codex_provider(provider_id: str):
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
     if provider.id != "codex-cli":
-        raise HTTPException(status_code=400, detail="Inventory endpoints are currently Codex-only")
+        raise HTTPException(status_code=400, detail="This provider endpoint is currently Codex-only")
     return provider
 
 
@@ -379,4 +380,15 @@ def get_provider_plugin_inventory(provider_id: str):
         "plugins": _redact_value(_parse_plugin_rows(result.stdout)),
         "stderr": _redact_value(result.stderr),
         "raw_stdout": safe_stdout,
+    }
+
+
+@router.get("/providers/{provider_id}/usage-context-diagnostics")
+def get_provider_usage_context_diagnostics(provider_id: str):
+    provider = _require_codex_provider(provider_id)
+    diagnostics = CodexUsageContextService().get_diagnostics()
+    return {
+        "provider": provider.id,
+        "provider_display_name": provider.display_name,
+        **diagnostics,
     }

--- a/backend/app/services/codex_usage_context_service.py
+++ b/backend/app/services/codex_usage_context_service.py
@@ -1,0 +1,232 @@
+"""Read-only Codex usage/context diagnostics.
+
+Codex history contains prompt text, and the local model cache is not a stable
+usage source. This service reports only safe file-shape metadata so callers can
+explain the current unsupported state without exposing raw prompts or cache
+payloads.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from app.services.providers.codex_cli import get_codex_home
+
+
+METRIC_KEY_MARKERS = (
+    "token",
+    "usage",
+    "context",
+)
+
+MAX_HISTORY_ROWS = 50_000
+MAX_MODELS_CACHE_BYTES = 5 * 1024 * 1024
+
+
+class CodexUsageContextService:
+    """Summarize Codex usage/context data sources without exposing contents."""
+
+    def __init__(
+        self,
+        codex_home: Path | None = None,
+        *,
+        max_history_rows: int = MAX_HISTORY_ROWS,
+        max_models_cache_bytes: int = MAX_MODELS_CACHE_BYTES,
+    ):
+        self.codex_home = (codex_home or get_codex_home()).expanduser()
+        self.history_path = self.codex_home / "history.jsonl"
+        self.models_cache_path = self.codex_home / "models_cache.json"
+        self.max_history_rows = max_history_rows
+        self.max_models_cache_bytes = max_models_cache_bytes
+
+    def get_diagnostics(self) -> dict[str, Any]:
+        """Return safe diagnostics for Codex usage/context parity."""
+        history = self._summarize_history()
+        models_cache = self._summarize_models_cache()
+        sqlite_files = self._summarize_sqlite_files()
+
+        metric_fields = sorted(
+            set(history.get("metric_fields_present", []))
+            | set(models_cache.get("metric_fields_present", []))
+        )
+        stable_usage_surface = False
+        stable_context_surface = False
+
+        return {
+            "provider": "codex-cli",
+            "decision": {
+                "surface": "diagnostics_only",
+                "usage_status": "unsupported",
+                "context_status": "unsupported",
+                "reason": (
+                    "Local Codex files do not currently expose a stable usage "
+                    "or context metric surface that can be read without prompt "
+                    "text or raw cache payloads."
+                ),
+            },
+            "sources": {
+                "history": {
+                    "path": str(self.history_path),
+                    "exists": self.history_path.exists(),
+                },
+                "models_cache": {
+                    "path": str(self.models_cache_path),
+                    "exists": self.models_cache_path.exists(),
+                },
+                "sqlite_files": sqlite_files,
+            },
+            "history": history,
+            "models_cache": models_cache,
+            "metric_findings": {
+                "metric_fields_present": metric_fields,
+                "token_metrics_present": any("token" in field.lower() for field in metric_fields),
+                "context_metrics_present": any("context" in field.lower() for field in metric_fields),
+                "stable_usage_surface": stable_usage_surface,
+                "stable_context_surface": stable_context_surface,
+                "notes": [
+                    "history.jsonl text values are treated as prompt content and are not returned.",
+                    "models_cache.json model payloads are summarized by shape only.",
+                ],
+            },
+        }
+
+    def _summarize_history(self) -> dict[str, Any]:
+        summary: dict[str, Any] = {
+            "exists": False,
+            "size_bytes": 0,
+            "rows_read": 0,
+            "valid_rows": 0,
+            "invalid_rows": 0,
+            "truncated": False,
+            "observed_keys": [],
+            "standard_fields_present": [],
+            "metric_fields_present": [],
+            "prompt_text_omitted": True,
+        }
+        if not self.history_path.exists():
+            return summary
+
+        summary["exists"] = True
+        summary["size_bytes"] = self._safe_size(self.history_path)
+        observed_keys: set[str] = set()
+        standard_fields: set[str] = set()
+        metric_fields: set[str] = set()
+
+        try:
+            with self.history_path.open("r", encoding="utf-8", errors="replace") as handle:
+                for line in handle:
+                    if summary["rows_read"] >= self.max_history_rows:
+                        summary["truncated"] = True
+                        break
+                    stripped = line.strip()
+                    if not stripped:
+                        continue
+                    summary["rows_read"] += 1
+                    try:
+                        row = json.loads(stripped)
+                    except json.JSONDecodeError:
+                        summary["invalid_rows"] += 1
+                        continue
+                    if not isinstance(row, dict):
+                        summary["invalid_rows"] += 1
+                        continue
+                    summary["valid_rows"] += 1
+                    for key in row:
+                        key_string = str(key)
+                        observed_keys.add(key_string)
+                        if key_string in {"session_id", "ts", "text"}:
+                            standard_fields.add(key_string)
+                        if self._looks_like_metric_key(key_string):
+                            metric_fields.add(key_string)
+        except OSError as exc:
+            summary["read_error"] = type(exc).__name__
+
+        summary["observed_keys"] = sorted(observed_keys)
+        summary["standard_fields_present"] = sorted(standard_fields)
+        summary["metric_fields_present"] = sorted(metric_fields)
+        return summary
+
+    def _summarize_models_cache(self) -> dict[str, Any]:
+        summary: dict[str, Any] = {
+            "exists": False,
+            "size_bytes": 0,
+            "too_large": False,
+            "parse_error": None,
+            "root_keys": [],
+            "metadata_fields_present": [],
+            "metric_fields_present": [],
+            "model_count": None,
+            "models_shape": None,
+            "etag_present": False,
+            "raw_payload_omitted": True,
+        }
+        if not self.models_cache_path.exists():
+            return summary
+
+        summary["exists"] = True
+        summary["size_bytes"] = self._safe_size(self.models_cache_path)
+        if summary["size_bytes"] > self.max_models_cache_bytes:
+            summary["too_large"] = True
+            return summary
+
+        try:
+            payload = json.loads(self.models_cache_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            summary["parse_error"] = "invalid_json"
+            return summary
+        except OSError as exc:
+            summary["parse_error"] = type(exc).__name__
+            return summary
+
+        if not isinstance(payload, dict):
+            summary["parse_error"] = "root_not_object"
+            return summary
+
+        root_keys = sorted(str(key) for key in payload)
+        summary["root_keys"] = root_keys
+        summary["metadata_fields_present"] = [
+            key for key in ("fetched_at", "etag", "client_version") if key in payload
+        ]
+        summary["etag_present"] = "etag" in payload
+        summary["metric_fields_present"] = [
+            key for key in root_keys if self._looks_like_metric_key(key)
+        ]
+
+        models = payload.get("models")
+        if isinstance(models, list):
+            summary["models_shape"] = "list"
+            summary["model_count"] = len(models)
+        elif isinstance(models, dict):
+            summary["models_shape"] = "object"
+            summary["model_count"] = len(models)
+        elif models is not None:
+            summary["models_shape"] = type(models).__name__
+
+        return summary
+
+    def _summarize_sqlite_files(self) -> list[dict[str, Any]]:
+        files: list[dict[str, Any]] = []
+        for path in sorted(self.codex_home.glob("*.sqlite*")):
+            if not path.is_file():
+                continue
+            files.append(
+                {
+                    "name": path.name,
+                    "size_bytes": self._safe_size(path),
+                    "contents_omitted": True,
+                }
+            )
+        return files
+
+    @staticmethod
+    def _looks_like_metric_key(key: str) -> bool:
+        lower_key = key.lower()
+        return any(marker in lower_key for marker in METRIC_KEY_MARKERS)
+
+    @staticmethod
+    def _safe_size(path: Path) -> int:
+        try:
+            return path.stat().st_size
+        except OSError:
+            return 0

--- a/backend/tests/test_codex_usage_context_service.py
+++ b/backend/tests/test_codex_usage_context_service.py
@@ -1,0 +1,166 @@
+"""Tests for Codex usage/context diagnostics."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.services.codex_usage_context_service import CodexUsageContextService
+
+
+def test_diagnostics_omit_history_text_and_raw_model_cache(tmp_path):
+    prompt_sentinel = "TEXT_FIELD_SENTINEL_SHOULD_NOT_RETURN"
+    etag_sentinel = "OPAQUE_ETAG_SHOULD_NOT_RETURN"
+    model_sentinel = "MODEL_SENTINEL_SHOULD_NOT_RETURN"
+    (tmp_path / "history.jsonl").write_text(
+        json.dumps(
+            {
+                "session_id": "session-1",
+                "ts": "2026-05-26T10:00:00Z",
+                "text": prompt_sentinel,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "models_cache.json").write_text(
+        json.dumps(
+            {
+                "fetched_at": "2026-05-26T10:00:00Z",
+                "etag": etag_sentinel,
+                "client_version": "codex-cli 0.0.0",
+                "models": [{"id": model_sentinel, "context_window": 200000}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    diagnostics = CodexUsageContextService(codex_home=tmp_path).get_diagnostics()
+    serialized = json.dumps(diagnostics)
+
+    assert diagnostics["decision"]["usage_status"] == "unsupported"
+    assert diagnostics["decision"]["context_status"] == "unsupported"
+    assert diagnostics["history"]["valid_rows"] == 1
+    assert diagnostics["history"]["standard_fields_present"] == ["session_id", "text", "ts"]
+    assert diagnostics["models_cache"]["model_count"] == 1
+    assert diagnostics["models_cache"]["etag_present"] is True
+    assert diagnostics["models_cache"]["metadata_fields_present"] == [
+        "fetched_at",
+        "etag",
+        "client_version",
+    ]
+    assert prompt_sentinel not in serialized
+    assert etag_sentinel not in serialized
+    assert model_sentinel not in serialized
+
+
+def test_diagnostics_detect_metric_like_keys_without_values(tmp_path):
+    (tmp_path / "history.jsonl").write_text(
+        json.dumps(
+            {
+                "session_id": "session-1",
+                "ts": "2026-05-26T10:00:00Z",
+                "text": "omitted",
+                "input_tokens": 123,
+                "context_window": 200000,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "models_cache.json").write_text(
+        json.dumps({"models": [], "usage_hint": "not returned"}),
+        encoding="utf-8",
+    )
+
+    diagnostics = CodexUsageContextService(codex_home=tmp_path).get_diagnostics()
+
+    assert diagnostics["history"]["metric_fields_present"] == ["context_window", "input_tokens"]
+    assert diagnostics["models_cache"]["metric_fields_present"] == ["usage_hint"]
+    assert diagnostics["metric_findings"]["metric_fields_present"] == [
+        "context_window",
+        "input_tokens",
+        "usage_hint",
+    ]
+    assert diagnostics["metric_findings"]["token_metrics_present"] is True
+    assert diagnostics["metric_findings"]["context_metrics_present"] is True
+    assert diagnostics["metric_findings"]["stable_usage_surface"] is False
+
+
+def test_diagnostics_handle_missing_and_malformed_files(tmp_path):
+    service = CodexUsageContextService(codex_home=tmp_path)
+    missing = service.get_diagnostics()
+
+    assert missing["history"]["exists"] is False
+    assert missing["models_cache"]["exists"] is False
+
+    (tmp_path / "history.jsonl").write_text("{not-json\n", encoding="utf-8")
+    (tmp_path / "models_cache.json").write_text("{not-json", encoding="utf-8")
+
+    malformed = service.get_diagnostics()
+
+    assert malformed["history"]["rows_read"] == 1
+    assert malformed["history"]["invalid_rows"] == 1
+    assert malformed["models_cache"]["parse_error"] == "invalid_json"
+
+
+def test_diagnostics_limit_history_and_large_cache(tmp_path):
+    (tmp_path / "history.jsonl").write_text(
+        "\n".join(
+            json.dumps(
+                {
+                    "session_id": f"session-{index}",
+                    "ts": "2026-05-26T10:00:00Z",
+                    "text": "omitted",
+                }
+            )
+            for index in range(3)
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "models_cache.json").write_text("123456", encoding="utf-8")
+
+    diagnostics = CodexUsageContextService(
+        codex_home=tmp_path,
+        max_history_rows=2,
+        max_models_cache_bytes=5,
+    ).get_diagnostics()
+
+    assert diagnostics["history"]["rows_read"] == 2
+    assert diagnostics["history"]["truncated"] is True
+    assert diagnostics["models_cache"]["too_large"] is True
+    assert diagnostics["models_cache"]["raw_payload_omitted"] is True
+
+
+def test_diagnostics_include_sqlite_metadata_only(tmp_path):
+    (tmp_path / "logs.sqlite").write_text("opaque", encoding="utf-8")
+
+    diagnostics = CodexUsageContextService(codex_home=tmp_path).get_diagnostics()
+
+    assert diagnostics["sources"]["sqlite_files"] == [
+        {"name": "logs.sqlite", "size_bytes": 6, "contents_omitted": True}
+    ]
+
+
+def test_provider_usage_context_endpoint_is_codex_only(monkeypatch):
+    from app.api.v1 import providers as providers_api
+
+    class FakeService:
+        def get_diagnostics(self):
+            return {
+                "provider": "codex-cli",
+                "decision": {"usage_status": "unsupported", "context_status": "unsupported"},
+            }
+
+    monkeypatch.setattr(providers_api, "CodexUsageContextService", lambda: FakeService())
+
+    response = providers_api.get_provider_usage_context_diagnostics("codex-cli")
+
+    assert response["provider"] == "codex-cli"
+    assert response["provider_display_name"] == "Codex"
+    assert response["decision"]["usage_status"] == "unsupported"
+
+    with pytest.raises(providers_api.HTTPException) as exc_info:
+        providers_api.get_provider_usage_context_diagnostics("claude-code")
+    assert exc_info.value.status_code == 400

--- a/docs/plans/2026-05-26-codex-usage-context-investigation.md
+++ b/docs/plans/2026-05-26-codex-usage-context-investigation.md
@@ -1,0 +1,40 @@
+# Codex Usage/Context Parity Investigation
+
+Date: 2026-05-26
+Issue: #142
+
+## Decision
+
+Codex usage and context parity should stay diagnostics-only for now. The local
+Codex files observed on this machine do not expose a stable token usage or
+context-window metric surface that is safe to treat like Claude Code usage and
+context data.
+
+The backend now exposes a read-only Codex diagnostics endpoint:
+
+- `GET /api/v1/providers/codex-cli/usage-context-diagnostics`
+
+This endpoint returns file-shape metadata and an explicit unsupported decision.
+It does not return prompt text, raw history rows, raw model cache payloads,
+session ids, model ids, auth data, or cache contents.
+
+## Safe Observations
+
+Observed local Codex files:
+
+- `history.jsonl`: JSONL rows include keys such as `session_id`, `ts`, and
+  `text`. The `text` field is prompt content and must be treated as sensitive.
+- `models_cache.json`: root keys include metadata such as `fetched_at`, `etag`,
+  `client_version`, and `models`. The model list is cache data rather than a
+  usage ledger.
+
+The diagnostics endpoint reports counts, root keys, file sizes, parse status,
+and whether metric-like key names are present. It intentionally omits values for
+sensitive or opaque fields.
+
+## Product Implication
+
+Claude Code usage and context pages remain Claude-specific. Codex should not be
+shown as having usage or context parity until a stable local or CLI-backed Codex
+metric source exists that can be read without exposing prompt text or raw cache
+payloads.


### PR DESCRIPTION
## Summary
- Add a Codex-only usage/context diagnostics endpoint with explicit unsupported parity status
- Summarize history/model-cache file shapes without returning prompt text, session ids, model ids, or raw cache payloads
- Document the diagnostics-only decision for issue #142

Refs #142

## Checks
- /home/joni/repos/claude-deck/backend/venv/bin/python -m pytest backend/tests/test_codex_usage_context_service.py backend/tests/test_provider_inventory_api.py backend/tests/test_provider_cli_executor.py backend/tests/test_providers.py
- /home/joni/repos/claude-deck/backend/venv/bin/python - <<'PY'
import app.main
print('app import ok')
PY
- git diff --check