### PR TITLE
Fix Agent Bridge Claude resume sessions

### DIFF
--- a/backend/app/services/cc_bridge/spawn.py
+++ b/backend/app/services/cc_bridge/spawn.py
@@ -1,4 +1,5 @@
 """Spawn and kill Claude Code sessions in tmux."""
+import json
 import logging
 import shlex
 import subprocess
@@ -10,13 +11,35 @@ logger = logging.getLogger(__name__)
 _spawned_sessions: dict[str, dict] = {}
 
 
-def _resolve_project_directory(project_folder: str) -> str:
+def _resolve_project_directory(project_folder: str, session_id: str | None = None) -> str:
     """Resolve a Claude project folder name to the actual project directory.
 
-    Reconstructs the path from the folder name encoding (slashes → dashes).
-    This is inherently ambiguous for paths with actual hyphens, but works
-    for the common case.
+    Prefer the selected transcript's recorded cwd. Reconstructing the path from
+    Claude's folder name is lossy because both slashes and hyphens are encoded as
+    hyphens.
     """
+    folder_path = Path(project_folder)
+    if folder_path.name != project_folder or ".." in folder_path.parts:
+        raise ValueError(f"Invalid project folder: '{project_folder}'")
+
+    if session_id:
+        transcript = Path.home() / ".claude" / "projects" / project_folder / f"{session_id}.jsonl"
+        if transcript.is_file():
+            try:
+                with transcript.open("r", encoding="utf-8") as handle:
+                    for line in handle:
+                        try:
+                            cwd = json.loads(line).get("cwd")
+                        except json.JSONDecodeError:
+                            continue
+                        if not cwd:
+                            continue
+                        resolved = Path(cwd).resolve()
+                        if resolved.is_absolute() and ".." not in Path(cwd).parts and resolved.is_dir():
+                            return str(resolved)
+            except OSError:
+                logger.warning("Could not read Claude transcript for directory resolution: %s", transcript)
+
     decoded = "/" + project_folder.lstrip("-").replace("-", "/")
     resolved = Path(decoded).resolve()
     # Guard against path traversal — must be an existing absolute directory
