### PR TITLE
Clarify Codex backup restore policy

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -894,7 +894,7 @@ class BackupBase(BaseModel):
 
     name: str
     description: Optional[str] = None
-    scope: str  # "full", "user", "project"
+    scope: str  # "full", "user", "project", "codex"
 
 
 class BackupCreate(BackupBase):
@@ -1401,6 +1401,7 @@ class BackupManifestContents(BaseModel):
     agents: List[str] = []
     commands: List[str] = []
     provider_inventory: Dict[str, Any] = {}
+    backup_policy: Dict[str, Any] = {}
 
 
 class BackupManifest(BaseModel):

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -44,9 +44,14 @@ from app.utils.path_utils import (
     get_project_claude_md_file,
 )
 from app.services.cli_executor import ProviderCLIExecutor
+from app.services.providers import get_provider
 from app.services.providers.codex_cli import get_codex_home
 
 
+CODEX_RESTORE_REFUSAL_MESSAGE = (
+    "Codex backups are export-only; automatic restore is not supported because "
+    "exports intentionally exclude auth, history, cache, and local SQLite state."
+)
 SENSITIVE_KEY_PATTERN = re.compile(r"(token|secret|password|credential|api[_-]?key|auth|cookie|session)", re.I)
 SENSITIVE_ASSIGNMENT_PATTERN = re.compile(
     r"(?P<key>[A-Za-z0-9_.-]*(?:token|secret|password|credential|api[_-]?key|auth|cookie|session)[A-Za-z0-9_.-]*)"
@@ -175,6 +180,36 @@ class BackupService:
 
         return paths
 
+    def _get_codex_backup_policy(self) -> Dict[str, Any]:
+        """Return the Codex export/restore policy used in manifests and status."""
+        try:
+            provider_policy = get_provider("codex-cli").get_backup_policy()
+        except Exception:
+            provider_policy = None
+        return dict(provider_policy or {
+            "provider": "codex-cli",
+            "export_supported": True,
+            "automatic_restore_supported": False,
+            "restore_mode": "manual_review",
+            "included": [
+                "config.toml with secret-like assignments redacted",
+                "*.config.toml profile files with secret-like assignments redacted",
+                "rules/*.rules files with secret-like assignments redacted",
+                "redacted provider inventory metadata",
+            ],
+            "excluded": [
+                "auth.json",
+                "history.jsonl",
+                "models_cache.json",
+                "*.sqlite and related SQLite sidecar files",
+                "raw cache payloads and prompt text",
+            ],
+            "restore_refusal_reasons": [
+                "Codex auth, history, cache, and local state are intentionally excluded from exports.",
+                "Automatic restore could overwrite active Codex state without a stable provider-owned restore API.",
+            ],
+        })
+
     def _redact_value(self, value: Any, parent_key: str = "") -> Any:
         """Redact sensitive values from generated backup metadata."""
         if value is None:
@@ -212,6 +247,7 @@ class BackupService:
         inventory: Dict[str, Any] = {
             "provider": "codex-cli",
             "codex_home": str(self.codex_home),
+            "backup_policy": self._get_codex_backup_policy(),
             "files": [
                 {
                     "path": str(path),
@@ -388,6 +424,7 @@ class BackupService:
             contents.files.extend(extra_files.keys())
         if provider_inventory:
             contents.provider_inventory = provider_inventory
+            contents.backup_policy = provider_inventory.get("backup_policy", {})
 
         # Detect skills
         if scope != "codex":
@@ -671,14 +708,19 @@ class BackupService:
             platform_compatible=True,
         )
         if backup.scope == "codex":
+            policy = self._get_codex_backup_policy()
             plan.warnings.append(
                 RestorePlanWarning(
-                    type="version",
-                    message="Codex backups are export-only in this version. Download the archive and restore files manually.",
-                    severity="warning",
+                    type="unsupported_restore",
+                    message=CODEX_RESTORE_REFUSAL_MESSAGE,
+                    severity="error",
                 )
             )
-            plan.manual_steps.append("Review the redacted Codex export before manually copying files into CODEX_HOME.")
+            for reason in policy.get("restore_refusal_reasons", []):
+                plan.manual_steps.append(reason)
+            plan.manual_steps.append(
+                "Download and review the redacted Codex export before manually copying files into CODEX_HOME."
+            )
 
         # Check platform compatibility
         if manifest and manifest.platform != current_platform:
@@ -896,7 +938,7 @@ class BackupService:
         if backup.scope == "codex":
             return RestoreResult(
                 success=False,
-                message="Codex backups are export-only; automatic restore is not supported",
+                message=CODEX_RESTORE_REFUSAL_MESSAGE,
             )
 
         archive_path = Path(backup.file_path)

--- a/backend/app/services/providers/base.py
+++ b/backend/app/services/providers/base.py
@@ -117,6 +117,10 @@ class AgentProvider(ABC):
     def get_allowed_cli_commands(self) -> list[str]:
         """Return safe command names exposed by a provider CLI API."""
 
+    def get_backup_policy(self) -> dict[str, Any] | None:
+        """Return provider backup/export/restore policy metadata, if defined."""
+        return None
+
     def get_version(self) -> str | None:
         """Read the installed CLI version, if available."""
         binary_path = shutil.which(self.binary_name)
@@ -150,5 +154,5 @@ class AgentProvider(ABC):
             "version": version,
             "capabilities": self.get_capabilities(),
             "config_paths": self.get_config_paths(),
+            "backup_policy": self.get_backup_policy(),
         }
-

--- a/backend/app/services/providers/claude_code.py
+++ b/backend/app/services/providers/claude_code.py
@@ -34,6 +34,16 @@ class ClaudeCodeProvider(AgentProvider):
             "usage": True,
             "context": True,
             "doctor": False,
+            "backup": True,
+            "restore": True,
+        }
+
+    def get_backup_policy(self) -> dict:
+        return {
+            "provider": self.id,
+            "export_supported": True,
+            "automatic_restore_supported": True,
+            "restore_mode": "automatic",
         }
 
     def get_config_paths(self, project_path: str | None = None) -> dict:

--- a/backend/app/services/providers/codex_cli.py
+++ b/backend/app/services/providers/codex_cli.py
@@ -39,6 +39,33 @@ class CodexCliProvider(AgentProvider):
             "usage": False,
             "context": False,
             "doctor": True,
+            "backup": True,
+            "restore": False,
+        }
+
+    def get_backup_policy(self) -> dict:
+        return {
+            "provider": self.id,
+            "export_supported": True,
+            "automatic_restore_supported": False,
+            "restore_mode": "manual_review",
+            "included": [
+                "config.toml with secret-like assignments redacted",
+                "*.config.toml profile files with secret-like assignments redacted",
+                "rules/*.rules files with secret-like assignments redacted",
+                "redacted provider inventory metadata",
+            ],
+            "excluded": [
+                "auth.json",
+                "history.jsonl",
+                "models_cache.json",
+                "*.sqlite and related SQLite sidecar files",
+                "raw cache payloads and prompt text",
+            ],
+            "restore_refusal_reasons": [
+                "Codex auth, history, cache, and local state are intentionally excluded from exports.",
+                "Automatic restore could overwrite active Codex state without a stable provider-owned restore API.",
+            ],
         }
 
     def get_config_paths(self, project_path: str | None = None) -> dict:

--- a/backend/tests/test_codex_backup_service.py
+++ b/backend/tests/test_codex_backup_service.py
@@ -34,6 +34,7 @@ def test_codex_backup_exports_config_rules_and_redacted_inventory(monkeypatch, t
     (codex_home / "auth.json").write_text('{"token":"must-not-export"}', encoding="utf-8")
     (codex_home / "history.jsonl").write_text("must-not-export\n", encoding="utf-8")
     (codex_home / "models_cache.json").write_text("must-not-export\n", encoding="utf-8")
+    (codex_home / "logs.sqlite").write_text("must-not-export", encoding="utf-8")
 
     backup_dir = tmp_path / "backups"
     backup_dir.mkdir()
@@ -70,6 +71,8 @@ def test_codex_backup_exports_config_rules_and_redacted_inventory(monkeypatch, t
     assert manifest.claude_code_version is None
     assert manifest.contents.provider_inventory["provider"] == "codex-cli"
     assert manifest.contents.provider_inventory["mcp"]["servers"]["servers"]["linear"]["env"]["LINEAR_API_KEY"] == "[redacted]"
+    assert manifest.contents.backup_policy["automatic_restore_supported"] is False
+    assert manifest.contents.provider_inventory["backup_policy"]["restore_mode"] == "manual_review"
 
     with zipfile.ZipFile(backup.file_path) as zf:
         names = set(zf.namelist())
@@ -81,6 +84,7 @@ def test_codex_backup_exports_config_rules_and_redacted_inventory(monkeypatch, t
         assert "my-codex/auth.json" not in names
         assert "my-codex/history.jsonl" not in names
         assert "my-codex/models_cache.json" not in names
+        assert "my-codex/logs.sqlite" not in names
 
         config_export = zf.read("my-codex/config.toml").decode()
         assert "secret-config-token" not in config_export
@@ -89,10 +93,17 @@ def test_codex_backup_exports_config_rules_and_redacted_inventory(monkeypatch, t
         inventory_export = json.loads(zf.read("my-codex/provider-inventory.json"))
         assert "secret-api-key" not in json.dumps(inventory_export)
         assert "secret-plugin-token" not in json.dumps(inventory_export)
+        assert inventory_export["backup_policy"]["excluded"] == [
+            "auth.json",
+            "history.jsonl",
+            "models_cache.json",
+            "*.sqlite and related SQLite sidecar files",
+            "raw cache payloads and prompt text",
+        ]
 
 
 def test_codex_backup_restore_is_export_only(tmp_path):
-    from app.services.backup_service import BackupService
+    from app.services.backup_service import BackupService, CODEX_RESTORE_REFUSAL_MESSAGE
 
     archive_path = tmp_path / "codex.zip"
     with zipfile.ZipFile(archive_path, "w") as zf:
@@ -113,4 +124,59 @@ def test_codex_backup_restore_is_export_only(tmp_path):
     result = asyncio.run(service.restore_backup(1))
 
     assert result.success is False
-    assert "export-only" in result.message
+    assert result.message == CODEX_RESTORE_REFUSAL_MESSAGE
+
+
+def test_codex_backup_restore_plan_reports_explicit_refusal(tmp_path):
+    from app.services.backup_service import BackupService, CODEX_RESTORE_REFUSAL_MESSAGE
+
+    archive_path = tmp_path / "codex.zip"
+    manifest = {
+        "created_at": "2026-05-26T12:00:00",
+        "platform": "linux",
+        "scope": "codex",
+        "contents": {
+            "files": ["my-codex/config.toml", "my-codex/provider-inventory.json"],
+            "backup_policy": {
+                "automatic_restore_supported": False,
+                "restore_refusal_reasons": ["No provider-owned Codex restore API exists."],
+            },
+        },
+    }
+    with zipfile.ZipFile(archive_path, "w") as zf:
+        zf.writestr("manifest.json", json.dumps(manifest))
+        zf.writestr("my-codex/config.toml", 'model = "gpt-5"\n')
+        zf.writestr("my-codex/provider-inventory.json", "{}")
+
+    service = BackupService(db=None, codex_home=tmp_path / "my-codex")
+
+    async def fake_get_backup(_backup_id):
+        return SimpleNamespace(
+            id=7,
+            scope="codex",
+            file_path=str(archive_path),
+            name="codex-export",
+            created_at=datetime(2026, 5, 26, 12, 0, 0),
+        )
+
+    service.get_backup = fake_get_backup
+
+    plan = asyncio.run(service.get_restore_plan(7))
+
+    assert plan.scope == "codex"
+    assert plan.files_to_restore == ["my-codex/config.toml", "my-codex/provider-inventory.json"]
+    assert plan.warnings[0].type == "unsupported_restore"
+    assert plan.warnings[0].severity == "error"
+    assert plan.warnings[0].message == CODEX_RESTORE_REFUSAL_MESSAGE
+    assert any("Automatic restore could overwrite active Codex state" in step for step in plan.manual_steps)
+
+
+def test_codex_provider_status_exposes_backup_policy():
+    from app.services.providers import get_provider
+
+    status = get_provider("codex-cli").get_status()
+
+    assert status["capabilities"]["backup"] is True
+    assert status["capabilities"]["restore"] is False
+    assert status["backup_policy"]["automatic_restore_supported"] is False
+    assert "history.jsonl" in status["backup_policy"]["excluded"]

--- a/docs/plans/2026-05-26-codex-backup-restore-policy.md
+++ b/docs/plans/2026-05-26-codex-backup-restore-policy.md
@@ -1,0 +1,43 @@
+# Codex Backup/Export/Restore Policy
+
+Date: 2026-05-26
+Issue: #142
+
+## Decision
+
+Codex backups are export-only. Claude Deck may create and download a redacted
+Codex export, but it must not automatically restore Codex files until there is a
+stable provider-owned restore path.
+
+## Export Scope
+
+Codex exports include:
+
+- `config.toml` with secret-like assignments redacted
+- `*.config.toml` profile files with secret-like assignments redacted
+- `rules/*.rules` files with secret-like assignments redacted
+- redacted provider inventory metadata
+
+Codex exports exclude:
+
+- `auth.json`
+- `history.jsonl`
+- `models_cache.json`
+- `*.sqlite` files and related SQLite sidecars
+- raw cache payloads and prompt text
+
+## Restore Policy
+
+Automatic Codex restore is refused with an explicit error. The restore plan
+lists the archive contents for review, but the restore action returns a refusal
+instead of extracting files.
+
+Refusal reasons:
+
+- Codex auth, history, cache, and local state are intentionally excluded from
+  exports.
+- Automatic restore could overwrite active Codex state without a stable
+  provider-owned restore API.
+
+Manual restore remains possible outside Claude Deck after downloading and
+reviewing the redacted archive.


### PR DESCRIPTION
## Summary
- Add explicit provider backup/restore policy metadata for Claude Code and Codex
- Store Codex export policy in manifests/provider inventory and keep automatic restore refused with concrete reasons
- Document the Codex export-only policy and test excluded auth/history/cache/SQLite data

Refs #142

## Checks
- /home/joni/repos/claude-deck/backend/venv/bin/python -m pytest backend/tests/test_codex_backup_service.py backend/tests/test_providers.py
- /home/joni/repos/claude-deck/backend/venv/bin/python - <<'PY'
import app.main
print('app import ok')
PY
- git diff --check

Frontend checks not run; no frontend files changed.