### PR TITLE
Document Codex v2 provider framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A self-hosted web application for visualizing and managing local AI coding agent
 
 Claude Code starts simple, then slowly sprawls across config files and directories: `~/.claude.json`, `~/.claude/settings.json`, `.mcp.json`, slash commands, agents, skills, project settings, transcripts, and usage data. That works fine at small scale, but once your setup gets serious it becomes hard to see the whole picture, change things confidently, or understand what is actually configured.
 
-Claude Deck gives you one local interface for that sprawl. It also has first-class Codex CLI support for tmux sessions, TOML configuration, diagnostics, MCP inventory, and export-only backups.
+Claude Deck gives you one local interface for that sprawl. It also has provider-aware Codex CLI support for tmux sessions, safe TOML configuration, diagnostics, MCP/plugin inventory and supported CLI-backed mutations, and redacted export-only backups.
 
 ## Best For
 
@@ -47,6 +47,8 @@ If you only use Claude Code casually with mostly default config, Claude Deck may
 - **Plan History** — Browse and review Claude Code implementation plans
 - **Backup & Restore** — Create and manage Claude Code backups with selective restore, plus redacted export-only Codex backups
 - **Projects** — Discover and manage project directories
+
+Codex support is explicit about provider boundaries: usage/context parity and session transcript browsing are not supported for Codex yet; history and model-cache diagnostics avoid prompt text and raw cache payloads; Codex automatic restore is refused because exports intentionally exclude auth, history, cache, and local state.
 
 ## Screenshots
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
             { text: 'Installation', link: '/guide/installation' },
             { text: 'Quick Start', link: '/guide/quick-start' },
             { text: 'Architecture', link: '/guide/architecture' },
+            { text: 'Multi-Provider & Codex v2', link: '/guide/multi-provider-codex-v2' },
             { text: 'Contributing', link: '/guide/contributing' },
           ],
         },

--- a/docs/api/backup.md
+++ b/docs/api/backup.md
@@ -25,6 +25,8 @@ POST /api/v1/backup/create
 }
 ```
 
+Use `"scope": "codex"` for a Codex export. Codex exports are redacted and export-only.
+
 ### Get Backup
 
 ```http
@@ -74,6 +76,8 @@ Returns the ZIP archive file.
 ```http
 POST /api/v1/backup/{backup_id}/restore?project_path={path}
 ```
+
+Claude Code backups can be restored according to the restore plan. Codex backups refuse automatic restore and return an explicit failure because the archive excludes auth, history, cache, SQLite state, raw prompt text, and raw cache payloads.
 
 ### Install Dependencies
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -44,6 +44,8 @@ Error responses return JSON with a `detail` field:
 }
 ```
 
+Provider-aware endpoints may also map failures into normalized states such as unsupported capability, missing binary, unavailable CLI command, CLI failure, parse failure, or validation failure. Sensitive CLI stdout/stderr and raw provider payloads should be redacted or omitted before they are returned.
+
 ## API Documentation
 
 FastAPI generates interactive API docs at:

--- a/docs/api/providers.md
+++ b/docs/api/providers.md
@@ -12,6 +12,8 @@ GET /api/v1/providers
 
 Returns registered providers such as `claude-code` and `codex-cli`, including install status, version, capabilities, and config paths.
 
+Capability flags are stable booleans. Unsupported provider surfaces are returned as `false`; detailed provider-specific state belongs in metadata fields such as backup policy, diagnostics, inventory, or command status.
+
 ### Provider Status
 
 ```http
@@ -31,10 +33,11 @@ Runs Codex diagnostics and returns redacted output.
 ### Codex Inventory
 
 ```http
-GET /api/v1/providers/codex-cli/inventory
+GET /api/v1/providers/codex-cli/mcp
+GET /api/v1/providers/codex-cli/plugins
 ```
 
-Returns read-only Codex MCP and plugin inventory. Secret-like values are redacted.
+Returns Codex MCP and plugin inventory. Secret-like values are redacted. MCP JSON output is parsed and redacted before any raw output is returned. Plugin text output is treated as read-only text with best-effort row parsing.
 
 ### Codex MCP Mutation
 