@@ -57,7 +80,7 @@ def spawn_session(
     """
     # For resume mode, derive directory from project_folder if not provided
     if mode == "resume" and (not directory or not directory.strip()) and project_folder:
-        directory = _resolve_project_directory(project_folder)
+        directory = _resolve_project_directory(project_folder, session_id)
 
     # Validate directory — resolve to canonical path to prevent traversal attacks
     dir_path = Path(directory).resolve()

--- a/backend/app/services/providers/claude_code.py
+++ b/backend/app/services/providers/claude_code.py
@@ -76,7 +76,7 @@ class ClaudeCodeProvider(AgentProvider):
 
     def resolve_directory(self, options: SpawnCommandOptions) -> str:
         if options.mode == "resume" and not options.directory.strip() and options.project_folder:
-            return _resolve_project_directory(options.project_folder)
+            return _resolve_project_directory(options.project_folder, options.session_id)
         return options.directory
 
     def get_allowed_cli_commands(self) -> list[str]:

--- a/backend/tests/test_agent_bridge_spawn.py
+++ b/backend/tests/test_agent_bridge_spawn.py
@@ -1,4 +1,5 @@
 """Tests for provider-aware tmux spawning."""
+import json
 from types import SimpleNamespace
 
 
@@ -25,3 +26,43 @@ def test_claude_worktree_uses_generated_session_name_when_blank(monkeypatch, tmp
     assert calls[0][:7] == ["tmux", "new-session", "-d", "-s", "repo-abcd", "-c", str(tmp_path)]
     assert "--worktree repo-abcd" in calls[0][7]
     assert spawn.get_spawned_sessions()["repo-abcd"]["worktree_name"] == "repo-abcd"
+
+
+def test_claude_resume_resolves_directory_from_transcript_cwd(monkeypatch, tmp_path):
+    from app.services.agent_bridge import spawn
+    from app.services.cc_bridge import spawn as claude_spawn
+    from app.services.providers.base import SpawnCommandOptions
+
+    project_dir = tmp_path / "claude-deck"
+    project_dir.mkdir()
+    project_folder = "-tmp-claude-deck"
+    session_id = "session-123"
+    transcript_dir = tmp_path / ".claude" / "projects" / project_folder
+    transcript_dir.mkdir(parents=True)
+    transcript = transcript_dir / f"{session_id}.jsonl"
+    transcript.write_text(json.dumps({"cwd": str(project_dir)}) + "\n", encoding="utf-8")
+
+    calls = []
+
+    def fake_run(args, capture_output=True, text=True, timeout=10):
+        calls.append(args)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(claude_spawn.Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(spawn, "_session_name_for", lambda directory: "claude-deck-abcd")
+    monkeypatch.setattr(spawn.subprocess, "run", fake_run)
+    spawn.get_spawned_sessions().clear()
+
+    result = spawn.spawn_session(
+        "claude-code",
+        SpawnCommandOptions(
+            directory="",
+            mode="resume",
+            session_id=session_id,
+            project_folder=project_folder,
+        ),
+    )
+
+    assert result["session_name"] == "claude-deck-abcd"
+    assert calls[0][:7] == ["tmux", "new-session", "-d", "-s", "claude-deck-abcd", "-c", str(project_dir)]
+    assert "--resume session-123" in calls[0][7]

--- a/frontend/src/features/cc-bridge/NewSessionDialog.tsx
+++ b/frontend/src/features/cc-bridge/NewSessionDialog.tsx
@@ -19,7 +19,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { MODAL_SIZES } from '@/lib/constants'
-import { cn } from '@/lib/utils'
+import { claudeProjectFolderFromPath, cn } from '@/lib/utils'
 import { formatTimestamp } from '@/features/usage/utils'
 import { spawnSession } from './api'
 import { useSessionsApi } from '@/hooks/useSessionsApi'
@@ -76,21 +76,31 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
   const [loadingSessions, setLoadingSessions] = useState(false)
 
   const { listSessions } = useSessionsApi()
-  const { projects } = useProjectContext()
+  const { projects, activeProject } = useProjectContext()
   const isCodex = provider === 'codex-cli'
   const modeOptions = isCodex ? CODEX_MODE_OPTIONS : MODE_OPTIONS
+  const activeProjectFolder = activeProject?.path
+    ? claudeProjectFolderFromPath(activeProject.path)
+    : undefined
 
   // Fetch sessions when switching to resume mode
   useEffect(() => {
     if (mode !== 'resume' || isCodex) return
     let cancelled = false
+    setSelectedSession(null)
+    setRecentSessions([])
     setLoadingSessions(true)
-    listSessions({ limit: 20, sort_by: 'date', sort_order: 'desc' })
+    listSessions({
+      project_folder: activeProjectFolder,
+      limit: 20,
+      sort_by: 'date',
+      sort_order: 'desc',
+    })
       .then((data) => { if (!cancelled) setRecentSessions(data.sessions) })
       .catch(() => { if (!cancelled) setRecentSessions([]) })
       .finally(() => { if (!cancelled) setLoadingSessions(false) })
     return () => { cancelled = true }
-  }, [mode, isCodex, listSessions])
+  }, [mode, isCodex, listSessions, activeProjectFolder])
 
   // Reset state when dialog closes
   useEffect(() => {

--- a/frontend/src/features/cc-bridge/NewSessionDialog.tsx
+++ b/frontend/src/features/cc-bridge/NewSessionDialog.tsx
@@ -79,9 +79,16 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
   const { projects, activeProject } = useProjectContext()
   const isCodex = provider === 'codex-cli'
   const modeOptions = isCodex ? CODEX_MODE_OPTIONS : MODE_OPTIONS
-  const activeProjectFolder = activeProject?.path
-    ? claudeProjectFolderFromPath(activeProject.path)
+  const resumeProjectPath = directory.trim() || activeProject?.path || ''
+  const resumeProjectFolder = resumeProjectPath
+    ? claudeProjectFolderFromPath(resumeProjectPath)
     : undefined
+
+  useEffect(() => {
+    if (open && !directory.trim() && activeProject?.path) {
+      setDirectory(activeProject.path)
+    }
+  }, [open, activeProject?.path, directory])
 
   // Fetch sessions when switching to resume mode
   useEffect(() => {
@@ -91,7 +98,7 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
     setRecentSessions([])
     setLoadingSessions(true)
     listSessions({
-      project_folder: activeProjectFolder,
+      project_folder: resumeProjectFolder,
       limit: 20,
       sort_by: 'date',
       sort_order: 'desc',
@@ -100,7 +107,7 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
       .catch(() => { if (!cancelled) setRecentSessions([]) })
       .finally(() => { if (!cancelled) setLoadingSessions(false) })
     return () => { cancelled = true }
-  }, [mode, isCodex, listSessions, activeProjectFolder])
+  }, [mode, isCodex, listSessions, resumeProjectFolder])
 
   // Reset state when dialog closes
   useEffect(() => {
@@ -143,7 +150,7 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
     try {
       const request: SpawnSessionRequest = {
         provider,
-        directory: !isCodex && mode === 'resume' ? '' : directory.trim(),
+        directory: directory.trim(),
         mode,
         ...(provider === 'claude-code' && mode === 'worktree' && worktreeName.trim() && { worktree_name: worktreeName.trim() }),
         ...(provider === 'claude-code' && mode === 'resume' && selectedSession && {
@@ -236,32 +243,30 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
             </div>
           </div>
 
-          {/* Directory input (hidden in resume mode) */}
-          {(isCodex || mode !== 'resume') && (
-            <div className="space-y-1.5">
-              <Label htmlFor="session-directory">Project Directory</Label>
-              <Input
-                id="session-directory"
-                list="session-directory-projects"
-                value={directory}
-                onChange={(e) => setDirectory(e.target.value)}
-                placeholder="/home/user/project"
-                autoComplete="off"
-              />
-              {projects.length > 0 && (
-                <>
-                  <datalist id="session-directory-projects">
-                    {projects.map((p) => (
-                      <option key={p.id} value={p.path} label={p.name} />
-                    ))}
-                  </datalist>
-                  <p className="text-xs text-muted-foreground">
-                    Pick from configured projects or type any path.
-                  </p>
-                </>
-              )}
-            </div>
-          )}
+          {/* Directory input */}
+          <div className="space-y-1.5">
+            <Label htmlFor="session-directory">Project Directory</Label>
+            <Input
+              id="session-directory"
+              list="session-directory-projects"
+              value={directory}
+              onChange={(e) => setDirectory(e.target.value)}
+              placeholder="/home/user/project"
+              autoComplete="off"
+            />
+            {projects.length > 0 && (
+              <>
+                <datalist id="session-directory-projects">
+                  {projects.map((p) => (
+                    <option key={p.id} value={p.path} label={p.name} />
+                  ))}
+                </datalist>
+                <p className="text-xs text-muted-foreground">
+                  Pick from configured projects or type any path.
+                </p>
+              </>
+            )}
+          </div>
 
           {/* Worktree name (only in worktree mode) */}
           {!isCodex && mode === 'worktree' && (

--- a/frontend/src/features/cc-bridge/NewSessionDialog.tsx
+++ b/frontend/src/features/cc-bridge/NewSessionDialog.tsx
@@ -50,6 +50,8 @@ const CODEX_MODE_OPTIONS: { value: Mode; label: string }[] = [
   { value: 'fork', label: 'Fork' },
 ]
 
+const CUSTOM_PROJECT_VALUE = '__custom__'
+
 export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvider }: NewSessionDialogProps) {
   const { providers, selectedProviderId } = useProviderContext()
   const defaultProvider = initialProvider ?? selectedProviderId
@@ -79,7 +81,10 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
   const { projects, activeProject } = useProjectContext()
   const isCodex = provider === 'codex-cli'
   const modeOptions = isCodex ? CODEX_MODE_OPTIONS : MODE_OPTIONS
-  const resumeProjectPath = directory.trim() || activeProject?.path || ''
+  const selectedProjectPath = projects.some((project) => project.path === directory.trim())
+    ? directory.trim()
+    : CUSTOM_PROJECT_VALUE
+  const resumeProjectPath = directory.trim()
   const resumeProjectFolder = resumeProjectPath
     ? claudeProjectFolderFromPath(resumeProjectPath)
     : undefined
@@ -96,6 +101,10 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
     let cancelled = false
     setSelectedSession(null)
     setRecentSessions([])
+    if (!resumeProjectFolder) {
+      setLoadingSessions(false)
+      return () => { cancelled = true }
+    }
     setLoadingSessions(true)
     listSessions({
       project_folder: resumeProjectFolder,
@@ -139,7 +148,7 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
     if (isCodex && (mode === 'resume' || mode === 'fork')) {
       return directory.trim().length > 0 && (useLast || codexSessionId.trim().length > 0)
     }
-    if (!isCodex && mode === 'resume') return selectedSession !== null
+    if (!isCodex && mode === 'resume') return directory.trim().length > 0 && selectedSession !== null
     return directory.trim().length > 0
   })()
 
@@ -244,28 +253,48 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
           </div>
 
           {/* Directory input */}
-          <div className="space-y-1.5">
+          <div className="space-y-2">
+            {projects.length > 0 && (
+              <div className="space-y-1.5">
+                <Label>Project</Label>
+                <Select
+                  value={selectedProjectPath}
+                  onValueChange={(value) => {
+                    if (value === CUSTOM_PROJECT_VALUE) {
+                      setDirectory('')
+                    } else {
+                      setDirectory(value)
+                    }
+                    setSelectedSession(null)
+                    setError(null)
+                  }}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {projects.map((project) => (
+                      <SelectItem key={project.id} value={project.path}>
+                        {project.name}
+                      </SelectItem>
+                    ))}
+                    <SelectItem value={CUSTOM_PROJECT_VALUE}>Custom path</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
             <Label htmlFor="session-directory">Project Directory</Label>
             <Input
               id="session-directory"
-              list="session-directory-projects"
               value={directory}
-              onChange={(e) => setDirectory(e.target.value)}
+              onChange={(e) => {
+                setDirectory(e.target.value)
+                setSelectedSession(null)
+                setError(null)
+              }}
               placeholder="/home/user/project"
               autoComplete="off"
             />
-            {projects.length > 0 && (
-              <>
-                <datalist id="session-directory-projects">
-                  {projects.map((p) => (
-                    <option key={p.id} value={p.path} label={p.name} />
-                  ))}
-                </datalist>
-                <p className="text-xs text-muted-foreground">
-                  Pick from configured projects or type any path.
-                </p>
-              </>
-            )}
           </div>
 
           {/* Worktree name (only in worktree mode) */}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -22,8 +22,21 @@ export function buildEndpoint(
 }
 
 export interface ApiError {
-  message: string
-  detail?: string
+  message?: string
+  detail?: string | { msg?: string } | Array<{ msg?: string }>
+}
+
+function apiErrorMessage(error: ApiError, fallback = 'An error occurred'): string {
+  if (error.message) return error.message
+  if (typeof error.detail === 'string') return error.detail
+  if (Array.isArray(error.detail)) {
+    const messages = error.detail.map((item) => item.msg).filter(Boolean)
+    if (messages.length > 0) return messages.join(', ')
+  }
+  if (error.detail && typeof error.detail === 'object' && 'msg' in error.detail && error.detail.msg) {
+    return error.detail.msg
+  }
+  return fallback
 }
 
 export class ApiClient {
@@ -46,7 +59,7 @@ export class ApiClient {
         const error: ApiError = await response.json().catch(() => ({
           message: `HTTP ${response.status}: ${response.statusText}`,
         }))
-        throw new Error(error.message || 'An error occurred')
+        throw new Error(apiErrorMessage(error))
       }
 
       return response.json()
@@ -105,7 +118,7 @@ export async function apiClient<T>(endpoint: string, options?: RequestInit): Pro
       const error: ApiError = await response.json().catch(() => ({
         message: `HTTP ${response.status}: ${response.statusText}`,
       }))
-      throw new Error(error.message || 'An error occurred')
+      throw new Error(apiErrorMessage(error))
     }
 
     return response.json()

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,3 +4,7 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function claudeProjectFolderFromPath(path: string) {
+  return path.replace(/\/+$/, '').replace(/\//g, '-').replace(/\./g, '-')
+}


### PR DESCRIPTION
## Summary

Closes #153.

- Resolve Claude Code resume working directories from the selected transcript's recorded cwd before falling back to the lossy encoded folder decode.
- Add an explicit Project selector to the New Agent Session dialog so users can launch/resume from any configured project, not only the active one.
- Show and use the Project Directory field for resume filtering and launch, with the active project only used as the initial default.
- Avoid loading all Claude sessions when the resume project directory is blank.
- Show FastAPI error details in the frontend instead of the generic fallback message.
- Add a regression test for resuming a session from a hyphenated project path.

## Verification

- pytest backend/tests/test_agent_bridge_spawn.py
- npm run build