### PR TITLE
feat: add instance identity markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,18 @@ To make the dev environment reachable from another machine on your LAN or tailne
 
 Both servers will then bind to all interfaces.
 
+### Naming a Claude Deck instance
+
+When running Claude Deck on several machines, set a display name and accent color so each browser window clearly identifies the backend it controls:
+
+```bash
+CLAUDE_DECK_INSTANCE_NAME="Studio Mac" \
+CLAUDE_DECK_INSTANCE_ACCENT="blue" \
+./scripts/dev.sh --host 0.0.0.0
+```
+
+Supported accents are `blue`, `green`, `purple`, `orange`, `red`, `pink`, `cyan`, and `slate`. The name appears in the header, browser tab title, Agent Bridge terminal panes, and destructive confirmations.
+
 To preview the documentation site:
 
 ```bash

--- a/backend/app/api/v1/status.py
+++ b/backend/app/api/v1/status.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import get_db
 from app.models.constants import SessionStatus
 from app.models.schemas import SystemStatusResponse
+from app.services.instance_identity import get_instance_identity
 from app.services.presence_service import PresenceService
 from app.services.providers import get_provider, get_providers
 
@@ -64,4 +65,5 @@ async def get_system_status(db: AsyncSession = Depends(get_db)):
         claude_code_version=version,
         active_sessions=active_count,
         providers=provider_statuses,
+        instance=get_instance_identity(),
     )

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1,5 +1,6 @@
 """Pydantic schemas for API models."""
-from typing import Any, Dict, List, Optional, Union
+from datetime import datetime
+from typing import Any, Dict, List, Literal, Optional, Union
 from pydantic import BaseModel, Field
 
 
@@ -1814,9 +1815,24 @@ class PresenceConfigSnippet(BaseModel):
     instructions: str
 
 
+InstanceAccent = Literal["blue", "green", "purple", "orange", "red", "pink", "cyan", "slate"]
+
+
+class InstanceIdentity(BaseModel):
+    """Runtime identity for the Claude Deck backend instance."""
+
+    id: str
+    name: str
+    hostname: str
+    short_hostname: str
+    accent: InstanceAccent
+    started_at: datetime
+
+
 class SystemStatusResponse(BaseModel):
     """System status for header indicators."""
 
     claude_code_version: Optional[str] = None
     active_sessions: int = 0
     providers: Dict[str, Any] = Field(default_factory=dict)
+    instance: Optional[InstanceIdentity] = None

--- a/backend/app/services/instance_identity.py
+++ b/backend/app/services/instance_identity.py
@@ -1,0 +1,102 @@
+"""Runtime identity metadata for this Claude Deck backend instance."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import socket
+from datetime import datetime, timezone
+from functools import lru_cache
+
+from app.models.schemas import InstanceIdentity
+
+LOGGER = logging.getLogger(__name__)
+
+ALLOWED_ACCENTS: tuple[str, ...] = (
+    "blue",
+    "green",
+    "purple",
+    "orange",
+    "red",
+    "pink",
+    "cyan",
+    "slate",
+)
+
+_STARTED_AT = datetime.now(timezone.utc)
+_MAX_NAME_LENGTH = 64
+_MAX_ID_LENGTH = 64
+
+
+def _remove_control_chars(value: str) -> str:
+    return "".join(ch for ch in value if ch.isprintable()).strip()
+
+
+def _get_hostname() -> str:
+    hostname = _remove_control_chars(socket.gethostname())
+    return hostname or "unknown-host"
+
+
+def _short_hostname(hostname: str) -> str:
+    short = hostname.split(".", 1)[0].strip()
+    return short or hostname or "unknown-host"
+
+
+def _clean_name(raw_name: str | None, fallback: str) -> str:
+    name = _remove_control_chars(raw_name or "")
+    if not name:
+        return fallback[:_MAX_NAME_LENGTH]
+    return name[:_MAX_NAME_LENGTH]
+
+
+def _clean_explicit_id(raw_id: str | None) -> str | None:
+    value = _remove_control_chars(raw_id or "")
+    if not value:
+        return None
+
+    safe = "".join(ch for ch in value if ch.isalnum() or ch in {"-", "_"})
+    return safe[:_MAX_ID_LENGTH] or None
+
+
+def _stable_id(hostname: str, explicit_id: str | None) -> str:
+    cleaned = _clean_explicit_id(explicit_id)
+    if cleaned:
+        return cleaned
+    return hashlib.sha256(f"claude-deck:{hostname}".encode("utf-8")).hexdigest()[:12]
+
+
+def _accent_from_hostname(hostname: str) -> str:
+    digest = hashlib.sha256(hostname.encode("utf-8")).digest()
+    return ALLOWED_ACCENTS[digest[0] % len(ALLOWED_ACCENTS)]
+
+
+def _resolve_accent(hostname: str, raw_accent: str | None) -> str:
+    accent = _remove_control_chars(raw_accent or "").lower()
+    if not accent:
+        return _accent_from_hostname(hostname)
+    if accent in ALLOWED_ACCENTS:
+        return accent
+
+    LOGGER.warning(
+        "Unsupported CLAUDE_DECK_INSTANCE_ACCENT=%r; using hostname-derived accent",
+        raw_accent,
+    )
+    return _accent_from_hostname(hostname)
+
+
+@lru_cache(maxsize=1)
+def get_instance_identity() -> InstanceIdentity:
+    """Return process-lifetime display identity for this backend instance."""
+
+    hostname = _get_hostname()
+    short_hostname = _short_hostname(hostname)
+
+    return InstanceIdentity(
+        id=_stable_id(hostname, os.getenv("CLAUDE_DECK_INSTANCE_ID")),
+        name=_clean_name(os.getenv("CLAUDE_DECK_INSTANCE_NAME"), short_hostname),
+        hostname=hostname,
+        short_hostname=short_hostname,
+        accent=_resolve_accent(hostname, os.getenv("CLAUDE_DECK_INSTANCE_ACCENT")),
+        started_at=_STARTED_AT,
+    )

--- a/backend/tests/test_instance_identity.py
+++ b/backend/tests/test_instance_identity.py
@@ -1,0 +1,86 @@
+import importlib
+
+
+def _service():
+    module = importlib.import_module("app.services.instance_identity")
+    module.get_instance_identity.cache_clear()
+    return module
+
+
+def test_instance_identity_uses_env_overrides(monkeypatch):
+    service = _service()
+    monkeypatch.setattr(service.socket, "gethostname", lambda: "studio-mac.local")
+    monkeypatch.setenv("CLAUDE_DECK_INSTANCE_NAME", "Studio Mac")
+    monkeypatch.setenv("CLAUDE_DECK_INSTANCE_ACCENT", "blue")
+    monkeypatch.setenv("CLAUDE_DECK_INSTANCE_ID", "studio-mac")
+
+    identity = service.get_instance_identity()
+
+    assert identity.name == "Studio Mac"
+    assert identity.accent == "blue"
+    assert identity.id == "studio-mac"
+    assert identity.hostname == "studio-mac.local"
+    assert identity.short_hostname == "studio-mac"
+
+
+def test_instance_identity_defaults_are_stable_and_non_sensitive(monkeypatch):
+    service = _service()
+    monkeypatch.setattr(service.socket, "gethostname", lambda: "linux-box.local")
+    monkeypatch.delenv("CLAUDE_DECK_INSTANCE_NAME", raising=False)
+    monkeypatch.delenv("CLAUDE_DECK_INSTANCE_ACCENT", raising=False)
+    monkeypatch.delenv("CLAUDE_DECK_INSTANCE_ID", raising=False)
+
+    identity = service.get_instance_identity()
+
+    assert identity.name == "linux-box"
+    assert identity.hostname == "linux-box.local"
+    assert identity.short_hostname == "linux-box"
+    assert identity.accent in service.ALLOWED_ACCENTS
+    assert identity.id
+    assert "linux-box" not in identity.id
+    assert identity.id == service.get_instance_identity().id
+
+
+def test_instance_identity_sanitizes_display_values(monkeypatch):
+    service = _service()
+    monkeypatch.setattr(service.socket, "gethostname", lambda: "host\nname.local")
+    monkeypatch.setenv("CLAUDE_DECK_INSTANCE_NAME", "Studio\nMac\tProd")
+    monkeypatch.setenv("CLAUDE_DECK_INSTANCE_ID", "studio mac\nprod!@#")
+
+    identity = service.get_instance_identity()
+
+    assert identity.hostname == "hostname.local"
+    assert identity.name == "StudioMacProd"
+    assert identity.id == "studiomacprod"
+    assert "\n" not in identity.name
+    assert "\t" not in identity.name
+
+
+def test_instance_identity_invalid_accent_falls_back(monkeypatch):
+    service = _service()
+    monkeypatch.setattr(service.socket, "gethostname", lambda: "garage-mini")
+    monkeypatch.setenv("CLAUDE_DECK_INSTANCE_ACCENT", "neon")
+
+    identity = service.get_instance_identity()
+
+    assert identity.accent == service._accent_from_hostname("garage-mini")
+
+
+def test_status_response_can_serialize_instance(monkeypatch):
+    service = _service()
+    monkeypatch.setattr(service.socket, "gethostname", lambda: "studio-mac.local")
+    monkeypatch.setenv("CLAUDE_DECK_INSTANCE_NAME", "Studio Mac")
+
+    from app.models.schemas import SystemStatusResponse
+
+    response = SystemStatusResponse(
+        claude_code_version=None,
+        active_sessions=2,
+        providers={},
+        instance=service.get_instance_identity(),
+    )
+
+    dumped = response.model_dump(mode="json")
+    assert dumped["instance"]["name"] == "Studio Mac"
+    assert dumped["instance"]["hostname"] == "studio-mac.local"
+    assert dumped["instance"]["started_at"]

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -45,6 +45,19 @@ With Codex selected, start with:
 - **Config** — edit safe TOML settings, inspect profiles, and manage feature flags
 - **Backup** — create a redacted Codex export
 
+## Identify the Backend Instance
+
+When you run Claude Deck on more than one machine, or expose it over a LAN or tailnet, set an instance name so each browser window clearly shows the backend it controls:
+
+```bash
+CLAUDE_DECK_INSTANCE_NAME="Studio Mac" \
+CLAUDE_DECK_INSTANCE_ACCENT="blue" \
+CLAUDE_DECK_INSTANCE_ID="studio-mac" \
+./scripts/dev.sh --host 0.0.0.0
+```
+
+The instance name appears in the header, browser tab title, Agent Bridge terminal panes, and kill-session confirmations. Supported accents are `blue`, `green`, `purple`, `orange`, `red`, `pink`, `cyan`, and `slate`.
+
 ## Key Pages
 
 | Page | What You Can Do |

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,25 +1,38 @@
-import { Terminal, Radio, AlertCircle } from "lucide-react";
+import { Terminal, Radio, AlertCircle, Server } from "lucide-react";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { Badge } from "@/components/ui/badge";
 import { useTheme } from "@/contexts/ThemeContext";
 import { useSystemStatus } from "@/hooks/useSystemStatus";
+import { useInstanceDocumentTitle } from "@/hooks/useInstanceDocumentTitle";
 import { useProviderContext } from "@/contexts/ProviderContext";
+import { getInstanceAccentClasses } from "@/lib/instanceAccent";
 import { cn } from "@/lib/utils";
 
 export function Header() {
   const { theme } = useTheme();
   const status = useSystemStatus();
+  const instance = status?.instance ?? null;
+  const accentClasses = getInstanceAccentClasses(instance?.accent);
   const { providers, selectedProviderId, selectedProvider } = useProviderContext();
   const providerStatuses = providers
     .map((provider) => status?.providers?.[provider.id] ?? provider)
     .filter((provider) => provider.installed || provider.id === selectedProviderId);
+  useInstanceDocumentTitle(instance);
+
+  const instanceTitle = instance
+    ? [
+        `Claude Deck instance: ${instance.name}`,
+        `Hostname: ${instance.hostname}`,
+        `Opened from: ${typeof window === "undefined" ? "unknown" : window.location.host}`,
+      ].join("\n")
+    : undefined;
 
   if (providerStatuses.length === 0 && selectedProvider) {
     providerStatuses.push(status?.providers?.[selectedProviderId] ?? selectedProvider);
   }
 
   return (
-    <header className="border-b bg-background">
+    <header className={cn("border-b bg-background", instance && "border-t-4", instance && accentClasses.headerBorder)}>
       <div className="flex h-16 items-center justify-between px-6">
         <div className="flex items-center gap-3">
           <img
@@ -35,6 +48,17 @@ export function Header() {
         <div className="flex items-center gap-2">
           {status && (
             <>
+              {instance && (
+                <Badge
+                  variant="outline"
+                  className={cn("gap-1 text-xs max-w-[12rem] truncate", accentClasses.badge)}
+                  title={instanceTitle}
+                >
+                  <Server className="h-3 w-3 shrink-0" />
+                  <span className={cn("h-2 w-2 rounded-full shrink-0", accentClasses.dot)} />
+                  <span className="truncate">{instance.name}</span>
+                </Badge>
+              )}
               {providerStatuses.map((provider) => (
                 <Badge
                   key={provider.id}

--- a/frontend/src/features/cc-bridge/CCBridgePage.tsx
+++ b/frontend/src/features/cc-bridge/CCBridgePage.tsx
@@ -8,6 +8,7 @@ import { NewSessionDialog } from './NewSessionDialog'
 import { KillSessionDialog } from './KillSessionDialog'
 import type { CCSession } from './types'
 import { useProviderContext } from '@/contexts/ProviderContext'
+import { useSystemStatus } from '@/hooks/useSystemStatus'
 import type { AgentProviderId, AgentProviderStatus } from '@/types/providers'
 
 const MAX_GRID_PANES = 4
@@ -28,6 +29,8 @@ function addTarget(prev: string[], target: string): string[] {
 export function CCBridgePage() {
   const [providerFilter, setProviderFilter] = useState<ProviderFilter>('all')
   const { providers, selectedProviderId } = useProviderContext()
+  const status = useSystemStatus()
+  const instance = status?.instance ?? null
   const { sessions, loading, error, refresh } = useCCSessions()
   const [activeTargets, setActiveTargets] = useState<string[]>([])
   const [fullscreenTarget, setFullscreenTarget] = useState<string | null>(null)
@@ -160,6 +163,7 @@ export function CCBridgePage() {
               providerFilter={providerFilter}
               canCreateSession={canCreateSession}
               createDisabledReason={canCreateSession ? null : createDisabledReason}
+              instance={instance}
             />
           </div>
         )}
@@ -202,6 +206,7 @@ export function CCBridgePage() {
                           setFullscreenTarget(isThisFullscreen ? null : target)
                         }
                         onClose={() => removeTarget(target)}
+                        instance={instance}
                       />
                     </div>
                   </div>
@@ -225,6 +230,7 @@ export function CCBridgePage() {
         session={killSession}
         isWorktreeSession={false}
         onKilled={handleKilled}
+        instance={instance}
       />
     </div>
   )

--- a/frontend/src/features/cc-bridge/KillSessionDialog.tsx
+++ b/frontend/src/features/cc-bridge/KillSessionDialog.tsx
@@ -13,6 +13,7 @@ import { Label } from '@/components/ui/label'
 import { MODAL_SIZES } from '@/lib/constants'
 import { killSession } from './api'
 import type { CCSession } from './types'
+import type { InstanceIdentity } from '@/types/status'
 
 interface KillSessionDialogProps {
   open: boolean
@@ -20,6 +21,7 @@ interface KillSessionDialogProps {
   session: CCSession | null
   isWorktreeSession: boolean
   onKilled: () => void
+  instance?: InstanceIdentity | null
 }
 
 export function KillSessionDialog({
@@ -28,6 +30,7 @@ export function KillSessionDialog({
   session,
   isWorktreeSession,
   onKilled,
+  instance,
 }: KillSessionDialogProps) {
   const [cleanupWorktree, setCleanupWorktree] = useState(false)
   const [submitting, setSubmitting] = useState(false)
@@ -65,10 +68,12 @@ export function KillSessionDialog({
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className={MODAL_SIZES.SM}>
         <DialogHeader>
-          <DialogTitle>Kill Session</DialogTitle>
+          <DialogTitle>
+            Kill {session?.session_name ?? 'session'}{instance ? ` on ${instance.name}` : ''}?
+          </DialogTitle>
           <DialogDescription>
-            Are you sure you want to kill session{' '}
-            <strong>{session?.session_name}</strong>? This will terminate the
+            This will terminate tmux target <strong>{session?.tmux_target}</strong>
+            {instance ? ` on hostname ${instance.hostname}` : ''} and stop the{' '}
             {session?.provider_display_name ?? 'agent'} process.
           </DialogDescription>
         </DialogHeader>

--- a/frontend/src/features/cc-bridge/SessionCard.tsx
+++ b/frontend/src/features/cc-bridge/SessionCard.tsx
@@ -4,15 +4,17 @@ import { Badge } from '@/components/ui/badge'
 import { CLICKABLE_CARD } from '@/lib/constants'
 import { cn } from '@/lib/utils'
 import type { CCSession } from './types'
+import type { InstanceIdentity } from '@/types/status'
 
 interface SessionCardProps {
   session: CCSession
   gridPosition: number | null
   onClick: () => void
   onKill: (session: CCSession) => void
+  instance?: InstanceIdentity | null
 }
 
-export function SessionCard({ session, gridPosition, onClick, onKill }: SessionCardProps) {
+export function SessionCard({ session, gridPosition, onClick, onKill, instance }: SessionCardProps) {
   const projectName = session.cwd.split('/').pop() || session.cwd
   const isActive = gridPosition !== null
 
@@ -59,8 +61,11 @@ export function SessionCard({ session, gridPosition, onClick, onKill }: SessionC
         <p className="text-xs text-muted-foreground truncate mt-1" title={session.cwd}>
           {projectName}
         </p>
-        <p className="text-xs text-muted-foreground mt-0.5">
-          {session.tmux_target}
+        <p
+          className="text-xs text-muted-foreground mt-0.5 truncate"
+          title={instance ? `${instance.name} · tmux: ${session.tmux_target}` : session.tmux_target}
+        >
+          {instance ? `${instance.name} · ` : ''}tmux: {session.tmux_target}
         </p>
       </CardContent>
     </Card>

--- a/frontend/src/features/cc-bridge/SessionList.tsx
+++ b/frontend/src/features/cc-bridge/SessionList.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils'
 import { SessionCard } from './SessionCard'
 import type { CCSession } from './types'
 import type { AgentProviderId } from '@/types/providers'
+import type { InstanceIdentity } from '@/types/status'
 
 type ProviderFilter = 'all' | AgentProviderId
 
@@ -19,6 +20,7 @@ interface SessionListProps {
   providerFilter: ProviderFilter
   canCreateSession: boolean
   createDisabledReason: string | null
+  instance?: InstanceIdentity | null
 }
 
 export function SessionList({
@@ -33,6 +35,7 @@ export function SessionList({
   providerFilter,
   canCreateSession,
   createDisabledReason,
+  instance,
 }: SessionListProps) {
   const emptyName = providerFilter === 'all'
     ? 'agent'
@@ -93,6 +96,7 @@ export function SessionList({
               gridPosition={pos === -1 ? null : pos}
               onClick={() => onToggleTarget(session.tmux_target)}
               onKill={onKillSession}
+              instance={instance}
             />
           )
         })}

--- a/frontend/src/features/cc-bridge/TerminalView.tsx
+++ b/frontend/src/features/cc-bridge/TerminalView.tsx
@@ -2,19 +2,24 @@ import { useRef, useEffect } from 'react'
 import { Monitor, Maximize2, Minimize2, X } from 'lucide-react'
 import { useTerminal } from './useTerminal'
 import { Button } from '@/components/ui/button'
+import { getInstanceAccentClasses } from '@/lib/instanceAccent'
 import { cn } from '@/lib/utils'
+import type { InstanceIdentity } from '@/types/status'
 
 interface TerminalViewProps {
   target: string | null
   fullscreen?: boolean
   onToggleFullscreen?: () => void
   onClose?: () => void
+  instance?: InstanceIdentity | null
 }
 
-export function TerminalView({ target, fullscreen, onToggleFullscreen, onClose }: TerminalViewProps) {
+export function TerminalView({ target, fullscreen, onToggleFullscreen, onClose, instance }: TerminalViewProps) {
   const wrapperRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const { connected, readOnly, setReadOnly, attach, detach } = useTerminal(containerRef, wrapperRef)
+  const accentClasses = getInstanceAccentClasses(instance?.accent)
+  const modeLabel = readOnly ? 'Read-only' : 'Interactive'
 
   useEffect(() => {
     if (target) {
@@ -43,8 +48,8 @@ export function TerminalView({ target, fullscreen, onToggleFullscreen, onClose }
       </div>
 
       {target && (
-        <div className="flex items-center justify-between px-3 py-2 border-t bg-background">
-          <div className="flex items-center gap-3">
+        <div className={cn("flex items-center justify-between gap-3 px-3 py-2 border-t bg-background", accentClasses.terminal)}>
+          <div className="flex items-center gap-3 min-w-0">
             <div className="flex items-center gap-2 text-sm">
               <button
                 className={cn(
@@ -70,13 +75,19 @@ export function TerminalView({ target, fullscreen, onToggleFullscreen, onClose }
               </button>
             </div>
             <span className={cn(
-              'text-xs',
+              'text-xs shrink-0',
               connected ? 'text-green-500' : 'text-muted-foreground'
             )}>
               {connected ? 'Connected' : 'Disconnected'}
             </span>
+            <span
+              className="text-xs text-muted-foreground truncate"
+              title={instance ? `${modeLabel} on ${instance.name} (${instance.hostname}) · ${target}` : target}
+            >
+              {instance ? `${modeLabel} on ${instance.name}` : target}
+            </span>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 shrink-0">
             {onToggleFullscreen && (
               <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onToggleFullscreen} title={fullscreen ? 'Exit fullscreen' : 'Fullscreen'}>
                 {fullscreen ? <Minimize2 className="h-3.5 w-3.5" /> : <Maximize2 className="h-3.5 w-3.5" />}

--- a/frontend/src/hooks/useInstanceDocumentTitle.ts
+++ b/frontend/src/hooks/useInstanceDocumentTitle.ts
@@ -1,0 +1,11 @@
+import { useEffect } from 'react'
+
+import type { InstanceIdentity } from '@/types/status'
+
+const BASE_TITLE = 'Claude Deck'
+
+export function useInstanceDocumentTitle(instance?: InstanceIdentity | null) {
+  useEffect(() => {
+    document.title = instance?.name ? `${instance.name} · ${BASE_TITLE}` : BASE_TITLE
+  }, [instance?.name])
+}

--- a/frontend/src/hooks/useSystemStatus.ts
+++ b/frontend/src/hooks/useSystemStatus.ts
@@ -1,11 +1,12 @@
 import { useState, useEffect, useCallback } from 'react'
 import { apiClient } from '@/lib/api'
-import type { SystemStatusResponse } from '@/types/status'
+import type { InstanceIdentity, SystemStatusResponse } from '@/types/status'
 
 interface SystemStatus {
   claudeCodeVersion: string | null
   activeSessions: number
   providers: SystemStatusResponse['providers']
+  instance: InstanceIdentity | null
 }
 
 function parseStatus(res: SystemStatusResponse): SystemStatus {
@@ -13,6 +14,7 @@ function parseStatus(res: SystemStatusResponse): SystemStatus {
     claudeCodeVersion: res.claude_code_version,
     activeSessions: res.active_sessions,
     providers: res.providers ?? {},
+    instance: res.instance ?? null,
   }
 }
 

--- a/frontend/src/lib/instanceAccent.ts
+++ b/frontend/src/lib/instanceAccent.ts
@@ -1,0 +1,69 @@
+import type { InstanceAccent } from '@/types/status'
+
+export interface InstanceAccentClasses {
+  headerBorder: string
+  badge: string
+  dot: string
+  terminal: string
+}
+
+export const DEFAULT_INSTANCE_ACCENT: InstanceAccent = 'blue'
+
+export const INSTANCE_ACCENT_CLASSES: Record<InstanceAccent, InstanceAccentClasses> = {
+  blue: {
+    headerBorder: 'border-t-blue-500',
+    badge: 'border-blue-500/40 bg-blue-500/10 text-blue-700 dark:text-blue-300',
+    dot: 'bg-blue-500',
+    terminal: 'border-blue-500/40',
+  },
+  green: {
+    headerBorder: 'border-t-green-500',
+    badge: 'border-green-500/40 bg-green-500/10 text-green-700 dark:text-green-300',
+    dot: 'bg-green-500',
+    terminal: 'border-green-500/40',
+  },
+  purple: {
+    headerBorder: 'border-t-purple-500',
+    badge: 'border-purple-500/40 bg-purple-500/10 text-purple-700 dark:text-purple-300',
+    dot: 'bg-purple-500',
+    terminal: 'border-purple-500/40',
+  },
+  orange: {
+    headerBorder: 'border-t-orange-500',
+    badge: 'border-orange-500/40 bg-orange-500/10 text-orange-700 dark:text-orange-300',
+    dot: 'bg-orange-500',
+    terminal: 'border-orange-500/40',
+  },
+  red: {
+    headerBorder: 'border-t-red-500',
+    badge: 'border-red-500/40 bg-red-500/10 text-red-700 dark:text-red-300',
+    dot: 'bg-red-500',
+    terminal: 'border-red-500/40',
+  },
+  pink: {
+    headerBorder: 'border-t-pink-500',
+    badge: 'border-pink-500/40 bg-pink-500/10 text-pink-700 dark:text-pink-300',
+    dot: 'bg-pink-500',
+    terminal: 'border-pink-500/40',
+  },
+  cyan: {
+    headerBorder: 'border-t-cyan-500',
+    badge: 'border-cyan-500/40 bg-cyan-500/10 text-cyan-700 dark:text-cyan-300',
+    dot: 'bg-cyan-500',
+    terminal: 'border-cyan-500/40',
+  },
+  slate: {
+    headerBorder: 'border-t-slate-500',
+    badge: 'border-slate-500/40 bg-slate-500/10 text-slate-700 dark:text-slate-300',
+    dot: 'bg-slate-500',
+    terminal: 'border-slate-500/40',
+  },
+}
+
+export function getInstanceAccentClasses(accent?: string | null): InstanceAccentClasses {
+  if (!accent || !(accent in INSTANCE_ACCENT_CLASSES)) {
+    return INSTANCE_ACCENT_CLASSES[DEFAULT_INSTANCE_ACCENT]
+  }
+
+  return INSTANCE_ACCENT_CLASSES[accent as InstanceAccent]
+}

--- a/frontend/src/types/status.ts
+++ b/frontend/src/types/status.ts
@@ -1,7 +1,27 @@
 import type { AgentProviderStatus } from './providers'
 
+export type InstanceAccent =
+  | 'blue'
+  | 'green'
+  | 'purple'
+  | 'orange'
+  | 'red'
+  | 'pink'
+  | 'cyan'
+  | 'slate'
+
+export interface InstanceIdentity {
+  id: string
+  name: string
+  hostname: string
+  short_hostname: string
+  accent: InstanceAccent
+  started_at: string
+}
+
 export interface SystemStatusResponse {
   claude_code_version: string | null
   active_sessions: number
   providers?: Record<string, AgentProviderStatus>
+  instance?: InstanceIdentity
 }


### PR DESCRIPTION
## Summary

- Adds backend `instance` metadata to `/api/v1/status` with env overrides, hostname fallbacks, accent validation, and sanitized display values.
- Shows the current instance in the header, browser tab title, Agent Bridge session labels, terminal footer, and kill confirmation.
- Documents instance naming for LAN/tailnet usage.

## Tracking

Resolves #182.

## Checks

- `backend/venv/bin/python -m pytest backend/tests/test_instance_identity.py backend/tests/test_providers.py backend/tests/test_multi_provider_smoke.py` fallback used `python3`; 15 passed.
- Backend app import: `app import ok`.
- Focused frontend ESLint on changed files: passed.
- `npm run build`: passed with existing Vite large chunk warning.
- `git diff --check`: passed.

## Note

Full `npm run lint` still reports pre-existing unrelated lint errors across older files; this PR's changed files pass focused ESLint.
