### PR TITLE
Fix New Session modal clipping footer when Bedrock + Resume selected

### DIFF
--- a/frontend/src/features/cc-bridge/NewSessionDialog.tsx
+++ b/frontend/src/features/cc-bridge/NewSessionDialog.tsx
@@ -253,7 +253,7 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className={MODAL_SIZES.MD}>
+      <DialogContent className={cn(MODAL_SIZES.MD, 'overflow-y-auto')}>
         <DialogHeader>
           <DialogTitle>New Agent Session</DialogTitle>
           <DialogDescription>


### PR DESCRIPTION
## Summary

In the Agent Bridge **New Session** dialog, selecting **Amazon Bedrock** reveals the Region/Profile/Model fields; selecting **Resume** mode adds the **Recent Sessions** list. With both shown, the content exceeds the dialog's `max-h-[85vh]` cap — but the dialog had no overflow handling, so the **Launch / Cancel footer buttons were clipped off-screen** and unreachable.

Fix: add `overflow-y-auto` to the dialog content (via `cn(MODAL_SIZES.MD, 'overflow-y-auto')`), so overflowing content scrolls and the footer stays reachable. This matches the existing `MODAL_SIZES.SM` convention (`max-h-[80vh] overflow-y-auto`). One-line, low-risk change; `cn` was already imported.

## Test plan

- [x] `tsc -b` clean
- [x] `npm run build` succeeds
- [x] No new ESLint findings in `NewSessionDialog.tsx`
- [ ] Manual: open New Session → Claude Code → Bedrock + Resume, confirm the modal scrolls and Launch/Cancel are reachable; confirm short content (Anthropic + Plain) is unchanged

Closes #161