### PR TITLE
Agent Bridge: Anthropic/Bedrock platform selection

### DIFF
--- a/backend/app/api/v1/agent_bridge/router.py
+++ b/backend/app/api/v1/agent_bridge/router.py
@@ -42,6 +42,10 @@ class SpawnRequest(BaseModel):
     no_alt_screen: bool = False
     dangerously_bypass_approvals_and_sandbox: bool = False
     use_last: bool = False
+    platform: str = "anthropic"
+    aws_region: str | None = None
+    aws_profile: str | None = None
+    bedrock_model: str | None = None
 
 
 @router.get("/sessions")
@@ -133,6 +137,10 @@ def spawn_session_endpoint(request: SpawnRequest):
             no_alt_screen=request.no_alt_screen,
             dangerously_bypass_approvals_and_sandbox=request.dangerously_bypass_approvals_and_sandbox,
             use_last=request.use_last,
+            platform=request.platform,
+            aws_region=request.aws_region,
+            aws_profile=request.aws_profile,
+            bedrock_model=request.bedrock_model,
         )
         return spawn_session(request.provider, options)
     except ValueError as exc:

--- a/backend/app/services/agent_bridge/spawn.py
+++ b/backend/app/services/agent_bridge/spawn.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from app.services.providers import get_provider
 from app.services.providers.base import SpawnCommandOptions
 from app.services.providers.claude_code import ClaudeCodeProvider
+from app.services.providers.platform_env import build_platform_env
 
 logger = logging.getLogger(__name__)
 
@@ -49,9 +50,19 @@ def spawn_session(provider_id: str, options: SpawnCommandOptions) -> dict:
     command = provider.build_spawn_command(options)
     shell_command = " ".join(shlex.quote(part) for part in command)
 
+    platform_env = build_platform_env(
+        options.platform,
+        region=options.aws_region,
+        aws_profile=options.aws_profile,
+        model=options.bedrock_model,
+    )
+    env_flags: list[str] = []
+    for key, value in platform_env.items():
+        env_flags += ["-e", f"{key}={value}"]
+
     try:
         result = subprocess.run(
-            ["tmux", "new-session", "-d", "-s", name, "-c", directory, shell_command],
+            ["tmux", "new-session", "-d", "-s", name, "-c", directory, *env_flags, shell_command],
             capture_output=True,
             text=True,
             timeout=10,
@@ -68,6 +79,7 @@ def spawn_session(provider_id: str, options: SpawnCommandOptions) -> dict:
         "mode": options.mode,
         "directory": directory,
         "worktree_name": options.worktree_name or (name if options.mode == "worktree" else None),
+        "platform": options.platform,
     }
 
     logger.info("Spawned %s session %s in %s (mode=%s)", provider.id, name, directory, options.mode)

--- a/backend/app/services/providers/base.py
+++ b/backend/app/services/providers/base.py
@@ -35,6 +35,10 @@ class SpawnCommandOptions:
     no_alt_screen: bool = False
     dangerously_bypass_approvals_and_sandbox: bool = False
     use_last: bool = False
+    platform: str = "anthropic"
+    aws_region: str | None = None
+    aws_profile: str | None = None
+    bedrock_model: str | None = None
 
 
 def argv0_name(command: str) -> str:

--- a/backend/app/services/providers/platform_env.py
+++ b/backend/app/services/providers/platform_env.py
@@ -1,0 +1,45 @@
+"""Map an Agent Bridge platform selection to process environment variables.
+
+Single source of truth for platform -> env mapping. Credentials are never
+handled here: only non-secret configuration (region, profile name, model id)
+is set, and the AWS SDK credential chain on the host resolves actual creds.
+"""
+from __future__ import annotations
+
+PLATFORM_ANTHROPIC = "anthropic"
+PLATFORM_BEDROCK = "bedrock"
+
+
+def _clean(value: str | None) -> str | None:
+    """Trim a value and reject control characters that break env injection."""
+    if value is None:
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    if "\n" in stripped or "\r" in stripped or "\x00" in stripped:
+        raise ValueError("Environment value must not contain newlines or null bytes")
+    return stripped
+
+
+def build_platform_env(
+    platform: str | None,
+    region: str | None = None,
+    aws_profile: str | None = None,
+    model: str | None = None,
+) -> dict[str, str]:
+    """Return the env vars for a platform selection (empty for Anthropic)."""
+    if platform != PLATFORM_BEDROCK:
+        return {}
+
+    env: dict[str, str] = {"CLAUDE_CODE_USE_BEDROCK": "1"}
+    cleaned_region = _clean(region)
+    if cleaned_region:
+        env["AWS_REGION"] = cleaned_region
+    cleaned_profile = _clean(aws_profile)
+    if cleaned_profile:
+        env["AWS_PROFILE"] = cleaned_profile
+    cleaned_model = _clean(model)
+    if cleaned_model:
+        env["ANTHROPIC_MODEL"] = cleaned_model
+    return env

