### PR TITLE
Add external Agent Mail orchestration API

### DIFF
--- a/backend/app/api/v1/external_agent_mail.py
+++ b/backend/app/api/v1/external_agent_mail.py
@@ -1,0 +1,229 @@
+"""External local Agent Mail orchestration endpoints."""
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.models.database import MailExternalActor
+from app.models.schemas import (
+    ExternalAgentMailContextRequest,
+    ExternalAgentMailHandoffRequest,
+    ExternalAgentMailMessageRequest,
+    ExternalAgentMailRequestStatus,
+    ExternalAgentMailSendResponse,
+    MailExternalActorCreate,
+    MailExternalActorCreateResponse,
+    MailExternalActorResponse,
+    MailThreadResponse,
+    TeamListResponse,
+)
+from app.services.external_agent_mail_service import (
+    ExternalAgentMailAuthError,
+    ExternalAgentMailRateLimitError,
+    external_agent_mail_service,
+)
+
+router = APIRouter()
+
+
+def _bearer_token(authorization: Optional[str]) -> Optional[str]:
+    if not authorization:
+        return None
+    prefix = "Bearer "
+    if not authorization.startswith(prefix):
+        return None
+    token = authorization[len(prefix) :].strip()
+    return token or None
+
+
+def _is_loopback_request(request: Request) -> bool:
+    host = request.client.host if request.client else ""
+    return host in {"127.0.0.1", "::1", "localhost", "test", "testclient"}
+
+
+async def external_actor(
+    authorization: Optional[str] = Header(default=None),
+    db: AsyncSession = Depends(get_db),
+) -> MailExternalActor:
+    try:
+        return await external_agent_mail_service.authenticate_actor(
+            db,
+            _bearer_token(authorization),
+        )
+    except ExternalAgentMailAuthError as exc:
+        raise HTTPException(status_code=401, detail=str(exc)) from exc
+
+
+def _rate_limit_response(exc: ExternalAgentMailRateLimitError) -> HTTPException:
+    return HTTPException(
+        status_code=429,
+        detail={
+            "code": "external_agent_mail_rate_limited",
+            "message": str(exc),
+            "retry_after_seconds": exc.retry_after_seconds,
+        },
+        headers={"Retry-After": str(exc.retry_after_seconds)},
+    )
+
+
+@router.post("/actors", response_model=MailExternalActorCreateResponse)
+async def create_external_actor(
+    request: Request,
+    actor_request: MailExternalActorCreate,
+    db: AsyncSession = Depends(get_db),
+):
+    """Create or rotate a local external actor token."""
+    if not _is_loopback_request(request):
+        raise HTTPException(status_code=403, detail="External actor tokens can only be created locally")
+    try:
+        return await external_agent_mail_service.create_actor(db, actor_request)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/actors/me", response_model=MailExternalActorResponse)
+async def get_external_actor_me(actor: MailExternalActor = Depends(external_actor)):
+    return external_agent_mail_service.actor_response(actor)
+
+
+@router.get("/members", response_model=TeamListResponse)
+async def list_external_agent_mail_members(
+    actor: MailExternalActor = Depends(external_actor),
+    db: AsyncSession = Depends(get_db),
+):
+    _ = actor
+    return await external_agent_mail_service.list_members(db)
+
+
+@router.post("/messages", response_model=ExternalAgentMailSendResponse)
+async def send_external_agent_mail_message(
+    request: ExternalAgentMailMessageRequest,
+    actor: MailExternalActor = Depends(external_actor),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        return await external_agent_mail_service.send_direct_message(db, actor, request)
+    except ExternalAgentMailRateLimitError as exc:
+        raise _rate_limit_response(exc) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("/broadcasts", response_model=ExternalAgentMailSendResponse)
+async def send_external_agent_mail_broadcast(
+    request: ExternalAgentMailMessageRequest,
+    actor: MailExternalActor = Depends(external_actor),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        return await external_agent_mail_service.send_broadcast(db, actor, request)
+    except ExternalAgentMailRateLimitError as exc:
+        raise _rate_limit_response(exc) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("/context-requests", response_model=ExternalAgentMailSendResponse)
+async def send_external_agent_mail_context_request(
+    request: ExternalAgentMailContextRequest,
+    actor: MailExternalActor = Depends(external_actor),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        return await external_agent_mail_service.send_context_request(db, actor, request)
+    except ExternalAgentMailRateLimitError as exc:
+        raise _rate_limit_response(exc) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("/handoffs", response_model=ExternalAgentMailSendResponse)
+async def send_external_agent_mail_handoff(
+    request: ExternalAgentMailHandoffRequest,
+    actor: MailExternalActor = Depends(external_actor),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        return await external_agent_mail_service.send_handoff(db, actor, request)
+    except ExternalAgentMailRateLimitError as exc:
+        raise _rate_limit_response(exc) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("/threads/{message_id}/replies", response_model=ExternalAgentMailSendResponse)
+async def reply_external_agent_mail_thread(
+    message_id: int,
+    request: ExternalAgentMailMessageRequest,
+    actor: MailExternalActor = Depends(external_actor),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        return await external_agent_mail_service.reply_in_thread(db, actor, message_id, request)
+    except ExternalAgentMailRateLimitError as exc:
+        raise _rate_limit_response(exc) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/threads/{message_id}", response_model=MailThreadResponse)
+async def get_external_agent_mail_thread(
+    message_id: int,
+    actor: MailExternalActor = Depends(external_actor),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        return await external_agent_mail_service.thread(db, actor, message_id)
+    except PermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.get("/requests/{message_id}/status", response_model=ExternalAgentMailRequestStatus)
+async def get_external_agent_mail_request_status(
+    message_id: int,
+    actor: MailExternalActor = Depends(external_actor),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        return await external_agent_mail_service.request_status(db, actor, message_id)
+    except PermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.get("/requests/{message_id}/wait", response_model=ExternalAgentMailRequestStatus)
+async def wait_external_agent_mail_request_status(
+    message_id: int,
+    timeout_seconds: int = 30,
+    actor: MailExternalActor = Depends(external_actor),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        return await external_agent_mail_service.wait_for_request_status(
+            db,
+            actor,
+            message_id,
+            timeout_seconds,
+        )
+    except PermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.post("/requests/{message_id}/ack", response_model=ExternalAgentMailRequestStatus)
+async def ack_external_agent_mail_request(
+    message_id: int,
+    response: Response,
+    actor: MailExternalActor = Depends(external_actor),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        response.status_code = 200
+        return await external_agent_mail_service.acknowledge_external_request(db, actor, message_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -20,6 +20,7 @@ from .plans import router as plans_router
 from .presence import router as presence_router
 from .agent_mail import router as agent_mail_router
 from .agent_teams import router as agent_teams_router
+from .external_agent_mail import router as external_agent_mail_router
 from .cc_bridge.router import router as cc_bridge_router
 from .agent_bridge.router import router as agent_bridge_router
 from .providers import router as providers_router
@@ -61,6 +62,7 @@ router.include_router(plans_router, tags=["Plans"])
 router.include_router(presence_router, prefix="/presence", tags=["Presence"])
 router.include_router(agent_mail_router, prefix="/agent-mail", tags=["Agent Mail"])
 router.include_router(agent_teams_router, prefix="/agent-teams", tags=["Agent Teams"])
+router.include_router(external_agent_mail_router, prefix="/external/agent-mail", tags=["External Agent Mail"])
 router.include_router(cc_bridge_router, prefix="/cc-bridge", tags=["CC Bridge"])
 router.include_router(agent_bridge_router, prefix="/agent-bridge", tags=["Agent Bridge"])
 router.include_router(providers_router, tags=["Providers"])

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -94,3 +94,9 @@ async def init_db() -> None:
                 await conn.execute(
                     text("ALTER TABLE agent_team_launch_items ADD COLUMN block_code VARCHAR")
                 )
+            result = await conn.execute(text("PRAGMA table_info(mail_messages)"))
+            message_columns = {row[1] for row in result.fetchall()}
+            if message_columns and "sender_actor_id" not in message_columns:
+                await conn.execute(
+                    text("ALTER TABLE mail_messages ADD COLUMN sender_actor_id INTEGER")
+                )

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -298,6 +298,21 @@ class MailAgentSession(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
 
 
+class MailExternalActor(Base):
+    """Durable identity for a local external Agent Mail orchestrator."""
+
+    __tablename__ = "mail_external_actors"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    actor_key: Mapped[str] = mapped_column(String, unique=True, index=True, nullable=False)
+    display_name: Mapped[str] = mapped_column(String, nullable=False)
+    kind: Mapped[str] = mapped_column(String, default="external_tool", nullable=False)
+    description: Mapped[str | None] = mapped_column(String, nullable=True)
+    token_hash: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+
 class MailMessage(Base):
     """Agent Mail message with request lifecycle state where applicable."""
 
@@ -310,6 +325,9 @@ class MailMessage(Base):
     kind: Mapped[str] = mapped_column(String, default="message", nullable=False, index=True)
     sender_member_id: Mapped[int | None] = mapped_column(
         Integer, ForeignKey("mail_team_members.id", ondelete="SET NULL"), nullable=True
+    )
+    sender_actor_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("mail_external_actors.id", ondelete="SET NULL"), nullable=True
     )
     recipient_member_id: Mapped[int | None] = mapped_column(
         Integer, ForeignKey("mail_team_members.id", ondelete="CASCADE"), index=True, nullable=True

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1909,6 +1909,9 @@ class MailMessageResponse(BaseModel):
     thread_root_id: Optional[int] = None
     kind: str
     sender_member_id: Optional[int] = None
+    sender_actor_id: Optional[int] = None
+    sender_type: str = "director"
+    sender_actor_kind: Optional[str] = None
     sender_name: str
     recipient_member_id: Optional[int] = None
     subject: Optional[str] = None
@@ -1931,6 +1934,81 @@ class MailInboxResponse(BaseModel):
     unread_count: int
     pending_count: int
     messages: List[MailMessageResponse] = Field(default_factory=list)
+
+
+class MailExternalActorCreate(BaseModel):
+    actor_key: str
+    display_name: str
+    kind: str = "external_tool"
+    description: Optional[str] = None
+
+
+class MailExternalActorResponse(BaseModel):
+    id: int
+    actor_key: str
+    display_name: str
+    kind: str
+    description: Optional[str] = None
+    created_at: datetime
+    last_used_at: Optional[datetime] = None
+
+
+class MailExternalActorCreateResponse(BaseModel):
+    actor: MailExternalActorResponse
+    token: str
+
+
+class ExternalAgentMailMessageRequest(BaseModel):
+    recipient_member_id: Optional[int] = None
+    subject: Optional[str] = None
+    body_markdown: str
+    payload: Optional[Dict[str, Any]] = None
+
+
+class ExternalAgentMailContextRequest(BaseModel):
+    recipient_member_id: int
+    subject: Optional[str] = None
+    body_markdown: str
+    why_needed: Optional[str] = None
+    files_or_symbols: List[str] = Field(default_factory=list)
+
+
+class ExternalAgentMailHandoffRequest(BaseModel):
+    recipient_member_id: int
+    subject: Optional[str] = None
+    body_markdown: str
+    files: List[str] = Field(default_factory=list)
+    next_steps: List[str] = Field(default_factory=list)
+
+
+class ExternalAgentMailDeliveryRecipient(BaseModel):
+    member_id: int
+    member_name: str
+    receipt_created: bool = True
+    status: str
+    wake_state: str
+    wake_attempted: bool = False
+    wake_succeeded: bool = False
+    wake_method: Optional[str] = None
+    wake_error: Optional[str] = None
+
+
+class ExternalAgentMailSendResponse(BaseModel):
+    actor: MailExternalActorResponse
+    message: MailMessageResponse
+    delivery_state: str
+    recipients: List[ExternalAgentMailDeliveryRecipient] = Field(default_factory=list)
+
+
+class ExternalAgentMailRequestStatus(BaseModel):
+    message_id: int
+    kind: str
+    request_status: Optional[str] = None
+    is_stale: bool = False
+    answered: bool = False
+    acknowledged: bool = False
+    root: MailMessageResponse
+    replies: List[MailMessageResponse] = Field(default_factory=list)
 
 
 class MailAgentRegisterRequest(BaseModel):

--- a/backend/app/services/agent_mail_service.py
+++ b/backend/app/services/agent_mail_service.py
@@ -13,6 +13,7 @@ from app.models.database import (
     AgentTeamPreset,
     AgentTeamSlot,
     MailAgentSession,
+    MailExternalActor,
     MailMessage,
     MailReceipt,
     MailTeamMember,
@@ -430,10 +431,17 @@ class AgentMailService:
         return responses
 
     async def send_message(
-        self, db: AsyncSession, request: MailMessageCreate
+        self,
+        db: AsyncSession,
+        request: MailMessageCreate,
+        *,
+        auto_nudge: bool = True,
+        sender_actor_id: Optional[int] = None,
     ) -> MailMessageResponse:
         if request.kind not in MAIL_MESSAGE_KINDS:
             raise ValueError(f"Invalid message kind: {request.kind}")
+        if request.sender_member_id is not None and sender_actor_id is not None:
+            raise ValueError("messages cannot have both sender_member_id and sender_actor_id")
         if request.kind == "answer" and request.thread_root_id is None:
             raise ValueError("answer messages require thread_root_id")
         if request.kind == "answer":
@@ -451,6 +459,7 @@ class AgentMailService:
             thread_root_id=request.thread_root_id,
             kind=request.kind,
             sender_member_id=request.sender_member_id,
+            sender_actor_id=sender_actor_id,
             recipient_member_id=request.recipient_member_id,
             subject=request.subject,
             body_markdown=request.body_markdown,
@@ -483,14 +492,25 @@ class AgentMailService:
 
         await db.commit()
         await db.refresh(message)
-        await self.auto_nudge_members(db, recipients)
+        if auto_nudge:
+            await self.auto_nudge_members(db, recipients)
         return await self._message_response(db, message, for_member_id=None)
 
-    async def _sender_name(self, db: AsyncSession, sender_member_id: Optional[int]) -> str:
+    async def _sender_identity(
+        self,
+        db: AsyncSession,
+        sender_member_id: Optional[int],
+        sender_actor_id: Optional[int],
+    ) -> tuple[str, str, str | None]:
+        if sender_actor_id is not None:
+            actor = await db.get(MailExternalActor, sender_actor_id)
+            if actor is not None:
+                return actor.display_name, "external_actor", actor.kind
+            return "unknown external actor", "external_actor", None
         if sender_member_id is None:
-            return "Director"
+            return "Director", "director", None
         member = await db.get(MailTeamMember, sender_member_id)
-        return member.display_name if member else "unknown"
+        return (member.display_name if member else "unknown", "member", None)
 
     async def _message_response(
         self, db: AsyncSession, message: MailMessage, for_member_id: Optional[int]
@@ -511,12 +531,20 @@ class AgentMailService:
             and message.request_status == "pending"
             and message.created_at < datetime.utcnow() - timedelta(minutes=STALE_REQUEST_MINUTES)
         )
+        sender_name, sender_type, sender_actor_kind = await self._sender_identity(
+            db,
+            message.sender_member_id,
+            message.sender_actor_id,
+        )
         return MailMessageResponse(
             id=message.id,
             thread_root_id=message.thread_root_id,
             kind=message.kind,
             sender_member_id=message.sender_member_id,
-            sender_name=await self._sender_name(db, message.sender_member_id),
+            sender_actor_id=message.sender_actor_id,
+            sender_type=sender_type,
+            sender_actor_kind=sender_actor_kind,
+            sender_name=sender_name,
             recipient_member_id=message.recipient_member_id,
             subject=message.subject,
             body_markdown=message.body_markdown,
@@ -706,6 +734,45 @@ class AgentMailService:
             self._last_auto_nudge_at[member_id] = now
             nudged.append({"member_id": member_id, **result})
         return nudged
+
+    async def recipient_ids_for_message(self, db: AsyncSession, message_id: int) -> set[int]:
+        rows = (
+            await db.execute(select(MailReceipt.member_id).where(MailReceipt.message_id == message_id))
+        ).scalars().all()
+        return set(rows)
+
+    async def wake_members_with_results(
+        self,
+        db: AsyncSession,
+        member_ids: set[int],
+    ) -> dict[int, dict[str, str | bool]]:
+        if not member_ids:
+            return {}
+        await self.sync_observed_sessions(db)
+        now = datetime.utcnow()
+        results: dict[int, dict[str, str | bool]] = {}
+        for member_id in sorted(member_ids):
+            try:
+                result = await self._wake_member(db, member_id, now)
+            except ValueError as exc:
+                results[member_id] = {
+                    "wake_attempted": True,
+                    "wake_succeeded": False,
+                    "wake_error": str(exc),
+                }
+                continue
+            if result is None:
+                results[member_id] = {
+                    "wake_attempted": False,
+                    "wake_succeeded": False,
+                }
+                continue
+            results[member_id] = {
+                "wake_attempted": True,
+                "wake_succeeded": True,
+                "wake_method": str(result.get("method") or ""),
+            }
+        return results
 
     async def queue_inbox_check(self, db: AsyncSession, member_id: int) -> dict[str, str]:
         await self.sync_observed_sessions(db)

--- a/backend/app/services/external_agent_mail_service.py
+++ b/backend/app/services/external_agent_mail_service.py
@@ -1,0 +1,419 @@
+"""External local orchestration surface for Agent Mail."""
+import asyncio
+import hashlib
+import hmac
+import re
+import secrets
+from collections import deque
+from datetime import datetime, timedelta
+from typing import Deque
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.database import MailExternalActor, MailMessage, MailTeamMember
+from app.models.schemas import (
+    ExternalAgentMailContextRequest,
+    ExternalAgentMailDeliveryRecipient,
+    ExternalAgentMailHandoffRequest,
+    ExternalAgentMailMessageRequest,
+    ExternalAgentMailRequestStatus,
+    ExternalAgentMailSendResponse,
+    MailExternalActorCreate,
+    MailExternalActorCreateResponse,
+    MailExternalActorResponse,
+    MailMessageCreate,
+    MailThreadResponse,
+    TeamListResponse,
+)
+from app.services.agent_mail_service import agent_mail_service
+
+ACTOR_KEY_PATTERN = re.compile(r"^[A-Za-z0-9_.:-]{2,80}$")
+EXTERNAL_RATE_LIMIT_MAX_MESSAGES = 30
+EXTERNAL_RATE_LIMIT_WINDOW_SECONDS = 60
+EXTERNAL_WAIT_MAX_SECONDS = 30
+EXTERNAL_WAIT_POLL_SECONDS = 0.5
+_REQUEST_RECIPIENT = object()
+
+
+class ExternalAgentMailAuthError(ValueError):
+    """Raised when a bearer token cannot be mapped to an external actor."""
+
+
+class ExternalAgentMailRateLimitError(ValueError):
+    """Raised when an external actor exceeds the local message rate limit."""
+
+    def __init__(self, retry_after_seconds: int) -> None:
+        super().__init__("External Agent Mail rate limit exceeded")
+        self.retry_after_seconds = retry_after_seconds
+
+
+class ExternalAgentMailService:
+    """Token-bound external actor helpers for Agent Mail orchestration."""
+
+    def __init__(self) -> None:
+        self._send_windows: dict[int, Deque[datetime]] = {}
+
+    def _hash_token(self, token: str) -> str:
+        return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+    def actor_response(self, actor: MailExternalActor) -> MailExternalActorResponse:
+        return MailExternalActorResponse(
+            id=actor.id,
+            actor_key=actor.actor_key,
+            display_name=actor.display_name,
+            kind=actor.kind,
+            description=actor.description,
+            created_at=actor.created_at,
+            last_used_at=actor.last_used_at,
+        )
+
+    async def create_actor(
+        self,
+        db: AsyncSession,
+        request: MailExternalActorCreate,
+    ) -> MailExternalActorCreateResponse:
+        actor_key = request.actor_key.strip()
+        display_name = request.display_name.strip()
+        kind = request.kind.strip() or "external_tool"
+        description = request.description.strip() if request.description else None
+        if not ACTOR_KEY_PATTERN.match(actor_key):
+            raise ValueError("actor_key must be 2-80 chars using letters, numbers, _, ., :, or -")
+        if not display_name:
+            raise ValueError("display_name is required")
+        if len(kind) > 80:
+            raise ValueError("kind must be 80 chars or less")
+
+        token = secrets.token_urlsafe(32)
+        result = await db.execute(
+            select(MailExternalActor).where(MailExternalActor.actor_key == actor_key)
+        )
+        actor = result.scalar_one_or_none()
+        if actor is None:
+            actor = MailExternalActor(
+                actor_key=actor_key,
+                display_name=display_name,
+                kind=kind,
+                description=description,
+                token_hash=self._hash_token(token),
+            )
+            db.add(actor)
+        else:
+            actor.display_name = display_name
+            actor.kind = kind
+            actor.description = description
+            actor.token_hash = self._hash_token(token)
+        await db.commit()
+        await db.refresh(actor)
+        return MailExternalActorCreateResponse(actor=self.actor_response(actor), token=token)
+
+    async def authenticate_actor(self, db: AsyncSession, token: str | None) -> MailExternalActor:
+        if not token:
+            raise ExternalAgentMailAuthError("Missing bearer token")
+        hashed = self._hash_token(token)
+        result = await db.execute(select(MailExternalActor))
+        for actor in result.scalars().all():
+            if hmac.compare_digest(actor.token_hash, hashed):
+                actor.last_used_at = datetime.utcnow()
+                await db.commit()
+                await db.refresh(actor)
+                return actor
+        raise ExternalAgentMailAuthError("Invalid bearer token")
+
+    def check_send_rate_limit(self, actor_id: int) -> None:
+        now = datetime.utcnow()
+        cutoff = now - timedelta(seconds=EXTERNAL_RATE_LIMIT_WINDOW_SECONDS)
+        window = self._send_windows.setdefault(actor_id, deque())
+        while window and window[0] < cutoff:
+            window.popleft()
+        if len(window) >= EXTERNAL_RATE_LIMIT_MAX_MESSAGES:
+            retry_after = max(
+                1,
+                int((window[0] + timedelta(seconds=EXTERNAL_RATE_LIMIT_WINDOW_SECONDS) - now).total_seconds()),
+            )
+            raise ExternalAgentMailRateLimitError(retry_after)
+        window.append(now)
+
+    async def list_members(self, db: AsyncSession) -> TeamListResponse:
+        await agent_mail_service.sync_observed_sessions(db)
+        return TeamListResponse(members=await agent_mail_service.list_team(db))
+
+    async def send_message(
+        self,
+        db: AsyncSession,
+        actor: MailExternalActor,
+        request: ExternalAgentMailMessageRequest,
+        *,
+        kind: str = "message",
+        recipient_member_id: int | None | object = _REQUEST_RECIPIENT,
+        thread_root_id: int | None = None,
+        subject: str | None = None,
+        body_markdown: str | None = None,
+        payload: dict | None = None,
+    ) -> ExternalAgentMailSendResponse:
+        self.check_send_rate_limit(actor.id)
+        resolved_recipient_id = (
+            request.recipient_member_id
+            if recipient_member_id is _REQUEST_RECIPIENT
+            else recipient_member_id
+        )
+        if resolved_recipient_id is not None:
+            await self._require_member(db, int(resolved_recipient_id))
+        message_request = MailMessageCreate(
+            kind=kind,
+            recipient_member_id=resolved_recipient_id,
+            thread_root_id=thread_root_id,
+            subject=subject if subject is not None else request.subject,
+            body_markdown=body_markdown if body_markdown is not None else request.body_markdown,
+            payload=payload if payload is not None else request.payload,
+        )
+        message = await agent_mail_service.send_message(
+            db,
+            message_request,
+            auto_nudge=False,
+            sender_actor_id=actor.id,
+        )
+        recipient_ids = await agent_mail_service.recipient_ids_for_message(db, message.id)
+        wake_results = await agent_mail_service.wake_members_with_results(db, recipient_ids)
+        recipients = await self._delivery_recipients(db, recipient_ids, wake_results)
+        return ExternalAgentMailSendResponse(
+            actor=self.actor_response(actor),
+            message=message,
+            delivery_state=self._delivery_state(recipients),
+            recipients=recipients,
+        )
+
+    async def send_direct_message(
+        self,
+        db: AsyncSession,
+        actor: MailExternalActor,
+        request: ExternalAgentMailMessageRequest,
+    ) -> ExternalAgentMailSendResponse:
+        if request.recipient_member_id is None:
+            raise ValueError("recipient_member_id is required")
+        return await self.send_message(db, actor, request, kind="message")
+
+    async def send_broadcast(
+        self,
+        db: AsyncSession,
+        actor: MailExternalActor,
+        request: ExternalAgentMailMessageRequest,
+    ) -> ExternalAgentMailSendResponse:
+        return await self.send_message(db, actor, request, kind="broadcast", recipient_member_id=None)
+
+    async def send_context_request(
+        self,
+        db: AsyncSession,
+        actor: MailExternalActor,
+        request: ExternalAgentMailContextRequest,
+    ) -> ExternalAgentMailSendResponse:
+        payload = {
+            "why_needed": request.why_needed,
+            "files_or_symbols": request.files_or_symbols,
+        }
+        return await self.send_message(
+            db,
+            actor,
+            ExternalAgentMailMessageRequest(
+                recipient_member_id=request.recipient_member_id,
+                subject=request.subject,
+                body_markdown=request.body_markdown,
+            ),
+            kind="context_request",
+            payload=payload,
+        )
+
+    async def send_handoff(
+        self,
+        db: AsyncSession,
+        actor: MailExternalActor,
+        request: ExternalAgentMailHandoffRequest,
+    ) -> ExternalAgentMailSendResponse:
+        payload = {
+            "files": request.files,
+            "next_steps": request.next_steps,
+        }
+        return await self.send_message(
+            db,
+            actor,
+            ExternalAgentMailMessageRequest(
+                recipient_member_id=request.recipient_member_id,
+                subject=request.subject,
+                body_markdown=request.body_markdown,
+            ),
+            kind="handoff",
+            payload=payload,
+        )
+
+    async def reply_in_thread(
+        self,
+        db: AsyncSession,
+        actor: MailExternalActor,
+        root_id: int,
+        request: ExternalAgentMailMessageRequest,
+    ) -> ExternalAgentMailSendResponse:
+        root = await db.get(MailMessage, root_id)
+        if root is None:
+            raise ValueError("Thread root not found")
+        if root.sender_actor_id != actor.id:
+            raise ValueError("External actors can only reply in threads they created")
+        return await self.send_message(
+            db,
+            actor,
+            request,
+            kind="message",
+            recipient_member_id=root.recipient_member_id,
+            thread_root_id=root_id,
+            subject=request.subject,
+            body_markdown=request.body_markdown,
+            payload=request.payload,
+        )
+
+    async def thread(
+        self,
+        db: AsyncSession,
+        actor: MailExternalActor,
+        message_id: int,
+    ) -> MailThreadResponse:
+        thread = await agent_mail_service.get_thread(db, message_id)
+        self._require_actor_owns_thread(thread, actor)
+        return thread
+
+    async def request_status(
+        self,
+        db: AsyncSession,
+        actor: MailExternalActor,
+        message_id: int,
+    ) -> ExternalAgentMailRequestStatus:
+        thread = await self.thread(db, actor, message_id)
+        root = thread.root
+        if root.kind not in {"context_request", "handoff"}:
+            raise ValueError("Message is not a request")
+        answered = root.request_status in {"answered", "acknowledged"} or any(
+            reply.kind == "answer" for reply in thread.replies
+        )
+        acknowledged = root.request_status == "acknowledged"
+        return ExternalAgentMailRequestStatus(
+            message_id=root.id,
+            kind=root.kind,
+            request_status=root.request_status,
+            is_stale=root.is_stale,
+            answered=answered,
+            acknowledged=acknowledged,
+            root=root,
+            replies=thread.replies,
+        )
+
+    async def wait_for_request_status(
+        self,
+        db: AsyncSession,
+        actor: MailExternalActor,
+        message_id: int,
+        timeout_seconds: int,
+    ) -> ExternalAgentMailRequestStatus:
+        timeout = max(0, min(timeout_seconds, EXTERNAL_WAIT_MAX_SECONDS))
+        deadline = datetime.utcnow() + timedelta(seconds=timeout)
+        status = await self.request_status(db, actor, message_id)
+        while (
+            status.request_status == "pending"
+            and not status.answered
+            and not status.is_stale
+            and datetime.utcnow() < deadline
+        ):
+            # Do not pin a DB transaction/connection while long-polling.
+            await db.rollback()
+            db.expire_all()
+            await asyncio.sleep(EXTERNAL_WAIT_POLL_SECONDS)
+            status = await self.request_status(db, actor, message_id)
+        return status
+
+    async def acknowledge_external_request(
+        self,
+        db: AsyncSession,
+        actor: MailExternalActor,
+        message_id: int,
+    ) -> ExternalAgentMailRequestStatus:
+        root = await db.get(MailMessage, message_id)
+        if root is None:
+            raise ValueError("Message not found")
+        if root.sender_actor_id != actor.id:
+            raise ValueError("External actors can only acknowledge requests they created")
+        if root.kind not in {"context_request", "handoff"}:
+            raise ValueError("Message is not a request")
+        if root.request_status == "answered":
+            root.request_status = "acknowledged"
+            await db.commit()
+        return await self.request_status(db, actor, message_id)
+
+    async def _delivery_recipients(
+        self,
+        db: AsyncSession,
+        recipient_ids: set[int],
+        wake_results: dict[int, dict[str, str | bool]],
+    ) -> list[ExternalAgentMailDeliveryRecipient]:
+        members = {member.id: member for member in (await agent_mail_service.list_team(db))}
+        recipients: list[ExternalAgentMailDeliveryRecipient] = []
+        for member_id in sorted(recipient_ids):
+            member = members.get(member_id)
+            if member is None:
+                db_member = await db.get(MailTeamMember, member_id)
+                member_name = db_member.display_name if db_member is not None else f"Member {member_id}"
+                wake_state = "offline"
+            else:
+                member_name = member.display_name
+                wake_state = member.wake_state
+            wake = wake_results.get(member_id, {})
+            wake_attempted = bool(wake.get("wake_attempted", False))
+            wake_succeeded = bool(wake.get("wake_succeeded", False))
+            if wake_succeeded:
+                status = "wake_succeeded"
+            elif wake_attempted:
+                status = "wake_failed"
+            elif wake_state == "offline":
+                status = "stored_offline"
+            elif wake_state == "delivered_waiting":
+                status = "delivered_waiting"
+            else:
+                status = "stored"
+            recipients.append(
+                ExternalAgentMailDeliveryRecipient(
+                    member_id=member_id,
+                    member_name=member_name,
+                    status=status,
+                    wake_state=wake_state,
+                    wake_attempted=wake_attempted,
+                    wake_succeeded=wake_succeeded,
+                    wake_method=str(wake["wake_method"]) if "wake_method" in wake else None,
+                    wake_error=str(wake["wake_error"]) if "wake_error" in wake else None,
+                )
+            )
+        return recipients
+
+    async def _require_member(self, db: AsyncSession, member_id: int) -> None:
+        if await db.get(MailTeamMember, member_id) is None:
+            raise ValueError(f"Recipient member {member_id} not found")
+
+    def _require_actor_owns_thread(
+        self,
+        thread: MailThreadResponse,
+        actor: MailExternalActor,
+    ) -> None:
+        if thread.root.sender_actor_id != actor.id:
+            raise PermissionError("External actors can only read threads they created")
+
+    def _delivery_state(self, recipients: list[ExternalAgentMailDeliveryRecipient]) -> str:
+        if not recipients:
+            return "stored_no_recipients"
+        statuses = {recipient.status for recipient in recipients}
+        if "wake_succeeded" in statuses:
+            return "wake_succeeded"
+        if "wake_failed" in statuses:
+            return "wake_failed"
+        if "delivered_waiting" in statuses:
+            return "delivered_waiting"
+        if "stored_offline" in statuses:
+            return "stored_offline"
+        return "stored"
+
+
+external_agent_mail_service = ExternalAgentMailService()

--- a/backend/tests/agent_mail/test_external_api.py
+++ b/backend/tests/agent_mail/test_external_api.py
@@ -1,0 +1,371 @@
+"""External Agent Mail orchestration API behavior."""
+from types import SimpleNamespace
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from app.database import get_db
+from app.main import app
+from app.models.database import MailAgentSession, MailTeamMember
+from app.services.external_agent_mail_service import external_agent_mail_service
+
+
+@pytest_asyncio.fixture
+async def client(db):
+    async def _override():
+        yield db
+
+    app.dependency_overrides[get_db] = _override
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(autouse=True)
+def clean_external_rate_limits(monkeypatch):
+    external_agent_mail_service._send_windows.clear()
+    monkeypatch.setattr("app.services.agent_mail_service.discover_agent_sessions", lambda: [])
+
+
+async def _member(db, repo_id, name):
+    member = MailTeamMember(
+        repo_id=repo_id,
+        repo_path=f"/tmp/{name}",
+        repo_name=name,
+        display_name=name,
+    )
+    db.add(member)
+    await db.commit()
+    await db.refresh(member)
+    return member
+
+
+async def _actor_token(client, key="openclaw", name="OpenClaw"):
+    resp = await client.post(
+        "/api/v1/external/agent-mail/actors",
+        json={
+            "actor_key": key,
+            "display_name": name,
+            "kind": "external_tool",
+            "description": "local orchestrator",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    return body["token"], body["actor"]
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_external_actor_registration_and_auth(client, db):
+    await _member(db, "repo-alpha", "alpha")
+    token, actor = await _actor_token(client)
+
+    assert actor["display_name"] == "OpenClaw"
+
+    unauthenticated = await client.get("/api/v1/external/agent-mail/members")
+    assert unauthenticated.status_code == 401
+
+    resp = await client.get("/api/v1/external/agent-mail/members", headers=_auth(token))
+    assert resp.status_code == 200
+    members = resp.json()["members"]
+    assert members[0]["display_name"] == "alpha"
+    assert "wake_state" in members[0]
+
+    me = await client.get("/api/v1/external/agent-mail/actors/me", headers=_auth(token))
+    assert me.status_code == 200
+    assert me.json()["actor_key"] == "openclaw"
+
+
+@pytest.mark.asyncio
+async def test_external_context_request_preserves_sender_attribution(client, db):
+    recipient = await _member(db, "repo-beta", "beta")
+    token, _ = await _actor_token(client)
+
+    resp = await client.post(
+        "/api/v1/external/agent-mail/context-requests",
+        headers=_auth(token),
+        json={
+            "recipient_member_id": recipient.id,
+            "subject": "Need repo context",
+            "body_markdown": "Please inspect the API owner.",
+            "why_needed": "OpenClaw validation",
+            "files_or_symbols": ["backend/app/api/v1/agent_mail.py"],
+        },
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["actor"]["display_name"] == "OpenClaw"
+    assert body["message"]["sender_name"] == "OpenClaw"
+    assert body["message"]["sender_type"] == "external_actor"
+    assert body["message"]["sender_member_id"] is None
+    assert body["message"]["sender_actor_id"] == body["actor"]["id"]
+    assert body["recipients"][0]["member_id"] == recipient.id
+
+    messages = await client.get("/api/v1/agent-mail/messages")
+    assert messages.status_code == 200
+    assert messages.json()[0]["sender_name"] == "OpenClaw"
+    assert messages.json()[0]["sender_type"] == "external_actor"
+
+
+@pytest.mark.asyncio
+async def test_legacy_message_create_cannot_spoof_external_actor(client, db):
+    recipient = await _member(db, "repo-beta", "beta")
+    _, actor = await _actor_token(client)
+
+    resp = await client.post(
+        "/api/v1/agent-mail/messages",
+        json={
+            "sender_actor_id": actor["id"],
+            "recipient_member_id": recipient.id,
+            "body_markdown": "Pretend to be OpenClaw.",
+        },
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["sender_actor_id"] is None
+    assert body["sender_type"] == "director"
+    assert body["sender_name"] == "Director"
+
+
+@pytest.mark.asyncio
+async def test_external_actor_cannot_read_other_actor_threads(client, db):
+    recipient = await _member(db, "repo-beta", "beta")
+    token, _ = await _actor_token(client, key="openclaw", name="OpenClaw")
+    other_token, _ = await _actor_token(client, key="runner", name="Runner")
+    created = await client.post(
+        "/api/v1/external/agent-mail/context-requests",
+        headers=_auth(token),
+        json={
+            "recipient_member_id": recipient.id,
+            "subject": "Private request",
+            "body_markdown": "Only OpenClaw should read this.",
+        },
+    )
+    message_id = created.json()["message"]["id"]
+
+    thread = await client.get(
+        f"/api/v1/external/agent-mail/threads/{message_id}",
+        headers=_auth(other_token),
+    )
+    status = await client.get(
+        f"/api/v1/external/agent-mail/requests/{message_id}/status",
+        headers=_auth(other_token),
+    )
+    wait = await client.get(
+        f"/api/v1/external/agent-mail/requests/{message_id}/wait?timeout_seconds=0",
+        headers=_auth(other_token),
+    )
+
+    assert thread.status_code == 403
+    assert status.status_code == 403
+    assert wait.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_external_delivery_reports_non_tmux_codex_as_delivered_waiting(client, db):
+    recipient = await _member(db, "repo-beta", "beta")
+    db.add(
+        MailAgentSession(
+            member_id=recipient.id,
+            provider="codex-cli",
+            source="mcp",
+            session_key="mcp:beta",
+            cwd=recipient.repo_path,
+            mailbox_status="connected",
+        )
+    )
+    await db.commit()
+    token, _ = await _actor_token(client)
+
+    resp = await client.post(
+        "/api/v1/external/agent-mail/context-requests",
+        headers=_auth(token),
+        json={
+            "recipient_member_id": recipient.id,
+            "subject": "Need repo context",
+            "body_markdown": "Please inspect this.",
+        },
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["delivery_state"] == "delivered_waiting"
+    assert body["recipients"][0]["status"] == "delivered_waiting"
+    assert body["recipients"][0]["wake_state"] == "delivered_waiting"
+    assert body["recipients"][0]["wake_attempted"] is False
+    assert body["recipients"][0]["wake_succeeded"] is False
+
+
+@pytest.mark.asyncio
+async def test_external_delivery_reports_tmux_wake_success(client, db, tmp_path, monkeypatch):
+    cwd = tmp_path / "repo-beta"
+    cwd.mkdir()
+    fake = [
+        {
+            "provider": "codex-cli",
+            "provider_display_name": "Codex",
+            "tmux_target": "deck:0.1",
+            "session_name": "deck",
+            "window_name": "main",
+            "pane_id": "%7",
+            "cwd": str(cwd),
+            "pid": "4242",
+            "status": "active",
+        }
+    ]
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr("app.services.agent_mail_service.discover_agent_sessions", lambda: fake)
+    monkeypatch.setattr("app.services.agent_mail_service.subprocess.run", fake_run)
+    monkeypatch.setattr("app.services.agent_mail_service.time.sleep", lambda delay: None)
+
+    token, _ = await _actor_token(client)
+    members = await client.get("/api/v1/external/agent-mail/members", headers=_auth(token))
+    recipient_id = members.json()["members"][0]["id"]
+
+    resp = await client.post(
+        "/api/v1/external/agent-mail/messages",
+        headers=_auth(token),
+        json={
+            "recipient_member_id": recipient_id,
+            "subject": "Wake check",
+            "body_markdown": "Please check your inbox.",
+        },
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["delivery_state"] == "wake_succeeded"
+    assert body["recipients"][0]["status"] == "wake_succeeded"
+    assert body["recipients"][0]["wake_method"] == "tmux"
+    tmux_calls = [call for call in calls if call[0][0] == "tmux"]
+    assert len(tmux_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_external_request_status_wait_and_ack_lifecycle(client, db):
+    recipient = await _member(db, "repo-beta", "beta")
+    token, _ = await _actor_token(client)
+    created = await client.post(
+        "/api/v1/external/agent-mail/context-requests",
+        headers=_auth(token),
+        json={
+            "recipient_member_id": recipient.id,
+            "subject": "Round trip",
+            "body_markdown": "Please answer.",
+        },
+    )
+    message_id = created.json()["message"]["id"]
+
+    pending = await client.get(
+        f"/api/v1/external/agent-mail/requests/{message_id}/status",
+        headers=_auth(token),
+    )
+    assert pending.status_code == 200
+    assert pending.json()["request_status"] == "pending"
+
+    answer = await client.post(
+        "/api/v1/agent-mail/messages",
+        json={
+            "kind": "answer",
+            "sender_member_id": recipient.id,
+            "thread_root_id": message_id,
+            "body_markdown": "Here is the answer.",
+        },
+    )
+    assert answer.status_code == 200
+
+    waited = await client.get(
+        f"/api/v1/external/agent-mail/requests/{message_id}/wait?timeout_seconds=1",
+        headers=_auth(token),
+    )
+    assert waited.status_code == 200
+    assert waited.json()["answered"] is True
+    assert waited.json()["request_status"] == "answered"
+
+    acked = await client.post(
+        f"/api/v1/external/agent-mail/requests/{message_id}/ack",
+        headers=_auth(token),
+    )
+    assert acked.status_code == 200
+    assert acked.json()["acknowledged"] is True
+    assert acked.json()["request_status"] == "acknowledged"
+
+
+@pytest.mark.asyncio
+async def test_external_actor_can_reply_in_own_thread(client, db):
+    recipient = await _member(db, "repo-beta", "beta")
+    token, _ = await _actor_token(client)
+    created = await client.post(
+        "/api/v1/external/agent-mail/context-requests",
+        headers=_auth(token),
+        json={
+            "recipient_member_id": recipient.id,
+            "subject": "Thread",
+            "body_markdown": "Initial request.",
+        },
+    )
+    message_id = created.json()["message"]["id"]
+
+    reply = await client.post(
+        f"/api/v1/external/agent-mail/threads/{message_id}/replies",
+        headers=_auth(token),
+        json={
+            "body_markdown": "Adding external follow-up detail.",
+        },
+    )
+
+    assert reply.status_code == 200
+    assert reply.json()["message"]["thread_root_id"] == message_id
+
+    thread = await client.get(
+        f"/api/v1/external/agent-mail/threads/{message_id}",
+        headers=_auth(token),
+    )
+    assert thread.status_code == 200
+    assert len(thread.json()["replies"]) == 1
+    assert thread.json()["replies"][0]["sender_name"] == "OpenClaw"
+
+
+@pytest.mark.asyncio
+async def test_external_message_rate_limit_returns_429(client, db, monkeypatch):
+    recipient = await _member(db, "repo-beta", "beta")
+    token, _ = await _actor_token(client)
+    monkeypatch.setattr(
+        "app.services.external_agent_mail_service.EXTERNAL_RATE_LIMIT_MAX_MESSAGES",
+        1,
+    )
+
+    first = await client.post(
+        "/api/v1/external/agent-mail/messages",
+        headers=_auth(token),
+        json={
+            "recipient_member_id": recipient.id,
+            "body_markdown": "one",
+        },
+    )
+    second = await client.post(
+        "/api/v1/external/agent-mail/messages",
+        headers=_auth(token),
+        json={
+            "recipient_member_id": recipient.id,
+            "body_markdown": "two",
+        },
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+    assert second.json()["detail"]["code"] == "external_agent_mail_rate_limited"
+    assert int(second.headers["retry-after"]) >= 1

--- a/docs/features/agent-mail.md
+++ b/docs/features/agent-mail.md
@@ -31,25 +31,9 @@ Non-tmux Codex sessions can still receive and send Agent Mail through MCP, but C
 
 ## External Local Callers
 
-Local tools such as OpenClaw can send Agent Mail through Claude Deck's REST API. A typical flow is:
+Local tools such as OpenClaw can use the external Agent Mail API to authenticate as a named local actor, discover members, send direct messages, request context, create handoffs, and poll request status.
 
-1. `GET /api/v1/agent-mail/team?sync=true` to find the target `member.id`.
-2. `POST /api/v1/agent-mail/messages` with a body like:
-
-```json
-{
-  "kind": "context_request",
-  "recipient_member_id": 2,
-  "subject": "Need repository context",
-  "body_markdown": "Please inspect the failing workflow and reply with the likely owner.",
-  "payload": {
-    "files_or_symbols": ["backend/app/api/v1/agent_mail.py"],
-    "why_needed": "OpenClaw is validating the Agent Mail integration."
-  }
-}
-```
-
-The same delivery path is used for UI, MCP, and external REST messages, so a nudgeable recipient is nudged automatically after the message is stored.
+See [External Agent Orchestration](./external-agent-orchestration.md) for token setup, endpoint examples, delivery result semantics, and Agent Teams launch integration.
 
 ## Setup Checklist
 
@@ -65,8 +49,8 @@ Without this setup, the page can still show install status, but agents cannot ex
 
 - Visibility is machine-global. Every local member is visible to every other member.
 - MVP identity is one team member per repository. Git worktrees of the same repository share the same member.
-- There is no Agent Mail token yet. This follows the current local Deck trust model, where existing configuration endpoints are local and unauthenticated.
-- External callers should only use the API from the same trusted machine or network until a broader Claude Deck auth model exists.
+- External Agent Mail calls use local actor bearer tokens. Token creation is loopback-only and follows Claude Deck's local trust model.
+- External callers should only use the API from the same trusted machine until a broader Claude Deck auth model exists.
 - Agent Mail is coordination state, not source control. Handoffs should still reference files, branches, issues, or commits when durable provenance matters.
 
 ## Install Details

--- a/docs/features/agent-teams.md
+++ b/docs/features/agent-teams.md
@@ -46,3 +46,5 @@ Local external agents can use the JSON API:
 4. `POST /api/v1/agent-teams/presets/{preset_id}/launch`
 
 Launch accepts a reviewed `confirm_plan_hash`, or `skip_plan_confirmation: true` for explicit single-step local automation. If a plan hash is stale, the API returns `409` with the updated plan.
+
+After a launch, use the [External Agent Orchestration](./external-agent-orchestration.md) Agent Mail API to discover registered members, send context requests, create handoffs, and poll for answers.

--- a/docs/features/external-agent-orchestration.md
+++ b/docs/features/external-agent-orchestration.md
@@ -1,0 +1,155 @@
+# External Agent Orchestration
+
+Claude Deck exposes a local Agent Mail API for tools such as OpenClaw to coordinate installed agents without pretending to be a repo agent or a UI user.
+
+This API is for same-machine automation. It does not replace Agent Teams preset launch APIs, and it does not add a new wake path for non-tmux Codex sessions.
+
+## Setup
+
+Create or rotate a local external actor token:
+
+```bash
+curl -s http://127.0.0.1:8000/api/v1/external/agent-mail/actors \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "actor_key": "openclaw",
+    "display_name": "OpenClaw",
+    "kind": "external_tool",
+    "description": "Local validation and orchestration agent"
+  }'
+```
+
+Store the returned `token` locally and send it as a bearer token:
+
+```bash
+export DECK_EXTERNAL_AGENT_TOKEN='returned-token'
+export DECK_API='http://127.0.0.1:8000/api/v1'
+```
+
+Actor registration is loopback-only. External Agent Mail endpoints require `Authorization: Bearer ...`.
+
+## Discover Members
+
+```bash
+curl -s "$DECK_API/external/agent-mail/members" \
+  -H "Authorization: Bearer $DECK_EXTERNAL_AGENT_TOKEN"
+```
+
+The response includes each Agent Mail member's repo, role, charter, connection status, inbox load, `wake_state`, `wake_methods`, and current Agent Team preset/slot context when present.
+
+Wake states mean:
+
+- `wakeable`: Claude Deck has a visible wake path, currently tmux-observed Codex through Agent Bridge.
+- `delivered_waiting`: the message can be stored and read through Agent Mail, but Claude Deck cannot wake the visible session.
+- `offline`: no live session is available.
+
+## Send A Direct Message
+
+```bash
+curl -s "$DECK_API/external/agent-mail/messages" \
+  -H "Authorization: Bearer $DECK_EXTERNAL_AGENT_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "recipient_member_id": 2,
+    "subject": "Validation note",
+    "body_markdown": "Please check your local test result when you are next active."
+  }'
+```
+
+The response includes the stored message, receipt recipients, aggregate `delivery_state`, and per-recipient wake results.
+
+## Request Context And Poll
+
+```bash
+curl -s "$DECK_API/external/agent-mail/context-requests" \
+  -H "Authorization: Bearer $DECK_EXTERNAL_AGENT_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "recipient_member_id": 2,
+    "subject": "Need API ownership context",
+    "body_markdown": "Which module owns the Agent Mail delivery path?",
+    "why_needed": "OpenClaw is validating a cross-repo change.",
+    "files_or_symbols": ["backend/app/services/agent_mail_service.py"]
+  }'
+```
+
+Poll the request:
+
+```bash
+curl -s "$DECK_API/external/agent-mail/requests/17/status" \
+  -H "Authorization: Bearer $DECK_EXTERNAL_AGENT_TOKEN"
+```
+
+Or wait briefly with bounded local long-polling:
+
+```bash
+curl -s "$DECK_API/external/agent-mail/requests/17/wait?timeout_seconds=20" \
+  -H "Authorization: Bearer $DECK_EXTERNAL_AGENT_TOKEN"
+```
+
+After consuming an answer, an external actor can acknowledge its own request:
+
+```bash
+curl -s -X POST "$DECK_API/external/agent-mail/requests/17/ack" \
+  -H "Authorization: Bearer $DECK_EXTERNAL_AGENT_TOKEN"
+```
+
+## Handoffs And Broadcasts
+
+Create a handoff:
+
+```bash
+curl -s "$DECK_API/external/agent-mail/handoffs" \
+  -H "Authorization: Bearer $DECK_EXTERNAL_AGENT_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "recipient_member_id": 2,
+    "subject": "Take over deploy check",
+    "body_markdown": "Please continue from the failed deploy step.",
+    "files": ["infra/deploy.yaml"],
+    "next_steps": ["Inspect the failing job", "Reply with the owner and likely fix"]
+  }'
+```
+
+Broadcast to all Agent Mail members:
+
+```bash
+curl -s "$DECK_API/external/agent-mail/broadcasts" \
+  -H "Authorization: Bearer $DECK_EXTERNAL_AGENT_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "subject": "Validation run started",
+    "body_markdown": "OpenClaw has started a local validation pass."
+  }'
+```
+
+## Agent Teams Integration
+
+External tools should use the existing Agent Teams API to launch or reuse a saved roster:
+
+```bash
+curl -s "$DECK_API/agent-teams/presets"
+curl -s -X POST "$DECK_API/agent-teams/presets/3/plan-launch" \
+  -H 'Content-Type: application/json' \
+  -d '{"requested_by": "OpenClaw"}'
+```
+
+After reviewing the plan, launch with the returned plan hash:
+
+```bash
+curl -s -X POST "$DECK_API/agent-teams/presets/3/launch" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "requested_by": "OpenClaw",
+    "confirm_plan_hash": "returned-plan-hash"
+  }'
+```
+
+Once agents register through Agent Mail, use `/external/agent-mail/members` to discover their member ids, then send context requests or handoffs through the external Agent Mail endpoints.
+
+## Safeguards
+
+- External actor tokens are distinct from Agent Mail members and are shown by name in the Agent Mail UI.
+- Non-tmux Codex sessions return `delivered_waiting`; they are not falsely reported as woken.
+- Per-actor message rate limits return `429` with a `Retry-After` header.
+- This is a local trust boundary, not a general network authentication system.

--- a/frontend/src/features/agent-mail/RequestsTab.tsx
+++ b/frontend/src/features/agent-mail/RequestsTab.tsx
@@ -19,10 +19,11 @@ import type {
 import {
   KIND_LABEL,
   formatDateTime,
-  memberName,
   messageSummary,
   recipientName,
   requestBadgeClass,
+  senderName,
+  senderTypeLabel,
 } from './utils'
 
 export type RequestKindFilter = 'all' | Exclude<MailMessageKind, 'answer'>
@@ -71,7 +72,7 @@ export function RequestsTab({
       KIND_LABEL[message.kind],
       message.subject ?? '',
       message.body_markdown,
-      memberName(members, message.sender_member_id),
+      senderName(message, members),
       recipientName(message, members),
     ].join(' ').toLowerCase()
     return matchesKind && matchesStatus && (!normalizedSearch || haystack.includes(normalizedSearch))
@@ -157,9 +158,16 @@ export function RequestsTab({
                     <h3 className="truncate text-base font-semibold">
                       {message.subject || `${KIND_LABEL[message.kind]} ${message.id}`}
                     </h3>
-                    <p className="mt-1 text-sm text-muted-foreground">
-                      {memberName(members, message.sender_member_id)} to {recipientName(message, members)}
-                    </p>
+                    <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+                      <span>
+                        {senderName(message, members)} to {recipientName(message, members)}
+                      </span>
+                      {senderTypeLabel(message) && (
+                        <Badge variant="outline" className="text-xs">
+                          {senderTypeLabel(message)}
+                        </Badge>
+                      )}
+                    </div>
                   </div>
                   <p className="text-sm leading-6 text-muted-foreground">{messageSummary(message)}</p>
                 </div>

--- a/frontend/src/features/agent-mail/ThreadDialog.tsx
+++ b/frontend/src/features/agent-mail/ThreadDialog.tsx
@@ -35,6 +35,8 @@ import {
   memberName,
   recipientName,
   requestBadgeClass,
+  senderName,
+  senderTypeLabel,
 } from './utils'
 
 interface ThreadDialogProps {
@@ -65,8 +67,15 @@ function MessageBlock({ message, members }: {
         )}
         <span className="text-xs text-muted-foreground">{formatDateTime(message.created_at)}</span>
       </div>
-      <div className="mb-3 text-sm text-muted-foreground">
-        From {memberName(members, message.sender_member_id)} to {recipientName(message, members)}
+      <div className="mb-3 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+        <span>
+          From {senderName(message, members)} to {recipientName(message, members)}
+        </span>
+        {senderTypeLabel(message) && (
+          <Badge variant="outline" className="text-xs">
+            {senderTypeLabel(message)}
+          </Badge>
+        )}
       </div>
       {message.subject && <h4 className="mb-2 text-sm font-semibold">{message.subject}</h4>}
       <MarkdownRenderer content={message.body_markdown} />

--- a/frontend/src/features/agent-mail/utils.ts
+++ b/frontend/src/features/agent-mail/utils.ts
@@ -19,6 +19,20 @@ export function memberName(members: MailMemberResponse[], memberId?: number | nu
   return members.find((member) => member.id === memberId)?.display_name ?? `Member ${memberId}`
 }
 
+export function senderName(message: MailMessageResponse, members: MailMemberResponse[]): string {
+  if (message.sender_type === 'external_actor') return message.sender_name || 'External actor'
+  if (message.sender_member_id) return memberName(members, message.sender_member_id)
+  return message.sender_name || 'Director'
+}
+
+export function senderTypeLabel(message: MailMessageResponse): string | null {
+  if (message.sender_type === 'external_actor') {
+    if (message.sender_actor_kind === 'external_tool') return 'External'
+    return message.sender_actor_kind || 'External'
+  }
+  return null
+}
+
 export function recipientName(message: MailMessageResponse, members: MailMemberResponse[]): string {
   if (message.kind === 'broadcast' || !message.recipient_member_id) return 'All members'
   return memberName(members, message.recipient_member_id)

--- a/frontend/src/types/agentMail.ts
+++ b/frontend/src/types/agentMail.ts
@@ -66,6 +66,9 @@ export interface MailMessageResponse {
   thread_root_id?: number | null
   kind: MailMessageKind
   sender_member_id?: number | null
+  sender_actor_id?: number | null
+  sender_type?: 'director' | 'member' | 'external_actor' | string
+  sender_actor_kind?: string | null
   sender_name: string
   recipient_member_id?: number | null
   subject?: string | null

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -184,6 +184,34 @@ ensure_port_available() {
     done
 }
 
+wait_for_backend() {
+    local host="$1"
+    local url="http://${host}:${BACKEND_PORT}/api/v1/health"
+    local attempts=60
+
+    if ! command -v curl >/dev/null 2>&1; then
+        echo "curl not found; waiting briefly for backend startup..."
+        sleep 2
+        return 0
+    fi
+
+    echo "Waiting for backend readiness..."
+    for _ in $(seq 1 "$attempts"); do
+        if curl -fsS --max-time 1 "$url" >/dev/null 2>&1; then
+            echo "Backend is ready."
+            return 0
+        fi
+        if ! kill -0 "$BACKEND_PID" 2>/dev/null; then
+            echo "Error: backend process exited before becoming ready."
+            exit 1
+        fi
+        sleep 0.5
+    done
+
+    echo "Error: backend did not become ready at $url"
+    exit 1
+}
+
 check_dependencies() {
     # Check if backend venv exists
     if [ ! -d "$BACKEND_DIR/venv" ]; then
@@ -226,6 +254,11 @@ start_servers() {
     source venv/bin/activate
     uvicorn app.main:app --reload --port "$BACKEND_PORT" "${BACKEND_HOST_ARGS[@]}" &
     BACKEND_PID=$!
+    BACKEND_CONNECT_HOST="${HOST:-127.0.0.1}"
+    if [ "$BACKEND_CONNECT_HOST" = "0.0.0.0" ]; then
+        BACKEND_CONNECT_HOST="127.0.0.1"
+    fi
+    wait_for_backend "$BACKEND_CONNECT_HOST"
 
     # Start frontend
     echo "Starting frontend server on http://${BACKEND_DISPLAY_HOST}:${FRONTEND_PORT}..."


### PR DESCRIPTION
## Summary
- add external Agent Mail actor identities with loopback token creation and bearer-token auth
- add external orchestration endpoints for discovery, direct messages, broadcasts, context requests, handoffs, thread replies, request status, wait, and ack
- return explicit delivery/wake results, preserve external sender attribution in Agent Mail UI, and document OpenClaw-style usage
- wait for backend readiness before starting Vite in `scripts/dev.sh` to avoid startup proxy ECONNREFUSED noise

Closes #187

## Validation
- `./backend/venv/bin/pytest backend/tests -q` -> 224 passed
- `npm --prefix frontend run build` -> passed, existing chunk-size warning
- `/home/joni/.codex/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings
- `bash -n scripts/dev.sh`
- `timeout --foreground 25s ./scripts/dev.sh start` -> backend readiness gate verified before Vite starts