@@ -43,4 +46,47 @@ POST /api/v1/providers/codex-cli/mcp
 DELETE /api/v1/providers/codex-cli/mcp/{name}
 ```
 
-Adds or removes Codex MCP servers through the Codex CLI with strict validation. Plugin mutation remains read-only in this version.
+Adds or removes Codex MCP servers through the Codex CLI with strict validation.
+
+### Codex Plugin Mutation
+
+```http
+POST /api/v1/providers/codex-cli/plugins/install
+DELETE /api/v1/providers/codex-cli/plugins/{name}
+```
+
+Installs or removes Codex plugins through the Codex CLI when the installed CLI exposes safe commands. Codex plugin enable/disable remains unsupported until Codex exposes a stable safe contract.
+
+### Codex Config/Profile Diagnostics
+
+```http
+GET /api/v1/codex-config
+GET /api/v1/codex-config/profile-diagnostics
+```
+
+Returns redacted Codex config summaries, profile-file diagnostics, and active/default profile resolution. Auth, history, cache, and raw secret values are omitted or redacted.
+
+### Codex Usage/Context Diagnostics
+
+```http
+GET /api/v1/providers/codex-cli/usage-context-diagnostics
+```
+
+Returns diagnostics-only metadata for Codex history and model cache shape. This endpoint does not return prompt text, session ids, raw history rows, model ids, raw model cache payloads, auth data, or SQLite contents. Usage and context parity are explicitly unsupported for Codex.
+
+## Normalized Provider Errors
+
+Provider endpoints should surface user-actionable error states:
+
+| Error code/state | Meaning |
+|------------------|---------|
+| `unknown_provider` | The requested provider id is not registered. |
+| `unsupported_operation` | The provider does not support the requested capability. |
+| `unsupported_provider_operation` | The endpoint exists, but only for another provider. |
+| `command_not_allowed` | The requested CLI command is outside the provider whitelist. |
+| `provider_binary_missing` | The provider CLI is not installed or not on `PATH`. |
+| CLI failure | The CLI returned a non-zero exit code; stdout/stderr are redacted. |
+| Parse failure | CLI output could not be parsed; raw sensitive payloads are omitted or redacted. |
+| Validation failure | User input failed strict validation before any CLI command ran. |
+
+The frontend should use provider status and these error states to disable unsupported controls instead of routing Codex users to Claude-only pages.

--- a/docs/features/agent-bridge.md
+++ b/docs/features/agent-bridge.md
@@ -16,6 +16,12 @@ Session cards include:
 
 The terminal grid is shared across providers. Read-only and interactive modes work the same way whether the pane is Claude Code or Codex.
 
+Provider filters are explicit:
+
+- **All** — mixed Claude Code and Codex sessions
+- **Claude Code** — Claude Code panes only
+- **Codex** — Codex panes only
+
 ## New Sessions
 
 The new session dialog starts with a provider choice.
@@ -40,3 +46,7 @@ Dangerous Codex bypass mode is exposed as an explicit advanced option because it
 The frontend route `/agent-bridge` is the primary route. `/cc-bridge` remains as a compatibility alias.
 
 The backend keeps `/api/v1/cc-bridge/*` for existing callers and adds `/api/v1/agent-bridge/*` for provider-aware clients.
+
+## Smoke Coverage
+
+Multi-provider smoke checks should cover mixed discovery, provider filters, attach/read-only/interactive terminal behavior, Codex spawn/resume/fork options, and the legacy `/cc-bridge` compatibility route. Claude-only transcript, usage, context, plugin, permission, hook, agent, skill, and memory pages should stay hidden or disabled when Codex is the selected provider until provider-aware equivalents exist.

--- a/docs/features/backup.md
+++ b/docs/features/backup.md
@@ -4,7 +4,7 @@ Create and manage configuration backups with selective component restore.
 
 ## Overview
 
-The Backup page lets you create ZIP archives of your Claude Code configuration, restore from backups, and manage backup history.
+The Backup page lets you create ZIP archives of your Claude Code configuration, restore from Claude Code backups, create redacted Codex exports, and manage backup history.
 
 ## How to Use
 
@@ -35,6 +35,8 @@ Click **Restore** on any backup to open the restore wizard:
 Restoring overwrites existing configuration files for the selected components. Make a backup of your current configuration first if needed.
 :::
 
+Codex backups are export-only. The restore plan can show archive contents and explain why automatic restore is refused, but Claude Deck does not extract Codex exports back into `CODEX_HOME`.
+
 ### Managing Backups
 
 - **Download** — save the ZIP archive to your local machine
@@ -45,6 +47,12 @@ Stat cards at the top show total backups, combined size, and count with external
 ## Configuration
 
 Backups are stored in `~/.claude-registry/backups/` as ZIP files with a JSON manifest containing metadata, component list, and dependency information.
+
+### Codex Export Scope
+
+Codex exports include redacted `config.toml`, redacted `*.config.toml` profile files, redacted `rules/*.rules` files, and redacted provider inventory metadata.
+
+Codex exports exclude `auth.json`, `history.jsonl`, `models_cache.json`, SQLite state, SQLite sidecar files, raw prompt text, and raw cache payloads. Automatic restore is refused because these exports intentionally omit provider state and because Codex does not currently expose a stable provider-owned restore API.
 
 ## Tips
 

--- a/docs/features/config.md
+++ b/docs/features/config.md
@@ -71,6 +71,12 @@ When the selected provider is Codex CLI, the Config page switches to Codex-speci
 
 Codex config writes are intentionally narrower than Claude Code settings. Claude Deck only updates whitelisted TOML keys, creates a backup before saving, and refuses unsafe paths. Auth, history, model cache, and log files are not shown in the raw viewer.
 
+Profile diagnostics resolve default and active profiles, profile files, inherited and overridden settings, and missing or malformed profile files. Summaries redact secret-like values and avoid exposing auth, history, or cache data.
+
+History and model-cache diagnostics are privacy-bounded. They may report file existence, size, parse state, root keys, row counts, and metric-like key names, but they do not return prompt text, session ids, raw history rows, model ids, raw model cache payloads, or SQLite contents.
+
+Usage and context parity are not supported for Codex. Claude Code usage and context pages remain Claude-specific until Codex exposes a stable metric source that can be read without sensitive prompt or cache data.
+
 Codex backups are export-only in this version. They include redacted config, profile files, rules, and provider inventory metadata, but automatic restore is disabled.
 
 ## Tips

--- a/docs/features/plugins.md
+++ b/docs/features/plugins.md
@@ -57,6 +57,17 @@ The actions bar supports:
 
 Marketplace URLs are configured in Claude Code settings.
 
+## Codex CLI
+
+When Codex is selected, plugin handling is provider-aware:
+
+- Inventory comes from `codex plugin list`
+- Install/remove operations use the Codex CLI when the installed CLI exposes safe commands
+- Enable/disable is unsupported until Codex exposes a stable safe contract for it
+- Raw plugin output is retained only after redacting secret-like values
+
+Claude Code plugin pages remain the source of truth for Claude plugin enable/disable, marketplace browsing, updates, and settings-backed plugin state.
+
 ## Tips
 
 - **Local plugins** can be uninstalled; marketplace plugins use enable/disable.

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -13,9 +13,9 @@ Claude Deck is a full-stack application with a Python backend and React frontend
 └─────────────────────────┘     └──────────┬──────────────┘
                                            │
                                     ┌──────▼──────┐
-                                    │  ~/.claude/  │
-                                    │  Claude Code │
-                                    │  config files│
+                                    │ ~/.claude/   │
+                                    │ $CODEX_HOME  │
+                                    │ provider CLI │
                                     └─────────────┘
 ```
 
@@ -43,6 +43,12 @@ backend/
 All routes live under `/api/v1/`. The frontend's Vite dev server proxies `/api` requests to the backend at `http://localhost:8000`.
 
 Route modules: `health`, `config`, `codex-config`, `providers`, `projects`, `cli`, `mcp`, `commands`, `plugins`, `hooks`, `permissions`, `agents`, `backup`, `output-styles`, `statusline`, `sessions`, `agent-bridge`, `cc-bridge`, `usage`, `memory`
+
+### Provider Boundaries
+
+Claude Deck keeps shared terminal viewing in Agent Bridge and pushes provider-specific behavior into provider modules, config services, diagnostics, and backup policy. The UI reads provider capabilities before showing controls so Codex users do not land on Claude-only mutation pages.
+
+Codex diagnostics are intentionally privacy-conservative. History, model cache, and SQLite files are not product data sources; diagnostics may summarize shape and parse state but must not expose prompt text, raw cache payloads, or SQLite contents.
 
 ### Database
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -12,6 +12,7 @@ Claude Code stores configuration across multiple JSON files and directories (`~/
 - **Track usage** — monitor token costs, billing blocks, and daily/monthly trends
 - **Browse sessions** — view conversation transcripts with tool use details
 - **Monitor live sessions** — attach to running Claude Code terminals via CC Bridge
+- **Switch providers intentionally** — use shared surfaces for Claude Code and Codex CLI while unsupported provider-specific pages stay hidden or disabled
 
 ## Features
 
@@ -24,6 +25,12 @@ Claude Deck covers Claude Code configuration and the shared local-agent operatio
 | **Monitoring** | Sessions, usage tracking, context window, Agent Bridge |
 | **Customization** | Output styles, status line, memory |
 | **Management** | Projects, plans, backup & restore |
+
+## Provider Support
+
+Claude Deck exposes provider capabilities and status through the Providers API. Claude Code remains the full-featured provider for usage, context, transcripts, plugins, hooks, agents, skills, memory, backup, and restore. Codex CLI support focuses on mixed tmux sessions, safe TOML configuration, diagnostics, MCP/plugin inventory and safe CLI-backed mutations, and redacted export-only backups.
+
+See [Multi-Provider and Codex v2](/guide/multi-provider-codex-v2) for the supported, diagnostics-only, and unsupported Codex surfaces.
 
 ## Tech Stack
 

--- a/docs/guide/multi-provider-codex-v2.md
+++ b/docs/guide/multi-provider-codex-v2.md
@@ -1,0 +1,99 @@
+# Multi-Provider and Codex v2
+
+Claude Deck is moving from a Claude Code-only control surface to a provider-aware local agent dashboard. Claude Code remains the most complete provider. Codex CLI support is explicit about what is supported, what is diagnostics-only, and what is intentionally unavailable.
+
+## Provider Model
+
+Provider status comes from `/api/v1/providers` and `/api/v1/providers/{provider_id}/status`.
+
+Each provider reports:
+
+- install state, binary path, and version when available
+- config paths used by the provider
+- capability flags used by the API and UI
+- provider-specific policy metadata, such as backup and restore behavior
+
+Boolean capability flags stay backward-compatible: unsupported or unavailable surfaces are `false`, not omitted. Newer provider-specific details live in metadata objects so older clients can continue using the boolean flags.
+
+## Capability Summary
+
+| Surface | Claude Code | Codex CLI |
+|---------|-------------|-----------|
+| Agent Bridge tmux discovery | Supported | Supported |
+| Spawn/resume/fork | Spawn and resume; no fork | Spawn, resume, and fork |
+| Config editing | JSON settings, scopes, permissions | Safe TOML scalar and feature edits |
+| Config/profile diagnostics | Scope resolver | Profile and profile-file diagnostics |
+| MCP inventory | Claude settings/API | `codex mcp list --json` |
+| MCP mutation | Claude MCP pages | CLI-backed add/remove only |
+| Plugin inventory | Supported | `codex plugin list` inventory |
+| Plugin install/remove | Supported | CLI-backed install/remove when supported by Codex CLI |
+| Plugin enable/disable | Supported | Unsupported until Codex exposes a safe contract |
+| History/session transcripts | Supported | Diagnostics-only investigation |
+| Usage/context metrics | Supported | Unsupported |
+| Backup/export | Backup and automatic restore | Redacted export only |
+| Automatic restore | Supported | Refused |
+
+## Codex Supported Surfaces
+
+Codex CLI support is productized for:
+
+- mixed-provider Agent Bridge sessions with provider filters
+- provider status, version, config paths, and capability metadata
+- safe TOML settings edits for whitelisted scalar and feature fields
+- config/profile diagnostics, including active/default profile resolution and malformed profile reporting
+- MCP inventory and CLI-backed MCP add/remove
+- plugin inventory and CLI-backed plugin install/remove where the local Codex CLI supports those commands
+- `codex doctor` diagnostics with secret-like values redacted
+- redacted export-only backups
+
+## Diagnostics-Only Surfaces
+
+Some local Codex files are useful for support diagnostics but are not stable product data sources.
+
+History and model cache diagnostics may report file existence, size, parse status, root keys, row counts, and whether metric-like key names appear. They must not return prompt text, session ids, raw history rows, model ids, raw model cache payloads, auth data, or SQLite contents.
+
+Usage and context parity are not supported for Codex. Claude Deck should not present Codex token usage, cost, billing block, or context-window metrics until Codex exposes a stable source that can be read without sensitive prompt or cache data.
+
+## Backup and Restore Policy
+
+Codex backups are redacted exports, not automatic restore points.
+
+Codex exports may include:
+
+- `config.toml` with secret-like assignments redacted
+- `*.config.toml` profile files with secret-like assignments redacted
+- `rules/*.rules` files with secret-like assignments redacted
+- redacted provider inventory metadata
+
+Codex exports must exclude:
+
+- `auth.json`
+- `history.jsonl`
+- `models_cache.json`
+- SQLite state and SQLite sidecar files
+- raw prompt text and raw cache payloads
+
+Automatic Codex restore is refused. The restore plan can show archive contents and refusal reasons, but the restore action must not extract files into `CODEX_HOME`.
+
+## Provider Errors
+
+Provider-specific operations should return normalized, user-actionable errors:
+
+- unsupported capability
+- provider binary missing
+- command unavailable in the installed CLI
+- CLI execution failure with redacted stdout/stderr
+- parse failure with raw sensitive payloads omitted or redacted
+- validation failure for unsafe input
+
+The UI should use these states to disable unsupported controls rather than routing users to Claude-only pages while Codex is selected.
+
+## Smoke Coverage
+
+Multi-provider smoke coverage should exercise both providers in one run:
+
+- provider registry returns Claude Code and Codex status without requiring both binaries to be installed
+- Agent Bridge can show mixed Claude Code and Codex tmux sessions together and can filter All, Claude Code, and Codex
+- Codex config, doctor, MCP, plugin, history/model-cache diagnostics, and backup export paths redact sensitive values
+- unsupported Codex usage/context and automatic restore states are visible and non-mutating
+- Claude-only pages remain hidden or disabled when Codex is selected

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: Claude Deck
   text: Documentation
-  tagline: Visual configuration and live session control for Claude Code
+  tagline: Visual configuration and live session control for Claude Code and Codex CLI
   actions:
     - theme: brand
       text: Get Started
@@ -15,11 +15,11 @@ hero:
 
 features:
   - icon: 🌉
-    title: CC Bridge
-    details: Monitor and interact with live Claude Code tmux sessions from the browser in a multi-terminal grid.
+    title: Agent Bridge
+    details: Monitor and interact with live Claude Code and Codex CLI tmux sessions from the browser in a multi-terminal grid.
   - icon: 🎛️
-    title: Visual Configuration
-    details: Manage Claude Code settings, MCP servers, commands, hooks, and permissions without a command-line-only workflow.
+    title: Provider-Aware Configuration
+    details: Manage Claude Code JSON settings and safe Codex TOML settings with clear provider capability states.
   - icon: 📊
     title: Dashboard & Usage
     details: See configuration status, context windows, session activity, and token usage in one place.
@@ -30,6 +30,6 @@ features:
     title: Agents & Skills
     details: Create custom agent configurations and discover skills from the community.
   - icon: 💾
-    title: Backup & Restore
-    details: Protect real Claude Code setups with full backup and restore before major changes.
+    title: Backup & Export
+    details: Protect Claude Code setups with backup and restore, and create redacted export-only Codex backups.
 ---


### PR DESCRIPTION
## Summary
- Add a Multi-Provider and Codex v2 guide covering capabilities, supported surfaces, diagnostics-only surfaces, unsupported usage/context parity, provider errors, backups, and smoke coverage
- Update existing provider, config, plugin, backup, Agent Bridge, architecture, and README docs to align product framing
- Keep this docs-only; no runtime behavior changes

Refs #142

## Checks
- npm ci (docs package)
- npm run build (docs package)
- git diff --check