### PR TITLE
Add Claude Opus 4.8 support and close settings.json parity gaps

### DIFF
--- a/frontend/src/features/config/settings/cards/AdvancedCard.tsx
+++ b/frontend/src/features/config/settings/cards/AdvancedCard.tsx
@@ -109,6 +109,32 @@ export function AdvancedCard({ getSetting, updateSetting }: SettingsCardProps) {
           onCheckedChange={(v) => updateSetting('disableDeepLinkRegistration', v)}
         />
 
+        <SwitchSetting
+          label="Disable Workflows"
+          description="Disable dynamic workflows and the bundled workflow commands."
+          checked={getSetting<boolean>('disableWorkflows', false)}
+          onCheckedChange={(v) => updateSetting('disableWorkflows', v)}
+        />
+
+        <SwitchSetting
+          label="Disable Agent View"
+          description="Turn off background agents and agent view (claude agents, --bg, /background, and the on-demand supervisor)."
+          checked={getSetting<boolean>('disableAgentView', false)}
+          onCheckedChange={(v) => updateSetting('disableAgentView', v)}
+        />
+
+        <div className="grid gap-2">
+          <Label>CLAUDE.md Excludes</Label>
+          <p className="text-sm text-muted-foreground">
+            Glob patterns or absolute paths of CLAUDE.md files to skip when loading memory. Does not apply to managed policy files.
+          </p>
+          <ListEditor
+            value={getSetting<string[]>('claudeMdExcludes', [])}
+            onChange={(v) => updateSetting('claudeMdExcludes', v)}
+            placeholder="e.g., **/vendor/**/CLAUDE.md"
+          />
+        </div>
+
         <div className="grid gap-2 rounded border p-3">
           <Label>Spinner Tips Override</Label>
           <p className="text-sm text-muted-foreground">

--- a/frontend/src/features/config/settings/cards/AuthenticationCard.tsx
+++ b/frontend/src/features/config/settings/cards/AuthenticationCard.tsx
@@ -11,7 +11,7 @@ export function AuthenticationCard({ getSetting, updateSetting, scope }: Setting
       <CardHeader>
         <CardTitle>Authentication</CardTitle>
         <CardDescription>
-          Login restrictions (managed) and AWS/OTel credential helpers (Bedrock)
+          Login restrictions (managed) and AWS/GCP/OTel credential helpers (Bedrock, Vertex AI)
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -53,6 +53,15 @@ export function AuthenticationCard({ getSetting, updateSetting, scope }: Setting
           value={getSetting<string>('awsCredentialExport', '')}
           onChange={(v) => updateSetting('awsCredentialExport', v)}
           placeholder="/bin/aws-credentials.sh"
+        />
+
+        <TextSetting
+          id="gcpAuthRefresh"
+          label="GCP Auth Refresh Script"
+          description="Script that refreshes GCP Application Default Credentials when they expire or cannot be loaded. Used for Vertex AI."
+          value={getSetting<string>('gcpAuthRefresh', '')}
+          onChange={(v) => updateSetting('gcpAuthRefresh', v)}
+          placeholder="gcloud auth application-default login"
         />
 
         <TextSetting

--- a/frontend/src/features/config/settings/cards/GeneralCard.tsx
+++ b/frontend/src/features/config/settings/cards/GeneralCard.tsx
@@ -40,7 +40,7 @@ export function GeneralCard({ getSetting, updateSetting }: SettingsCardProps) {
         <SelectSetting
           id="effortLevel"
           label="Effort Level"
-          description="Persist the effort level across sessions. Supported on Opus 4.6 and Sonnet 4.6."
+          description="Persist the effort level across sessions. Supported on Opus 4.6+ and Sonnet 4.6. Note: Opus 4.8 defaults to high."
           value={getSetting<string>('effortLevel', '')}
           onValueChange={(v) => updateSetting('effortLevel', v)}
           placeholder="Select effort level"

--- a/frontend/src/features/config/settings/cards/ManagedPolicyCard.tsx
+++ b/frontend/src/features/config/settings/cards/ManagedPolicyCard.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
-import { ListEditor, SwitchSetting } from '../field-components'
+import { ListEditor, SwitchSetting, TextSetting } from '../field-components'
 import type { SettingsCardProps } from '../types'
 
 /**
@@ -21,6 +21,14 @@ export function ManagedPolicyCard({ getSetting, scope }: SettingsCardProps) {
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
+        <TextSetting
+          id="claudeMd"
+          label="Managed CLAUDE.md"
+          description="CLAUDE.md-style instructions injected as organization-managed memory. Only honored in managed/policy settings."
+          value={getSetting<string>('claudeMd', '')}
+          onChange={() => {}}
+        />
+
         <SwitchSetting
           label="Allow Managed Hooks Only"
           description="Reject user/project hooks — only hooks defined in managed settings run."

--- a/frontend/src/features/config/settings/cards/MemoryCard.tsx
+++ b/frontend/src/features/config/settings/cards/MemoryCard.tsx
@@ -12,9 +12,9 @@ export function MemoryCard({ getSetting, updateSetting }: SettingsCardProps) {
       <CardContent className="space-y-4">
         <SwitchSetting
           label="Auto Memory"
-          description="Claude automatically takes notes on your project — build commands, preferences, architectural decisions — and loads them at the start of every session"
-          checked={getSetting<boolean>('autoMemory', false)}
-          onCheckedChange={(v) => updateSetting('autoMemory', v)}
+          description="Claude automatically takes notes on your project — build commands, preferences, architectural decisions — and loads them at the start of every session. Enabled by default; turn off to stop reading from and writing to the auto memory directory."
+          checked={getSetting<boolean>('autoMemoryEnabled', true)}
+          onCheckedChange={(v) => updateSetting('autoMemoryEnabled', v)}
         />
         <TextSetting
           id="autoMemoryDirectory"

--- a/frontend/src/features/config/settings/cards/WorktreeCard.tsx
+++ b/frontend/src/features/config/settings/cards/WorktreeCard.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
-import { ListEditor, SwitchSetting } from '../field-components'
+import { ListEditor, SelectSetting, SwitchSetting } from '../field-components'
+import { WORKTREE_BASE_REF_OPTIONS, WORKTREE_BG_ISOLATION_OPTIONS } from '../constants'
 import type { SettingsCardProps } from '../types'
 
 export function WorktreeCard({ getSetting, updateSetting }: SettingsCardProps) {
@@ -11,6 +12,26 @@ export function WorktreeCard({ getSetting, updateSetting }: SettingsCardProps) {
         <CardDescription>Behavior when creating git worktrees from Claude Code</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
+        <SelectSetting
+          id="worktreeBaseRef"
+          label="Base Ref"
+          description="Which ref new worktrees branch from. Fresh branches from origin/<default-branch>; HEAD branches from your current local HEAD."
+          value={getSetting<string>('worktree.baseRef', '')}
+          onValueChange={(v) => updateSetting('worktree.baseRef', v)}
+          placeholder="Fresh (default)"
+          options={WORKTREE_BASE_REF_OPTIONS}
+        />
+
+        <SelectSetting
+          id="worktreeBgIsolation"
+          label="Background Isolation"
+          description="Isolation mode for background sessions. Worktree blocks Edit/Write in the main checkout until EnterWorktree; None edits the working copy directly. Requires Claude Code v2.1.143+."
+          value={getSetting<string>('worktree.bgIsolation', '')}
+          onValueChange={(v) => updateSetting('worktree.bgIsolation', v)}
+          placeholder="Worktree (default)"
+          options={WORKTREE_BG_ISOLATION_OPTIONS}
+        />
+
         <SwitchSetting
           label="Symlink Directories"
           description="Symlink ignored/untracked directories (e.g., node_modules, venv) into new worktrees to save time and disk."

--- a/frontend/src/features/config/settings/constants.ts
+++ b/frontend/src/features/config/settings/constants.ts
@@ -1,4 +1,5 @@
 export const MODEL_OPTIONS = [
+  { value: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
   { value: 'claude-opus-4-7', label: 'Claude Opus 4.7' },
   { value: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
   { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
@@ -79,6 +80,16 @@ export const SPINNER_VERBS_MODE_OPTIONS = [
   { value: 'default', label: 'Default' },
   { value: 'append', label: 'Append to defaults' },
   { value: 'replace', label: 'Replace defaults' },
+]
+
+export const WORKTREE_BASE_REF_OPTIONS = [
+  { value: 'fresh', label: 'Fresh (origin/<default-branch>)' },
+  { value: 'head', label: 'HEAD (current local branch)' },
+]
+
+export const WORKTREE_BG_ISOLATION_OPTIONS = [
+  { value: 'worktree', label: 'Worktree (block edits until EnterWorktree)' },
+  { value: 'none', label: 'None (edit working copy directly)' },
 ]
 
 export const HOOK_EVENT_GROUPS = [


### PR DESCRIPTION
## Summary

Opus 4.8 shipped (API ID `claude-opus-4-8`) but wasn't selectable in Claude Deck because the **Model** dropdown is a constrained list that topped out at `claude-opus-4-7`. While adding it, I reviewed the current [Claude Code settings docs](https://code.claude.com/docs/en/settings) against the Config UI and closed a handful of other `settings.json` parity gaps, including one key-name bug.

Changes:
- **Models**: add `claude-opus-4-8` (first entry); refresh `effortLevel` help text (4.7/4.8 also support effort; 4.8 defaults to `high`).
- **Bug fix — auto memory**: `MemoryCard` wrote `autoMemory`, but the canonical key is `autoMemoryEnabled` (default `true`). The old key was a no-op in Claude Code; switched the key and default.
- **`gcpAuthRefresh`**: GCP/Vertex equivalent of the existing AWS helpers → Authentication card.
- **CLAUDE.md control**: `claudeMd` (managed-only, read-only) → Managed Policy card; `claudeMdExcludes` (glob list) → Advanced card.
- **Worktree**: add `worktree.baseRef` and `worktree.bgIsolation`.
- **Background/workflows**: add `disableWorkflows` and `disableAgentView` toggles → Advanced card.

`enableAllProjectMcpServers` / `enabledMcpjsonServers` / `disabledMcpjsonServers` and the HTTP-hook allowlists were already covered — no change needed.

Settings are stored as free-form `Dict[str, Any]` server-side, so these are frontend-only additions.

## Test plan

- [x] `npm run build` (tsc + vite) passes
- [x] `npm run lint` clean for all touched files (the 14 remaining errors are pre-existing in `usePresenceWebSocket.ts` / `api.ts`, untouched here)
- [ ] Manual: open Config → confirm Opus 4.8 selectable; new fields render and round-trip in user/project/managed scopes as appropriate

Closes #157