--- a/backend/tests/test_agent_bridge_spawn.py
+++ b/backend/tests/test_agent_bridge_spawn.py
@@ -66,3 +66,65 @@ def test_claude_resume_resolves_directory_from_transcript_cwd(monkeypatch, tmp_p
     assert result["session_name"] == "claude-deck-abcd"
     assert calls[0][:7] == ["tmux", "new-session", "-d", "-s", "claude-deck-abcd", "-c", str(project_dir)]
     assert "--resume session-123" in calls[0][7]
+
+
+def test_bedrock_platform_injects_env_flags(monkeypatch, tmp_path):
+    from app.services.agent_bridge import spawn
+    from app.services.providers.base import SpawnCommandOptions
+
+    calls = []
+
+    def fake_run(args, capture_output=True, text=True, timeout=10):
+        calls.append(args)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(spawn, "_session_name_for", lambda directory: "repo-abcd")
+    monkeypatch.setattr(spawn.subprocess, "run", fake_run)
+    spawn.get_spawned_sessions().clear()
+
+    spawn.spawn_session(
+        "claude-code",
+        SpawnCommandOptions(
+            directory=str(tmp_path),
+            mode="plain",
+            platform="bedrock",
+            aws_region="us-east-1",
+            aws_profile="bedrock-prod",
+        ),
+    )
+
+    argv = calls[0]
+    # Fixed prefix stays identical to the no-env command.
+    assert argv[:7] == ["tmux", "new-session", "-d", "-s", "repo-abcd", "-c", str(tmp_path)]
+    # Env flags are injected as -e KEY=VALUE pairs before the shell command.
+    assert "-e" in argv
+    assert "CLAUDE_CODE_USE_BEDROCK=1" in argv
+    assert "AWS_REGION=us-east-1" in argv
+    assert "AWS_PROFILE=bedrock-prod" in argv
+    assert spawn.get_spawned_sessions()["repo-abcd"]["platform"] == "bedrock"
+
+
+def test_anthropic_platform_adds_no_env_flags(monkeypatch, tmp_path):
+    from app.services.agent_bridge import spawn
+    from app.services.providers.base import SpawnCommandOptions
+
+    calls = []
+
+    def fake_run(args, capture_output=True, text=True, timeout=10):
+        calls.append(args)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(spawn, "_session_name_for", lambda directory: "repo-abcd")
+    monkeypatch.setattr(spawn.subprocess, "run", fake_run)
+    spawn.get_spawned_sessions().clear()
+
+    spawn.spawn_session(
+        "claude-code",
+        SpawnCommandOptions(directory=str(tmp_path), mode="plain"),
+    )
+
+    argv = calls[0]
+    assert "-e" not in argv
+    assert argv[:7] == ["tmux", "new-session", "-d", "-s", "repo-abcd", "-c", str(tmp_path)]
+    assert len(argv) == 8
+    assert spawn.get_spawned_sessions()["repo-abcd"]["platform"] == "anthropic"

--- a/backend/tests/test_platform_env.py
+++ b/backend/tests/test_platform_env.py
@@ -1,0 +1,65 @@
+"""Tests for platform -> environment-variable mapping."""
+import pytest
+
+
+def test_anthropic_returns_empty_env():
+    from app.services.providers.platform_env import build_platform_env, PLATFORM_ANTHROPIC
+
+    assert build_platform_env(PLATFORM_ANTHROPIC) == {}
+
+
+def test_unknown_platform_returns_empty_env():
+    from app.services.providers.platform_env import build_platform_env
+
+    assert build_platform_env("vertex") == {}
+
+
+def test_bedrock_minimal_sets_use_bedrock_flag():
+    from app.services.providers.platform_env import build_platform_env, PLATFORM_BEDROCK
+
+    assert build_platform_env(PLATFORM_BEDROCK) == {"CLAUDE_CODE_USE_BEDROCK": "1"}
+
+
+def test_bedrock_with_all_fields():
+    from app.services.providers.platform_env import build_platform_env, PLATFORM_BEDROCK
+
+    env = build_platform_env(
+        PLATFORM_BEDROCK,
+        region="us-east-1",
+        aws_profile="bedrock-prod",
+        model="arn:aws:bedrock:us-east-1:123:inference-profile/x",
+    )
+    assert env == {
+        "CLAUDE_CODE_USE_BEDROCK": "1",
+        "AWS_REGION": "us-east-1",
+        "AWS_PROFILE": "bedrock-prod",
+        "ANTHROPIC_MODEL": "arn:aws:bedrock:us-east-1:123:inference-profile/x",
+    }
+
+
+def test_bedrock_skips_blank_and_whitespace_values():
+    from app.services.providers.platform_env import build_platform_env, PLATFORM_BEDROCK
+
+    env = build_platform_env(PLATFORM_BEDROCK, region="  ", aws_profile="", model=None)
+    assert env == {"CLAUDE_CODE_USE_BEDROCK": "1"}
+
+
+def test_bedrock_strips_surrounding_whitespace():
+    from app.services.providers.platform_env import build_platform_env, PLATFORM_BEDROCK
+
+    env = build_platform_env(PLATFORM_BEDROCK, region="  us-west-2  ")
+    assert env["AWS_REGION"] == "us-west-2"
+
+
+def test_bedrock_rejects_newline_in_value():
+    from app.services.providers.platform_env import build_platform_env, PLATFORM_BEDROCK
+
+    with pytest.raises(ValueError):
+        build_platform_env(PLATFORM_BEDROCK, region="us-east-1\nFOO=bar")
+
+
+def test_bedrock_rejects_null_byte_in_value():
+    from app.services.providers.platform_env import build_platform_env, PLATFORM_BEDROCK
+
+    with pytest.raises(ValueError):
+        build_platform_env(PLATFORM_BEDROCK, model="bad\x00value")

--- a/docs/superpowers/plans/2026-05-29-agent-bridge-bedrock-platform.md
+++ b/docs/superpowers/plans/2026-05-29-agent-bridge-bedrock-platform.md
@@ -1,0 +1,664 @@
+# Agent Bridge Bedrock Platform Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users pick Anthropic (default) or Amazon Bedrock as the platform when starting an Agent Bridge session, injecting the right Bedrock environment variables into the spawned `claude` process.
+
+**Architecture:** A `platform` enum plus a provider-side env builder. The new-session dialog gains a Platform selector (Claude Code provider only); selecting Bedrock reveals optional Region/Profile/Model fields. On spawn, the backend converts the platform choice into a `dict[str, str]` of env vars and injects them into the tmux session via `tmux new-session -e KEY=VALUE`. Anthropic yields an empty env map, so its tmux command is byte-for-byte identical to today. Credentials are never collected or stored — they resolve from the server's AWS SDK credential chain.
+
+**Tech Stack:** Python 3.11 / FastAPI / Pydantic / pytest (backend); React 19 / TypeScript / Vite / shadcn-ui (frontend); tmux for session spawning.
+
+**Spec:** `docs/superpowers/specs/2026-05-29-agent-bridge-bedrock-platform-design.md`
+
+**Branch:** `feat/agent-bridge-bedrock-platform` (already created; the design doc is the first commit).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `backend/app/services/providers/platform_env.py` | **New.** Platform constants + `build_platform_env()` — the single place platform→env mapping lives. |
+| `backend/app/services/providers/base.py` | Add 4 platform fields to the `SpawnCommandOptions` dataclass. |
+| `backend/app/services/agent_bridge/spawn.py` | Build the env map and inject `-e KEY=VALUE` flags into the tmux argv; record `platform` in session metadata. |
+| `backend/app/api/v1/agent_bridge/router.py` | Add 4 platform fields to `SpawnRequest` and forward them into `SpawnCommandOptions`. |
+| `backend/tests/test_platform_env.py` | **New.** Unit tests for `build_platform_env()`. |
+| `backend/tests/test_agent_bridge_spawn.py` | Add tests asserting `-e` flags land in the tmux argv (Bedrock) and are absent (Anthropic). |
+| `frontend/src/features/cc-bridge/types.ts` | Add 4 platform fields to `SpawnSessionRequest`. |
+| `frontend/src/features/cc-bridge/NewSessionDialog.tsx` | Platform `<Select>` + conditional Bedrock inputs + localStorage remember/prefill. |
+
+---
+
+## Task 1: Platform env builder (backend, pure function)
+
+**Files:**
+- Create: `backend/app/services/providers/platform_env.py`
+- Test: `backend/tests/test_platform_env.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/test_platform_env.py`:
+
+```python
+"""Tests for platform -> environment-variable mapping."""
+import pytest
+
+
+def test_anthropic_returns_empty_env():
+    from app.services.providers.platform_env import build_platform_env, PLATFORM_ANTHROPIC
+
+    assert build_platform_env(PLATFORM_ANTHROPIC) == {}
+
+
+def test_unknown_platform_returns_empty_env():
+    from app.services.providers.platform_env import build_platform_env
+
+    assert build_platform_env("vertex") == {}
+
+
+def test_bedrock_minimal_sets_use_bedrock_flag():
+    from app.services.providers.platform_env import build_platform_env, PLATFORM_BEDROCK
+
+    assert build_platform_env(PLATFORM_BEDROCK) == {"CLAUDE_CODE_USE_BEDROCK": "1"}
+
+
+def test_bedrock_with_all_fields():
+    from app.services.providers.platform_env import build_platform_env, PLATFORM_BEDROCK
+
+    env = build_platform_env(
+        PLATFORM_BEDROCK,
+        region="us-east-1",
+        aws_profile="bedrock-prod",
+        model="arn:aws:bedrock:us-east-1:123:inference-profile/x",
+    )
+    assert env == {
+        "CLAUDE_CODE_USE_BEDROCK": "1",
+        "AWS_REGION": "us-east-1",
+        "AWS_PROFILE": "bedrock-prod",
+        "ANTHROPIC_MODEL": "arn:aws:bedrock:us-east-1:123:inference-profile/x",
+    }
+
+
+def test_bedrock_skips_blank_and_whitespace_values():
+    from app.services.providers.platform_env import build_platform_env, PLATFORM_BEDROCK
+
+    env = build_platform_env(PLATFORM_BEDROCK, region="  ", aws_profile="", model=None)
+    assert env == {"CLAUDE_CODE_USE_BEDROCK": "1"}
+
+
+def test_bedrock_strips_surrounding_whitespace():
+    from app.services.providers.platform_env import build_platform_env, PLATFORM_BEDROCK
+
+    env = build_platform_env(PLATFORM_BEDROCK, region="  us-west-2  ")
+    assert env["AWS_REGION"] == "us-west-2"
+
+
+def test_bedrock_rejects_newline_in_value():
+    from app.services.providers.platform_env import build_platform_env, PLATFORM_BEDROCK
+
+    with pytest.raises(ValueError):
+        build_platform_env(PLATFORM_BEDROCK, region="us-east-1\nFOO=bar")
+
+
+def test_bedrock_rejects_null_byte_in_value():
+    from app.services.providers.platform_env import build_platform_env, PLATFORM_BEDROCK
+
+    with pytest.raises(ValueError):
+        build_platform_env(PLATFORM_BEDROCK, model="bad\x00value")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && source venv/bin/activate && pytest tests/test_platform_env.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.services.providers.platform_env'`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `backend/app/services/providers/platform_env.py`:
+
+```python
+"""Map an Agent Bridge platform selection to process environment variables.
+
+Single source of truth for platform -> env mapping. Credentials are never
+handled here: only non-secret configuration (region, profile name, model id)
+is set, and the AWS SDK credential chain on the host resolves actual creds.
+"""
+from __future__ import annotations
+
+PLATFORM_ANTHROPIC = "anthropic"
+PLATFORM_BEDROCK = "bedrock"
+
+
+def _clean(value: str | None) -> str | None:
+    """Trim a value and reject control characters that break env injection."""
+    if value is None:
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    if "\n" in stripped or "\r" in stripped or "\x00" in stripped:
+        raise ValueError("Environment value must not contain newlines or null bytes")
+    return stripped
+
+
+def build_platform_env(
+    platform: str | None,
+    region: str | None = None,
+    aws_profile: str | None = None,
+    model: str | None = None,
+) -> dict[str, str]:
+    """Return the env vars for a platform selection (empty for Anthropic)."""
+    if platform != PLATFORM_BEDROCK:
+        return {}
+
+    env: dict[str, str] = {"CLAUDE_CODE_USE_BEDROCK": "1"}
+    cleaned_region = _clean(region)
+    if cleaned_region:
+        env["AWS_REGION"] = cleaned_region
+    cleaned_profile = _clean(aws_profile)
+    if cleaned_profile:
+        env["AWS_PROFILE"] = cleaned_profile
+    cleaned_model = _clean(model)
+    if cleaned_model:
+        env["ANTHROPIC_MODEL"] = cleaned_model
+    return env
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && source venv/bin/activate && pytest tests/test_platform_env.py -v`
+Expected: PASS (8 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/providers/platform_env.py backend/tests/test_platform_env.py
+git commit -m "feat(agent-bridge): add platform->env builder for Bedrock"
+```
+
+---
+
+## Task 2: Add platform fields to SpawnCommandOptions
+
+**Files:**
+- Modify: `backend/app/services/providers/base.py:18-37`
+
+- [ ] **Step 1: Add the fields**
+
+In `backend/app/services/providers/base.py`, the `SpawnCommandOptions` dataclass currently ends with `use_last: bool = False`. Add four fields immediately after it (still inside the dataclass):
+
+```python
+    use_last: bool = False
+    platform: str = "anthropic"
+    aws_region: str | None = None
+    aws_profile: str | None = None
+    bedrock_model: str | None = None
+```
+
+- [ ] **Step 2: Verify it imports**
+
+Run: `cd backend && source venv/bin/activate && python -c "from app.services.providers.base import SpawnCommandOptions; print(SpawnCommandOptions(directory='/tmp').platform)"`
+Expected: prints `anthropic`
+
+- [ ] **Step 3: Run the existing spawn tests (must still pass)**
+
+Run: `cd backend && source venv/bin/activate && pytest tests/test_agent_bridge_spawn.py -v`
+Expected: PASS (2 passed) — new optional fields don't change existing behavior.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/app/services/providers/base.py
+git commit -m "feat(agent-bridge): add platform options to SpawnCommandOptions"
+```
+
+---
+
+## Task 3: Inject env vars into the tmux spawn
+
+**Files:**
+- Modify: `backend/app/services/agent_bridge/spawn.py:37-79`
+- Test: `backend/tests/test_agent_bridge_spawn.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/tests/test_agent_bridge_spawn.py`:
+
+```python
+def test_bedrock_platform_injects_env_flags(monkeypatch, tmp_path):
+    from app.services.agent_bridge import spawn
+    from app.services.providers.base import SpawnCommandOptions
+
+    calls = []
+
+    def fake_run(args, capture_output=True, text=True, timeout=10):
+        calls.append(args)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(spawn, "_session_name_for", lambda directory: "repo-abcd")
+    monkeypatch.setattr(spawn.subprocess, "run", fake_run)
+    spawn.get_spawned_sessions().clear()
+
+    spawn.spawn_session(
+        "claude-code",
+        SpawnCommandOptions(
+            directory=str(tmp_path),
+            mode="plain",
+            platform="bedrock",
+            aws_region="us-east-1",
+            aws_profile="bedrock-prod",
+        ),
+    )
+
+    argv = calls[0]
+    # Fixed prefix stays identical to the no-env command.
+    assert argv[:7] == ["tmux", "new-session", "-d", "-s", "repo-abcd", "-c", str(tmp_path)]
+    # Env flags are injected as -e KEY=VALUE pairs before the shell command.
+    assert "-e" in argv
+    assert "CLAUDE_CODE_USE_BEDROCK=1" in argv
+    assert "AWS_REGION=us-east-1" in argv
+    assert "AWS_PROFILE=bedrock-prod" in argv
+    assert spawn.get_spawned_sessions()["repo-abcd"]["platform"] == "bedrock"
+
+
+def test_anthropic_platform_adds_no_env_flags(monkeypatch, tmp_path):
+    from app.services.agent_bridge import spawn
+    from app.services.providers.base import SpawnCommandOptions
+
+    calls = []
+
+    def fake_run(args, capture_output=True, text=True, timeout=10):
+        calls.append(args)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(spawn, "_session_name_for", lambda directory: "repo-abcd")
+    monkeypatch.setattr(spawn.subprocess, "run", fake_run)
+    spawn.get_spawned_sessions().clear()
+
+    spawn.spawn_session(
+        "claude-code",
+        SpawnCommandOptions(directory=str(tmp_path), mode="plain"),
+    )
+
+    argv = calls[0]
+    assert "-e" not in argv
+    # Command is exactly prefix + single shell-command element.
+    assert argv[:7] == ["tmux", "new-session", "-d", "-s", "repo-abcd", "-c", str(tmp_path)]
+    assert len(argv) == 8
+    assert spawn.get_spawned_sessions()["repo-abcd"]["platform"] == "anthropic"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && source venv/bin/activate && pytest tests/test_agent_bridge_spawn.py -v`
+Expected: FAIL — `test_bedrock_platform_injects_env_flags` (no `-e` in argv) and both `platform` metadata assertions raise `KeyError`.
+
+- [ ] **Step 3: Implement env injection**
+
+In `backend/app/services/agent_bridge/spawn.py`:
+
+(a) Add the import near the existing provider imports (after line 13):
+
+```python
+from app.services.providers.claude_code import ClaudeCodeProvider
+from app.services.providers.platform_env import build_platform_env
+```
+
+(b) Replace the spawn body from the `command = provider.build_spawn_command(options)` line through the `subprocess.run(...)` call (currently lines 49-58) with:
+
+```python
+    command = provider.build_spawn_command(options)
+    shell_command = " ".join(shlex.quote(part) for part in command)
+
+    platform_env = build_platform_env(
+        options.platform,
+        region=options.aws_region,
+        aws_profile=options.aws_profile,
+        model=options.bedrock_model,
+    )
+    env_flags: list[str] = []
+    for key, value in platform_env.items():
+        env_flags += ["-e", f"{key}={value}"]
+
+    try:
+        result = subprocess.run(
+            ["tmux", "new-session", "-d", "-s", name, "-c", directory, *env_flags, shell_command],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+```
+
+(c) In the `_spawned_sessions[name] = {...}` dict (currently lines 66-71), add a `platform` entry:
+
+```python
+    _spawned_sessions[name] = {
+        "provider": provider.id,
+        "mode": options.mode,
+        "directory": directory,
+        "worktree_name": options.worktree_name or (name if options.mode == "worktree" else None),
+        "platform": options.platform,
+    }
+```
+
+Note: env flags are placed **after** `-c directory` and **before** `shell_command`, so the fixed `[:7]` prefix the existing tests assert remains unchanged, and the Anthropic (empty-env) command is byte-for-byte identical to today.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && source venv/bin/activate && pytest tests/test_agent_bridge_spawn.py -v`
+Expected: PASS (4 passed — 2 original + 2 new)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/agent_bridge/spawn.py backend/tests/test_agent_bridge_spawn.py
+git commit -m "feat(agent-bridge): inject platform env vars into tmux spawn"
+```
+
+---
+
+## Task 4: Forward platform fields through the API
+
+**Files:**
+- Modify: `backend/app/api/v1/agent_bridge/router.py:27-44` and `:119-136`
+
+- [ ] **Step 1: Add fields to SpawnRequest**
+
+In `backend/app/api/v1/agent_bridge/router.py`, the `SpawnRequest` model currently ends with `use_last: bool = False`. Add four fields immediately after it (still inside the class):
+
+```python
+    use_last: bool = False
+    platform: str = "anthropic"
+    aws_region: str | None = None
+    aws_profile: str | None = None
+    bedrock_model: str | None = None
+```
+
+- [ ] **Step 2: Forward them into SpawnCommandOptions**
+
+In the same file, in `spawn_session_endpoint`, the `SpawnCommandOptions(...)` constructor currently ends with `use_last=request.use_last,`. Add four arguments immediately after it:
+
+```python
+            use_last=request.use_last,
+            platform=request.platform,
+            aws_region=request.aws_region,
+            aws_profile=request.aws_profile,
+            bedrock_model=request.bedrock_model,
+        )
+```
+
+- [ ] **Step 3: Verify the app imports cleanly**
+
+Run: `cd backend && source venv/bin/activate && python -c "import app.main"`
+Expected: no output, exit code 0.
+
+- [ ] **Step 4: Run the full backend test suite**
+
+Run: `cd backend && source venv/bin/activate && pytest tests/ -q`
+Expected: PASS (all tests, including the new platform tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/v1/agent_bridge/router.py
+git commit -m "feat(agent-bridge): accept platform fields in spawn API"
+```
+
+---
+
+## Task 5: Add platform fields to the frontend request type
+
+**Files:**
+- Modify: `frontend/src/features/cc-bridge/types.ts:33-51`
+
+- [ ] **Step 1: Add the fields**
+
+In `frontend/src/features/cc-bridge/types.ts`, the `SpawnSessionRequest` interface currently ends with `use_last?: boolean`. Add four fields immediately after it (still inside the interface):
+
+```typescript
+  use_last?: boolean
+  platform?: 'anthropic' | 'bedrock'
+  aws_region?: string
+  aws_profile?: string
+  bedrock_model?: string
+```
+
+- [ ] **Step 2: Verify the type compiles**
+
+Run: `cd frontend && npx tsc -b`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/features/cc-bridge/types.ts
+git commit -m "feat(agent-bridge): add platform fields to spawn request type"
+```
+
+---
+
+## Task 6: Platform selector + Bedrock fields in the dialog
+
+**Files:**
+- Modify: `frontend/src/features/cc-bridge/NewSessionDialog.tsx`
+
+This task wires UI state, localStorage persistence, request building, and the rendered controls. The dialog already imports `useState`, `useEffect`, `Input`, `Label`, and the `Select*` family — no new imports needed.
+
+- [ ] **Step 1: Add a localStorage constant and helper near the other module constants**
+
+After the `const CUSTOM_PROJECT_VALUE = '__custom__'` line (currently line 53), add:
+
+```typescript
+const PLATFORM_STORAGE_KEY = 'cc-bridge.platform'
+
+type Platform = 'anthropic' | 'bedrock'
+
+interface RememberedPlatform {
+  platform: Platform
+  aws_region: string
+  aws_profile: string
+  bedrock_model: string
+}
+
+function loadRememberedPlatform(): RememberedPlatform {
+  const fallback: RememberedPlatform = { platform: 'anthropic', aws_region: '', aws_profile: '', bedrock_model: '' }
+  try {
+    const raw = localStorage.getItem(PLATFORM_STORAGE_KEY)
+    if (!raw) return fallback
+    const parsed = JSON.parse(raw) as Partial<RememberedPlatform>
+    return {
+      platform: parsed.platform === 'bedrock' ? 'bedrock' : 'anthropic',
+      aws_region: typeof parsed.aws_region === 'string' ? parsed.aws_region : '',
+      aws_profile: typeof parsed.aws_profile === 'string' ? parsed.aws_profile : '',
+      bedrock_model: typeof parsed.bedrock_model === 'string' ? parsed.bedrock_model : '',
+    }
+  } catch {
+    return fallback
+  }
+}
+```
+
+- [ ] **Step 2: Add component state**
+
+After the `const [useLast, setUseLast] = useState(true)` line (currently line 72), add:
+
+```typescript
+  const [platform, setPlatform] = useState<Platform>('anthropic')
+  const [awsRegion, setAwsRegion] = useState('')
+  const [awsProfile, setAwsProfile] = useState('')
+  const [bedrockModel, setBedrockModel] = useState('')
+```
+
+- [ ] **Step 3: Prefill from localStorage when the dialog opens**
+
+After the existing "set directory from active project" effect (currently ends line 96), add a new effect:
+
+```typescript
+  // Prefill the remembered platform selection when the dialog opens.
+  useEffect(() => {
+    if (!open) return
+    const remembered = loadRememberedPlatform()
+    setPlatform(remembered.platform)
+    setAwsRegion(remembered.aws_region)
+    setAwsProfile(remembered.aws_profile)
+    setBedrockModel(remembered.bedrock_model)
+  }, [open])
+```
+
+- [ ] **Step 4: Do NOT reset platform on close**
+
+In the "Reset state when dialog closes" effect (currently lines 122-144), do **not** add platform resets — the prefill effect in Step 3 restores the remembered values on next open, which is the desired behavior. Leave that effect as-is.
+
+- [ ] **Step 5: Persist and include platform in the request**
+
+In `handleLaunch`, immediately after `setSubmitting(true)` (currently line 157), add the persistence write:
+
+```typescript
+    try {
+      const isBedrock = !isCodex && platform === 'bedrock'
+      localStorage.setItem(
+        PLATFORM_STORAGE_KEY,
+        JSON.stringify({
+          platform: isCodex ? 'anthropic' : platform,
+          aws_region: awsRegion,
+          aws_profile: awsProfile,
+          bedrock_model: bedrockModel,
+        }),
+      )
+```
+
+Then extend the `request` object literal (currently lines 160-182) by adding these spread entries immediately before the closing `}` of the object (after the Codex `use_last` block on line 181):
+
+```typescript
+        ...(isBedrock && { platform: 'bedrock' as const }),
+        ...(isBedrock && awsRegion.trim() && { aws_region: awsRegion.trim() }),
+        ...(isBedrock && awsProfile.trim() && { aws_profile: awsProfile.trim() }),
+        ...(isBedrock && bedrockModel.trim() && { bedrock_model: bedrockModel.trim() }),
+```
+
+Note: the original `const request: SpawnSessionRequest = {` declaration stays; we are only adding fields. The `try {` opening shown in this step replaces the existing `try {` on line 159 so `isBedrock` and the `localStorage.setItem` sit at the top of the try block.
+
+- [ ] **Step 6: Render the Platform selector and Bedrock fields**
+
+In the JSX, replace the entire Claude Code "skip permissions" block (currently lines 430-446, the `{!isCodex && ( ... )}` block) with the platform UI followed by the unchanged skip-permissions UI:
+
+```tsx
+          {!isCodex && (
+            <div className="space-y-1.5">
+              <Label>Platform</Label>
+              <Select value={platform} onValueChange={(value) => setPlatform(value as Platform)}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="anthropic">Anthropic (default)</SelectItem>
+                  <SelectItem value="bedrock">Amazon Bedrock</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {!isCodex && platform === 'bedrock' && (
+            <div className="space-y-3 rounded-md border border-border p-3">
+              <p className="text-xs text-muted-foreground">
+                Uses AWS credentials from the server environment. Region is usually required.
+              </p>
+              <div className="space-y-1.5">
+                <Label htmlFor="aws-region">AWS Region</Label>
+                <Input id="aws-region" value={awsRegion} onChange={(e) => setAwsRegion(e.target.value)} placeholder="e.g. us-east-1" />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="aws-profile">AWS Profile (optional)</Label>
+                <Input id="aws-profile" value={awsProfile} onChange={(e) => setAwsProfile(e.target.value)} placeholder="e.g. bedrock-prod" />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="bedrock-model">Model ARN / ID (optional)</Label>
+                <Input id="bedrock-model" value={bedrockModel} onChange={(e) => setBedrockModel(e.target.value)} placeholder="arn:aws:bedrock:..." />
+              </div>
+            </div>
+          )}
+
+          {!isCodex && (
+            <div className="space-y-1">
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="skip-permissions"
+                  checked={skipPermissions}
+                  onCheckedChange={(checked) => setSkipPermissions(checked === true)}
+                />
+                <Label htmlFor="skip-permissions" className="cursor-pointer">
+                  Skip permission prompts
+                </Label>
+              </div>
+              <p className="text-xs text-destructive/80 ml-6">
+                Allows Claude to run tools without asking for confirmation
+              </p>
+            </div>
+          )}
+```
+
+- [ ] **Step 7: Typecheck and lint**
+
+Run: `cd frontend && npx tsc -b && npm run lint`
+Expected: `tsc` clean; ESLint reports no errors in `NewSessionDialog.tsx` or `types.ts` (pre-existing errors in `usePresenceWebSocket.ts` / `api.ts` are unrelated and acceptable).
+
+- [ ] **Step 8: Production build**
+
+Run: `cd frontend && npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/src/features/cc-bridge/NewSessionDialog.tsx
+git commit -m "feat(agent-bridge): add platform selector with Bedrock fields to new-session dialog"
+```
+
+---
+
+## Task 7: Manual verification + PR
+
+**Files:** none (verification + PR).
+
+- [ ] **Step 1: Start dev servers and smoke-test**
+
+Run: `./scripts/dev.sh`
+Then in the browser (Agent Bridge → New Session, Claude Code provider):
+- Confirm a **Platform** dropdown shows "Anthropic (default)" and "Amazon Bedrock".
+- Anthropic selected → launch a session → confirm it starts normally (unchanged behavior).
+- Switch to Bedrock → confirm Region/Profile/Model inputs appear.
+- Set a region, launch on an AWS-credentialed host → confirm `claude` starts on Bedrock (e.g. check the session uses Bedrock; `tmux show-environment -t <session>` lists `CLAUDE_CODE_USE_BEDROCK=1` and `AWS_REGION`).
+- Close and reopen the dialog → confirm the Bedrock selection + field values are pre-filled (localStorage).
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+gh auth switch -u juanrubio
+git -c credential.helper= \
+    -c credential.helper='!f() { echo username=juanrubio; echo "password=$(gh auth token -u juanrubio)"; }; f' \
+    push origin feat/agent-bridge-bedrock-platform
+```
+
+- [ ] **Step 3: Open the issue and PR against master**
+
+Create a GitHub issue describing the feature, then open a PR with `## Summary` / `## Test plan` sections referencing it with `Closes #N`, base `master`.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Platform picker (Anthropic/Bedrock), Claude Code only → Task 6. ✅
+- Bedrock fields Region/Profile/Model → Tasks 5 (type), 6 (UI), mapped to env in Task 1. ✅
+- Inherit-from-server credentials (no secret collection/storage) → Task 1 only sets non-secret vars; nothing persisted server-side. ✅
+- Env mapping table (`CLAUDE_CODE_USE_BEDROCK`/`AWS_REGION`/`AWS_PROFILE`/`ANTHROPIC_MODEL`) → Task 1 tests + impl. ✅
+- Injection via `tmux -e`, Anthropic byte-identical → Task 3 (placement after `-c dir`; `test_anthropic_platform_adds_no_env_flags` asserts `len(argv)==8`). ✅
+- Remember last selection in localStorage, non-secret only → Task 6 Steps 1,3,5. ✅
+- Backward compat (omitted `platform` defaults to anthropic) → Tasks 2 & 4 defaults; existing spawn tests retained. ✅
+- Injection safety (reject `\n`/`\0`) → Task 1 `_clean` + tests. ✅
+- Vertex out of scope, door open via `build_platform_env` map → Task 1 returns `{}` for non-bedrock. ✅
+- Testing strategy (pytest for builder + spawn argv; tsc/lint/manual for FE) → Tasks 1,3,6,7. ✅
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. ✅
+
+**Type consistency:** `platform`/`aws_region`/`aws_profile`/`bedrock_model` used identically across `SpawnCommandOptions` (Task 2), `SpawnRequest` (Task 4), `SpawnSessionRequest` (Task 5), and dialog request (Task 6). Env var names match between Task 1 impl and Task 3 assertions (`CLAUDE_CODE_USE_BEDROCK`, `AWS_REGION`, `AWS_PROFILE`, `ANTHROPIC_MODEL`). `build_platform_env` signature `(platform, region=, aws_profile=, model=)` matches the call site in Task 3. ✅

--- a/docs/superpowers/specs/2026-05-29-agent-bridge-bedrock-platform-design.md
+++ b/docs/superpowers/specs/2026-05-29-agent-bridge-bedrock-platform-design.md
@@ -1,0 +1,114 @@
+# Agent Bridge — Platform selection (Anthropic / Bedrock)
+
+**Date:** 2026-05-29
+**Status:** Design — pending implementation
+**Scope:** Add a per-session platform picker (Anthropic default / Amazon Bedrock) to the Agent Bridge "New Session" dialog for the Claude Code provider, injecting the appropriate Bedrock environment variables into the spawned `claude` process.
+
+## Problem
+
+The Agent Bridge spawns `claude` inside a tmux session (`backend/app/services/agent_bridge/spawn.py`). Today it calls `tmux new-session` **without passing any environment**, so the session simply inherits the backend server's environment. There is no way, from the UI, to start a session against Amazon Bedrock rather than the default Anthropic API. Running Claude Code against Bedrock requires setting `CLAUDE_CODE_USE_BEDROCK=1` plus AWS configuration (region, optionally profile and model) in the process environment.
+
+The user wants to select **Bedrock vs. Anthropic** when starting an Agent Bridge session.
+
+## Decisions (locked)
+
+- **Credential source: inherit from the server.** Claude Deck never collects or stores AWS secrets. Selecting Bedrock sets non-secret env vars (`CLAUDE_CODE_USE_BEDROCK`, region, profile name, model ID) and lets the AWS SDK credential chain on the backend host resolve actual credentials (env vars, `~/.aws/credentials` profile, or instance role).
+- **Bedrock fields exposed:** AWS Region, AWS Profile name, Model ARN/ID. All optional.
+- **Vertex:** out of scope for now. The design leaves the door open via a single env-builder map so Vertex can be added later without reworking the plumbing.
+- **Remember last selection:** yes — persist the last-used platform and its (non-secret) field values in browser `localStorage` so the dialog pre-fills next time. No backend persistence change.
+
+## Approach
+
+A `platform` enum plus a provider-side env builder.
+
+1. The dialog gains a **Platform** selector for the Claude Code provider: `Anthropic` (default) or `Amazon Bedrock`.
+2. Selecting Bedrock reveals three optional inputs: **AWS Region**, **AWS Profile**, **Model ARN/ID**.
+3. On spawn, the backend translates the platform choice into a `dict[str, str]` of environment variables and injects them into the tmux session via `tmux new-session -e KEY=VALUE` (one `-e` per variable).
+4. `Anthropic` produces an **empty** env map → the tmux command is byte-for-byte identical to today (full backward compatibility).
+
+### Env mapping (Bedrock)
+
+| Setting | Env var | Condition |
+|---|---|---|
+| (platform = bedrock) | `CLAUDE_CODE_USE_BEDROCK=1` | always when Bedrock |
+| AWS Region | `AWS_REGION=<value>` | if provided |
+| AWS Profile | `AWS_PROFILE=<value>` | if provided |
+| Model ARN/ID | `ANTHROPIC_MODEL=<value>` | if provided |
+
+### Alternatives considered (rejected)
+
+- **settings.json `env` only** — Claude Code already reads `env` from settings.json, so Bedrock vars could be set globally there with zero code. Rejected: it is global, not the per-session picker requested, and the spawn path never sets a custom env anyway.
+- **Store AWS keys in Claude Deck** (typed per session, or saved profiles) — rejected in favor of inherit-from-server, which is safer (no secret storage) and simpler.
+
+## Components & data flow
+
+### Backend
+
+- **`backend/app/services/providers/platform_env.py` (new)**
+  - Constants: `PLATFORM_ANTHROPIC = "anthropic"`, `PLATFORM_BEDROCK = "bedrock"`.
+  - `build_platform_env(platform, region, aws_profile, model) -> dict[str, str]`:
+    - Anthropic → `{}`.
+    - Bedrock → `{"CLAUDE_CODE_USE_BEDROCK": "1", ...}` adding region/profile/model only when set.
+    - Defensive validation: reject values containing `\n` or `\0`; skip empty/whitespace-only values.
+  - Single extension point for a future Vertex platform.
+
+- **`backend/app/services/providers/base.py`** — add four frozen-dataclass fields to `SpawnCommandOptions`:
+  `platform: str = "anthropic"`, `aws_region: str | None = None`, `aws_profile: str | None = None`, `bedrock_model: str | None = None`.
+  A distinct `bedrock_model` (not the existing Codex-only `model`) avoids overloading semantics and keeps the Anthropic Claude Code spawn untouched.
+
+- **`backend/app/services/agent_bridge/spawn.py`** — in `spawn_session`:
+  - Call `build_platform_env(...)` from the options.
+  - Insert `-e KEY=VALUE` argv elements into the `tmux new-session` call (after `-d`, before `-s`). Empty env → unchanged command.
+  - Store `platform` in `_spawned_sessions[name]` metadata for visibility. Never log AWS values.
+
+- **`backend/app/api/v1/agent_bridge/router.py`** — add the four fields to `SpawnRequest` and pass them through when constructing `SpawnCommandOptions`.
+
+### Frontend
+
+- **`frontend/src/features/cc-bridge/types.ts`** — add `platform?`, `aws_region?`, `aws_profile?`, `bedrock_model?` to `SpawnSessionRequest`.
+- **`frontend/src/features/cc-bridge/NewSessionDialog.tsx`** — for the Claude Code provider:
+  - A **Platform** `<Select>` (Anthropic / Amazon Bedrock), defaulting to Anthropic.
+  - When Bedrock is selected, conditionally render Region / Profile / Model inputs (mirroring the existing Codex-only conditional fields), with a hint that region is usually required.
+  - **Remember last selection:** read/write `localStorage` (e.g. key `cc-bridge.platform`) holding `{platform, aws_region, aws_profile, bedrock_model}` — **non-secret values only** — to pre-fill on open.
+
+### Flow
+
+Dialog → `SpawnSessionRequest` (with platform fields) → `POST` spawn → `SpawnRequest` → `SpawnCommandOptions` → `spawn_session` → `build_platform_env` → `tmux new-session -e ...` → `claude` runs in a tmux session whose environment carries the Bedrock vars; the AWS SDK resolves credentials from the inherited chain.
+
+## Error handling & validation
+
+- **Injection safety:** values are passed as separate argv elements to `tmux -e KEY=VALUE`, never shell-interpolated, so there is no quoting/injection risk. `build_platform_env` additionally rejects values with `\n`/`\0`.
+- **Optional fields:** Region/profile/model are optional even for Bedrock. Bedrock with no region sets only `CLAUDE_CODE_USE_BEDROCK=1`; Claude Code / the AWS SDK surface their own "no region" error inside the tmux session. We do not duplicate AWS-side validation client-side.
+- **No credential handling** in the path — nothing to leak, log, or persist. Logs record `platform=bedrock` but no AWS values.
+- **Backward compatibility:** omitting `platform` defaults to `"anthropic"`; Anthropic yields an empty env map and the current tmux command.
+
+## Testing
+
+- **Backend (pytest):**
+  - `build_platform_env`: Anthropic → `{}`; Bedrock with all fields; Bedrock with only region; defensive rejection of `\n`/`\0` and empty values.
+  - `spawn_session`: mock `subprocess.run`; assert `-e` flags appear in the tmux argv for Bedrock, and that Anthropic produces no `-e` flags.
+- **Frontend:** no test harness exists yet (per CLAUDE.md); rely on `tsc` + ESLint and manual verification.
+- **Manual:** Anthropic session unchanged; Bedrock session on an AWS-credentialed host starts on Bedrock; dialog pre-fills the last selection.
+
+## Out of scope (YAGNI)
+
+- Google Vertex AI (door left open via the env-builder map).
+- Storing AWS secrets or named credential profiles in Claude Deck.
+- Database persistence of bridge sessions (they remain in-memory).
+- Editing settings.json from this feature.
+
+## Files to change
+
+| File | Change |
+|---|---|
+| `backend/app/services/providers/platform_env.py` | **New** — platform constants + `build_platform_env()` |
+| `backend/app/services/providers/base.py` | +4 fields on `SpawnCommandOptions` |
+| `backend/app/services/agent_bridge/spawn.py` | Build env, inject `-e` flags, store `platform` metadata |
+| `backend/app/api/v1/agent_bridge/router.py` | +4 fields on `SpawnRequest`, pass through |
+| `backend/tests/` | New tests for env builder + spawn argv |
+| `frontend/src/features/cc-bridge/types.ts` | +4 fields on `SpawnSessionRequest` |
+| `frontend/src/features/cc-bridge/NewSessionDialog.tsx` | Platform select + conditional Bedrock fields + localStorage remember |
+
+## Workflow
+
+Feature → GitHub issue + `feat/agent-bridge-bedrock-platform` branch + PR against `master`.

--- a/docs/superpowers/specs/2026-05-29-agent-bridge-bedrock-platform-design.md
+++ b/docs/superpowers/specs/2026-05-29-agent-bridge-bedrock-platform-design.md
@@ -58,7 +58,7 @@ A `platform` enum plus a provider-side env builder.
 
 - **`backend/app/services/agent_bridge/spawn.py`** — in `spawn_session`:
   - Call `build_platform_env(...)` from the options.
-  - Insert `-e KEY=VALUE` argv elements into the `tmux new-session` call (after `-d`, before `-s`). Empty env → unchanged command.
+  - Insert `-e KEY=VALUE` argv elements into the `tmux new-session` call (after `-c <dir>`, before the shell command, so the fixed `-d -s <name> -c <dir>` prefix is unchanged). Empty env → unchanged command.
   - Store `platform` in `_spawned_sessions[name]` metadata for visibility. Never log AWS values.
 
 - **`backend/app/api/v1/agent_bridge/router.py`** — add the four fields to `SpawnRequest` and pass them through when constructing `SpawnCommandOptions`.

--- a/frontend/src/features/cc-bridge/NewSessionDialog.tsx
+++ b/frontend/src/features/cc-bridge/NewSessionDialog.tsx
@@ -200,15 +200,19 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
 
     try {
       const isBedrock = !isCodex && platform === 'bedrock'
-      localStorage.setItem(
-        PLATFORM_STORAGE_KEY,
-        JSON.stringify({
-          platform: isCodex ? 'anthropic' : platform,
-          aws_region: awsRegion,
-          aws_profile: awsProfile,
-          bedrock_model: bedrockModel,
-        }),
-      )
+      try {
+        localStorage.setItem(
+          PLATFORM_STORAGE_KEY,
+          JSON.stringify({
+            platform: isCodex ? 'anthropic' : platform,
+            aws_region: awsRegion,
+            aws_profile: awsProfile,
+            bedrock_model: bedrockModel,
+          }),
+        )
+      } catch {
+        // Persisting the platform preference is best-effort; ignore storage failures.
+      }
       const request: SpawnSessionRequest = {
         provider,
         directory: directory.trim(),

--- a/frontend/src/features/cc-bridge/NewSessionDialog.tsx
+++ b/frontend/src/features/cc-bridge/NewSessionDialog.tsx
@@ -52,6 +52,34 @@ const CODEX_MODE_OPTIONS: { value: Mode; label: string }[] = [
 
 const CUSTOM_PROJECT_VALUE = '__custom__'
 
+const PLATFORM_STORAGE_KEY = 'cc-bridge.platform'
+
+type Platform = 'anthropic' | 'bedrock'
+
+interface RememberedPlatform {
+  platform: Platform
+  aws_region: string
+  aws_profile: string
+  bedrock_model: string
+}
+
+function loadRememberedPlatform(): RememberedPlatform {
+  const fallback: RememberedPlatform = { platform: 'anthropic', aws_region: '', aws_profile: '', bedrock_model: '' }
+  try {
+    const raw = localStorage.getItem(PLATFORM_STORAGE_KEY)
+    if (!raw) return fallback
+    const parsed = JSON.parse(raw) as Partial<RememberedPlatform>
+    return {
+      platform: parsed.platform === 'bedrock' ? 'bedrock' : 'anthropic',
+      aws_region: typeof parsed.aws_region === 'string' ? parsed.aws_region : '',
+      aws_profile: typeof parsed.aws_profile === 'string' ? parsed.aws_profile : '',
+      bedrock_model: typeof parsed.bedrock_model === 'string' ? parsed.bedrock_model : '',
+    }
+  } catch {
+    return fallback
+  }
+}
+
 export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvider }: NewSessionDialogProps) {
   const { providers, selectedProviderId } = useProviderContext()
   const defaultProvider = initialProvider ?? selectedProviderId
@@ -70,6 +98,10 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
   const [dangerousBypass, setDangerousBypass] = useState(false)
   const [codexSessionId, setCodexSessionId] = useState('')
   const [useLast, setUseLast] = useState(true)
+  const [platform, setPlatform] = useState<Platform>('anthropic')
+  const [awsRegion, setAwsRegion] = useState('')
+  const [awsProfile, setAwsProfile] = useState('')
+  const [bedrockModel, setBedrockModel] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -94,6 +126,16 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
       setDirectory(activeProject.path)
     }
   }, [open, activeProject?.path, directory])
+
+  // Prefill the remembered platform selection when the dialog opens.
+  useEffect(() => {
+    if (!open) return
+    const remembered = loadRememberedPlatform()
+    setPlatform(remembered.platform)
+    setAwsRegion(remembered.aws_region)
+    setAwsProfile(remembered.aws_profile)
+    setBedrockModel(remembered.bedrock_model)
+  }, [open])
 
   // Fetch sessions when switching to resume mode
   useEffect(() => {
@@ -157,6 +199,16 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
     setSubmitting(true)
 
     try {
+      const isBedrock = !isCodex && platform === 'bedrock'
+      localStorage.setItem(
+        PLATFORM_STORAGE_KEY,
+        JSON.stringify({
+          platform: isCodex ? 'anthropic' : platform,
+          aws_region: awsRegion,
+          aws_profile: awsProfile,
+          bedrock_model: bedrockModel,
+        }),
+      )
       const request: SpawnSessionRequest = {
         provider,
         directory: directory.trim(),
@@ -179,6 +231,10 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
           use_last: useLast,
           ...(!useLast && codexSessionId.trim() && { session_id: codexSessionId.trim() }),
         }),
+        ...(isBedrock && { platform: 'bedrock' as const }),
+        ...(isBedrock && awsRegion.trim() && { aws_region: awsRegion.trim() }),
+        ...(isBedrock && awsProfile.trim() && { aws_profile: awsProfile.trim() }),
+        ...(isBedrock && bedrockModel.trim() && { bedrock_model: bedrockModel.trim() }),
       }
 
       const response = await spawnSession(request)
@@ -423,6 +479,41 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
               <div className="col-span-2 space-y-1.5">
                 <Label htmlFor="codex-prompt">Initial Prompt</Label>
                 <Input id="codex-prompt" value={prompt} onChange={(e) => setPrompt(e.target.value)} placeholder="Optional prompt" />
+              </div>
+            </div>
+          )}
+
+          {!isCodex && (
+            <div className="space-y-1.5">
+              <Label>Platform</Label>
+              <Select value={platform} onValueChange={(value) => setPlatform(value as Platform)}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="anthropic">Anthropic (default)</SelectItem>
+                  <SelectItem value="bedrock">Amazon Bedrock</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {!isCodex && platform === 'bedrock' && (
+            <div className="space-y-3 rounded-md border border-border p-3">
+              <p className="text-xs text-muted-foreground">
+                Uses AWS credentials from the server environment. Region is usually required.
+              </p>
+              <div className="space-y-1.5">
+                <Label htmlFor="aws-region">AWS Region</Label>
+                <Input id="aws-region" value={awsRegion} onChange={(e) => setAwsRegion(e.target.value)} placeholder="e.g. us-east-1" />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="aws-profile">AWS Profile (optional)</Label>
+                <Input id="aws-profile" value={awsProfile} onChange={(e) => setAwsProfile(e.target.value)} placeholder="e.g. bedrock-prod" />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="bedrock-model">Model ARN / ID (optional)</Label>
+                <Input id="bedrock-model" value={bedrockModel} onChange={(e) => setBedrockModel(e.target.value)} placeholder="arn:aws:bedrock:..." />
               </div>
             </div>
           )}

--- a/frontend/src/features/cc-bridge/types.ts
+++ b/frontend/src/features/cc-bridge/types.ts
@@ -48,6 +48,10 @@ export interface SpawnSessionRequest {
   no_alt_screen?: boolean
   dangerously_bypass_approvals_and_sandbox?: boolean
   use_last?: boolean
+  platform?: 'anthropic' | 'bedrock'
+  aws_region?: string
+  aws_profile?: string
+  bedrock_model?: string
 }
 
 export interface SpawnSessionResponse {


### PR DESCRIPTION
## Summary

Adds a per-session **Platform** picker (Anthropic default / Amazon Bedrock) to the Agent Bridge "New Session" dialog for the Claude Code provider. Selecting Bedrock reveals optional **AWS Region**, **AWS Profile**, and **Model ARN/ID** fields; on spawn the backend maps the choice to environment variables and injects them into the tmux session via `tmux new-session -e KEY=VALUE`.

**Credentials are never collected or stored.** Only non-secret configuration is set, and the server's AWS SDK credential chain (env / `~/.aws` profile / instance role) resolves the actual credentials:

| Setting | Env var |
|---|---|
| platform = bedrock | `CLAUDE_CODE_USE_BEDROCK=1` |
| AWS Region | `AWS_REGION` |
| AWS Profile | `AWS_PROFILE` |
| Model ARN/ID | `ANTHROPIC_MODEL` |

Anthropic (the default, and any omitted/unknown platform) produces an **empty** env map, so the tmux command is byte-for-byte identical to before — fully backward compatible. The dialog remembers the last selection (non-secret values only) in `localStorage`.

### How it's built
- New `backend/app/services/providers/platform_env.py` — single `build_platform_env()` mapping point (also the extension seam for future Vertex support). Sanitizes values (rejects newlines/null bytes); never logs them.
- `SpawnCommandOptions` + `SpawnRequest` gain `platform` / `aws_region` / `aws_profile` / `bedrock_model`, threaded through to the spawn.
- `spawn_session` injects `-e` flags after `-c <dir>` (fixed prefix unchanged) and records `platform` in session metadata.
- Frontend: `SpawnSessionRequest` type + `NewSessionDialog` platform selector, conditional Bedrock fields, and best-effort localStorage persistence.

### Out of scope (by design)
Vertex AI (door left open via the env-builder), storing AWS secrets, DB persistence of sessions.

Design + plan: `docs/superpowers/specs/2026-05-29-agent-bridge-bedrock-platform-design.md`, `docs/superpowers/plans/2026-05-29-agent-bridge-bedrock-platform.md`.

## Test plan

- [x] Backend suite green: `pytest tests/` → 111 passed (incl. new `test_platform_env.py` and the two new spawn tests)
- [x] `build_platform_env` unit tests: anthropic→{}, unknown→{}, bedrock minimal/full, blank/whitespace skipping, whitespace stripping, newline/null-byte rejection
- [x] Spawn argv tests: Bedrock injects `-e CLAUDE_CODE_USE_BEDROCK=1`/`AWS_REGION`/`AWS_PROFILE`; Anthropic adds no `-e` and keeps `len(argv) == 8`
- [x] Frontend `tsc -b` clean and `npm run build` succeeds; no new ESLint findings in `NewSessionDialog.tsx`
- [ ] **Manual (needs an AWS-credentialed host — not run in this environment):** select Bedrock, set a region, launch, confirm `claude` comes up on Bedrock and `tmux show-environment` lists `CLAUDE_CODE_USE_BEDROCK=1`; confirm dialog pre-fills last selection after reopen

Closes #159