### PR TITLE
Discover Projects: fix dark-mode input + add directory browser

### DIFF
--- a/backend/app/api/v1/projects.py
+++ b/backend/app/api/v1/projects.py
@@ -1,5 +1,8 @@
 """Project management API endpoints."""
-from fastapi import APIRouter, Depends, HTTPException
+import os
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
@@ -44,6 +47,29 @@ async def discover_projects(
     service = ProjectService(db)
     discovered = service.discover_projects(request.base_path)
     return ProjectDiscoveryResponse(discovered=discovered)
+
+
+@router.get("/projects/browse")
+async def browse_directory(path: str = Query(default="~")):
+    """Return subdirectories of the given path for the directory browser."""
+    try:
+        resolved = Path(os.path.expanduser(path)).resolve()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid path")
+
+    if not resolved.is_dir():
+        raise HTTPException(status_code=404, detail="Path is not a directory")
+
+    try:
+        subdirs = sorted(
+            [e.name for e in resolved.iterdir() if e.is_dir() and not e.name.startswith(".")],
+            key=str.lower,
+        )
+    except PermissionError:
+        raise HTTPException(status_code=403, detail="Permission denied")
+
+    parent = str(resolved.parent) if resolved != resolved.parent else None
+    return {"path": str(resolved), "parent": parent, "directories": subdirs}
 
 
 # Active project routes - MUST be before /projects/{project_id} routes

--- a/backend/app/api/v1/projects.py
+++ b/backend/app/api/v1/projects.py
@@ -51,11 +51,22 @@ async def discover_projects(
 
 @router.get("/projects/browse")
 async def browse_directory(path: str = Query(default="~")):
-    """Return subdirectories of the given path for the directory browser."""
+    """Return subdirectories of the given path for the directory browser.
+
+    Restricted to paths within the current user's home directory to prevent
+    unintended exposure of arbitrary filesystem locations.
+    """
+    home = Path.home().resolve()
     try:
         resolved = Path(os.path.expanduser(path)).resolve()
     except Exception:
         raise HTTPException(status_code=400, detail="Invalid path")
+
+    # Constrain to home directory tree
+    try:
+        resolved.relative_to(home)
+    except ValueError:
+        raise HTTPException(status_code=403, detail="Path must be within your home directory")
 
     if not resolved.is_dir():
         raise HTTPException(status_code=404, detail="Path is not a directory")
@@ -68,7 +79,14 @@ async def browse_directory(path: str = Query(default="~")):
     except PermissionError:
         raise HTTPException(status_code=403, detail="Permission denied")
 
-    parent = str(resolved.parent) if resolved != resolved.parent else None
+    # Only expose parent if it stays within the home directory
+    try:
+        parent_path = resolved.parent
+        parent_path.relative_to(home)
+        parent = str(parent_path)
+    except ValueError:
+        parent = None  # resolved is home itself, no parent to expose
+
     return {"path": str(resolved), "parent": parent, "directories": subdirs}
 
 

--- a/frontend/src/features/projects/ProjectDiscovery.tsx
+++ b/frontend/src/features/projects/ProjectDiscovery.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useProjectContext } from '@/contexts/ProjectContext';
 import type { ProjectBase } from '@/types/projects';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -28,6 +28,13 @@ export function ProjectDiscovery({ onProjectsDiscovered }: ProjectDiscoveryProps
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [addingProjects, setAddingProjects] = useState<Set<string>>(new Set());
+
+  // Pre-populate with the real home path on mount
+  useEffect(() => {
+    apiClient<BrowseResult>('projects/browse?path=~')
+      .then((r) => setSearchPath(r.path))
+      .catch(() => { /* leave empty if backend not ready */ });
+  }, []);
 
   // Directory browser state
   const [browserOpen, setBrowserOpen] = useState(false);
@@ -115,7 +122,7 @@ export function ProjectDiscovery({ onProjectsDiscovered }: ProjectDiscoveryProps
             type="text"
             value={searchPath}
             onChange={(e) => setSearchPath(e.target.value)}
-            placeholder="/home/user/projects"
+            placeholder="~/projects"
             onKeyDown={(e) => { if (e.key === 'Enter') handleDiscover(); }}
           />
           <Button variant="outline" onClick={openBrowser} title="Browse directories">

--- a/frontend/src/features/projects/ProjectDiscovery.tsx
+++ b/frontend/src/features/projects/ProjectDiscovery.tsx
@@ -1,12 +1,21 @@
-/**
- * Project discovery wizard component
- */
 import { useState } from 'react';
 import { useProjectContext } from '@/contexts/ProjectContext';
 import type { ProjectBase } from '@/types/projects';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Folder, FolderOpen, ChevronRight, ArrowLeft } from 'lucide-react';
+import { apiClient } from '@/lib/api';
+import { MODAL_SIZES } from '@/lib/constants';
+
+interface BrowseResult {
+  path: string;
+  parent: string | null;
+  directories: string[];
+}
 
 interface ProjectDiscoveryProps {
   onProjectsDiscovered: () => void;
@@ -20,12 +29,17 @@ export function ProjectDiscovery({ onProjectsDiscovered }: ProjectDiscoveryProps
   const [error, setError] = useState<string | null>(null);
   const [addingProjects, setAddingProjects] = useState<Set<string>>(new Set());
 
+  // Directory browser state
+  const [browserOpen, setBrowserOpen] = useState(false);
+  const [browseResult, setBrowseResult] = useState<BrowseResult | null>(null);
+  const [browseLoading, setBrowseLoading] = useState(false);
+  const [browseError, setBrowseError] = useState<string | null>(null);
+
   const handleDiscover = async () => {
     if (!searchPath.trim()) {
       setError('Please enter a path to search');
       return;
     }
-
     setLoading(true);
     setError(null);
     try {
@@ -60,6 +74,33 @@ export function ProjectDiscovery({ onProjectsDiscovered }: ProjectDiscoveryProps
     }
   };
 
+  const browseTo = async (path: string) => {
+    setBrowseLoading(true);
+    setBrowseError(null);
+    try {
+      const result = await apiClient<BrowseResult>(
+        `/projects/browse?path=${encodeURIComponent(path)}`
+      );
+      setBrowseResult(result);
+    } catch (err) {
+      setBrowseError(err instanceof Error ? err.message : 'Failed to read directory');
+    } finally {
+      setBrowseLoading(false);
+    }
+  };
+
+  const openBrowser = () => {
+    setBrowserOpen(true);
+    browseTo(searchPath.trim() || '~');
+  };
+
+  const handleSelectDirectory = () => {
+    if (browseResult) {
+      setSearchPath(browseResult.path);
+    }
+    setBrowserOpen(false);
+  };
+
   return (
     <Card>
       <CardHeader>
@@ -70,27 +111,23 @@ export function ProjectDiscovery({ onProjectsDiscovered }: ProjectDiscoveryProps
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="flex gap-2">
-          <input
+          <Input
             type="text"
             value={searchPath}
             onChange={(e) => setSearchPath(e.target.value)}
             placeholder="/home/user/projects"
-            className="flex-1 px-3 py-2 border rounded-md"
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                handleDiscover();
-              }
-            }}
+            onKeyDown={(e) => { if (e.key === 'Enter') handleDiscover(); }}
           />
+          <Button variant="outline" onClick={openBrowser} title="Browse directories">
+            <Folder className="h-4 w-4" />
+          </Button>
           <Button onClick={handleDiscover} disabled={loading}>
             {loading ? 'Searching...' : 'Search'}
           </Button>
         </div>
 
         {error && (
-          <div className="text-sm text-destructive">
-            {error}
-          </div>
+          <div className="text-sm text-destructive">{error}</div>
         )}
 
         {discoveredProjects.length > 0 && (
@@ -111,7 +148,6 @@ export function ProjectDiscovery({ onProjectsDiscovered }: ProjectDiscoveryProps
                 Add All
               </Button>
             </div>
-
             <div className="space-y-2">
               {discoveredProjects.map((project) => (
                 <Card key={project.path}>
@@ -128,9 +164,7 @@ export function ProjectDiscovery({ onProjectsDiscovered }: ProjectDiscoveryProps
                             <Badge variant="outline">Discovered</Badge>
                           )}
                         </div>
-                        <p className="text-sm text-muted-foreground mt-1">
-                          {project.path}
-                        </p>
+                        <p className="text-sm text-muted-foreground mt-1">{project.path}</p>
                       </div>
                       <Button
                         size="sm"
@@ -147,6 +181,81 @@ export function ProjectDiscovery({ onProjectsDiscovered }: ProjectDiscoveryProps
           </div>
         )}
       </CardContent>
+
+      {/* Directory browser dialog */}
+      <Dialog open={browserOpen} onOpenChange={setBrowserOpen}>
+        <DialogContent className={MODAL_SIZES.SM}>
+          <DialogHeader>
+            <DialogTitle>Browse Directories</DialogTitle>
+          </DialogHeader>
+
+          <div className="space-y-3">
+            {/* Current path breadcrumb */}
+            {browseResult && (
+              <div className="flex items-center gap-1 text-sm text-muted-foreground bg-muted px-3 py-2 rounded-md min-w-0">
+                <FolderOpen className="h-4 w-4 shrink-0" />
+                <span className="truncate">{browseResult.path}</span>
+              </div>
+            )}
+
+            {/* Up / parent button */}
+            {browseResult?.parent && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="w-full justify-start gap-2 text-muted-foreground"
+                onClick={() => browseTo(browseResult.parent!)}
+              >
+                <ArrowLeft className="h-4 w-4" />
+                <span className="truncate">.. (up to {browseResult.parent})</span>
+              </Button>
+            )}
+
+            {browseError && (
+              <p className="text-sm text-destructive">{browseError}</p>
+            )}
+
+            {browseLoading && (
+              <p className="text-sm text-muted-foreground text-center py-4">Loading…</p>
+            )}
+
+            {/* Directory list */}
+            {!browseLoading && browseResult && (
+              browseResult.directories.length === 0 ? (
+                <p className="text-sm text-muted-foreground text-center py-4">
+                  No subdirectories
+                </p>
+              ) : (
+                <ScrollArea className="h-64 rounded-md border">
+                  <div className="p-1">
+                    {browseResult.directories.map((dir) => (
+                      <button
+                        key={dir}
+                        type="button"
+                        className="w-full flex items-center gap-2 px-3 py-2 rounded text-sm hover:bg-accent hover:text-accent-foreground transition-colors text-left"
+                        onClick={() => browseTo(`${browseResult.path}/${dir}`)}
+                      >
+                        <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
+                        <span className="truncate">{dir}</span>
+                        <ChevronRight className="h-4 w-4 shrink-0 ml-auto text-muted-foreground" />
+                      </button>
+                    ))}
+                  </div>
+                </ScrollArea>
+              )
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setBrowserOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleSelectDirectory} disabled={!browseResult}>
+              Use this directory
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </Card>
   );
 }

--- a/frontend/src/features/projects/ProjectDiscovery.tsx
+++ b/frontend/src/features/projects/ProjectDiscovery.tsx
@@ -79,7 +79,7 @@ export function ProjectDiscovery({ onProjectsDiscovered }: ProjectDiscoveryProps
     setBrowseError(null);
     try {
       const result = await apiClient<BrowseResult>(
-        `/projects/browse?path=${encodeURIComponent(path)}`
+        `projects/browse?path=${encodeURIComponent(path)}`
       );
       setBrowseResult(result);
     } catch (err) {


### PR DESCRIPTION
## Summary

Two UX improvements to the **Discover Projects** card:

### 1. Dark-mode input fix
The path input was a raw `<input>` with no theme-aware classes — in dark mode the browser rendered it with a white background and white text, making it unreadable. Replaced with the shadcn `<Input>` component which carries `bg-background text-foreground` automatically.

### 2. Directory browser
Added a **Browse** button (folder icon) next to the path input. Clicking it opens a step-through dialog:
- Shows the current directory path as a breadcrumb
- Lists all (non-hidden) subdirectories in a scrollable list
- Click any directory to navigate into it
- **↑ Up** button to go to the parent
- **"Use this directory"** button populates the search path and closes the dialog
- Opens at the current input value if set, otherwise `~`

Backed by a new `GET /api/v1/projects/browse?path=<dir>` endpoint that resolves `~`, returns sorted subdirs, and handles `PermissionError` (403) and non-directory paths (404) gracefully.

## Test plan
- [x] Backend: 112 tests pass; `import app.main` clean
- [x] Frontend: `tsc -b` clean; `npm run build` succeeds; no new lint findings in changed files
- [ ] Manual: open Projects → Discover, verify input is readable in dark mode; click Browse, navigate into subdirs, select a directory, confirm it populates the path field

Closes #163