### PR TITLE
Support Codex plan snapshots

### DIFF
--- a/backend/app/api/v1/plans.py
+++ b/backend/app/api/v1/plans.py
@@ -2,6 +2,7 @@
 from typing import Optional
 from fastapi import APIRouter, HTTPException, Query
 
+from app.services.codex_plan_service import CodexPlanService
 from app.services.plan_service import PlanService
 from app.models.schemas import (
     PlanDetailResponse,
@@ -13,15 +14,40 @@ from app.models.schemas import (
 router = APIRouter()
 
 
+PLAN_PROVIDERS = {"claude-code", "codex-cli"}
+
+
+def _validate_provider(provider: str) -> str:
+    if provider not in PLAN_PROVIDERS:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "unsupported_provider_operation",
+                "message": f"Plans are not supported for provider: {provider}",
+                "provider": provider,
+                "operation": "plans",
+                "supported_providers": sorted(PLAN_PROVIDERS),
+            },
+        )
+    return provider
+
+
 @router.get("/plans", response_model=PlanListResponse)
 async def list_plans(
     project_path: Optional[str] = Query(None, description="Active project path for settings resolution"),
+    provider: str = Query("claude-code", description="Agent provider id"),
 ):
     """List all plan files sorted by modification time (newest first)."""
     try:
-        plans_dir = PlanService.resolve_plans_dir(project_path)
-        plans = PlanService.list_plans(plans_dir)
+        provider = _validate_provider(provider)
+        if provider == "codex-cli":
+            plans = CodexPlanService().list_plans(project_path)
+        else:
+            plans_dir = PlanService.resolve_plans_dir(project_path)
+            plans = PlanService.list_plans(plans_dir)
         return {"plans": plans, "total": len(plans)}
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to list plans: {str(e)}")
 
@@ -29,11 +55,18 @@ async def list_plans(
 @router.get("/plans/stats", response_model=PlanStatsResponse)
 async def get_plan_stats(
     project_path: Optional[str] = Query(None, description="Active project path"),
+    provider: str = Query("claude-code", description="Agent provider id"),
 ):
     """Get plan statistics for dashboard."""
     try:
+        provider = _validate_provider(provider)
+        if provider == "codex-cli":
+            return CodexPlanService().get_plan_stats(project_path)
+
         plans_dir = PlanService.resolve_plans_dir(project_path)
         return PlanService.get_plan_stats(plans_dir)
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to get plan stats: {str(e)}")
 
@@ -42,12 +75,19 @@ async def get_plan_stats(
 async def search_plans(
     q: str = Query(..., min_length=1, description="Search query"),
     project_path: Optional[str] = Query(None, description="Active project path"),
+    provider: str = Query("claude-code", description="Agent provider id"),
 ):
     """Search plans by title and content."""
     try:
-        plans_dir = PlanService.resolve_plans_dir(project_path)
-        results = PlanService.search_plans(plans_dir, q)
+        provider = _validate_provider(provider)
+        if provider == "codex-cli":
+            results = CodexPlanService().search_plans(q, project_path)
+        else:
+            plans_dir = PlanService.resolve_plans_dir(project_path)
+            results = PlanService.search_plans(plans_dir, q)
         return {"results": results, "query": q, "total": len(results)}
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to search plans: {str(e)}")
 
@@ -56,17 +96,23 @@ async def search_plans(
 async def get_plan_detail(
     filename: str,
     project_path: Optional[str] = Query(None, description="Active project path"),
+    provider: str = Query("claude-code", description="Agent provider id"),
 ):
     """Get full plan detail with linked sessions."""
     try:
-        plans_dir = PlanService.resolve_plans_dir(project_path)
-        plan_data = PlanService.get_plan(plans_dir, filename)
+        provider = _validate_provider(provider)
+        if provider == "codex-cli":
+            plan_data = CodexPlanService().get_plan(filename, project_path)
+        else:
+            plans_dir = PlanService.resolve_plans_dir(project_path)
+            plan_data = PlanService.get_plan(plans_dir, filename)
 
         if not plan_data:
             raise HTTPException(status_code=404, detail="Plan not found")
 
-        linked_sessions = PlanService.get_plan_sessions(plan_data["slug"])
-        plan_data["linked_sessions"] = linked_sessions
+        if provider == "claude-code":
+            linked_sessions = PlanService.get_plan_sessions(plan_data["slug"])
+            plan_data["linked_sessions"] = linked_sessions
         return {"plan": plan_data}
     except HTTPException:
         raise

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1654,6 +1654,16 @@ class PlanSummary(BaseModel):
     excerpt: str
     modified_at: str
     size_bytes: int
+    source: str = "claude-code"
+    source_label: str = "Claude Code plan file"
+    project_path: Optional[str] = None
+    session_id: Optional[str] = None
+    git_branch: Optional[str] = None
+    step_count: Optional[int] = None
+    pending_count: Optional[int] = None
+    in_progress_count: Optional[int] = None
+    completed_count: Optional[int] = None
+    history_count: Optional[int] = None
 
 
 class PlanLinkedSession(BaseModel):
@@ -1680,6 +1690,17 @@ class PlanDetail(BaseModel):
     code_block_count: int
     table_count: int
     linked_sessions: List[PlanLinkedSession]
+    source: str = "claude-code"
+    source_label: str = "Claude Code plan file"
+    project_path: Optional[str] = None
+    session_id: Optional[str] = None
+    git_branch: Optional[str] = None
+    git_sha: Optional[str] = None
+    step_count: Optional[int] = None
+    pending_count: Optional[int] = None
+    in_progress_count: Optional[int] = None
+    completed_count: Optional[int] = None
+    history_count: Optional[int] = None
 
 
 class PlanSearchResult(BaseModel):
@@ -1690,6 +1711,8 @@ class PlanSearchResult(BaseModel):
     title: str
     matches: List[str]
     modified_at: str
+    source: str = "claude-code"
+    source_label: str = "Claude Code plan file"
 
 
 class PlanListResponse(BaseModel):
@@ -1720,6 +1743,8 @@ class PlanStatsResponse(BaseModel):
     oldest_date: Optional[str] = None
     newest_date: Optional[str] = None
     total_size_bytes: int
+    source: str = "claude-code"
+    source_label: str = "Claude Code plan file"
 
 
 # MCP Registry Schemas

--- a/backend/app/services/codex_plan_service.py
+++ b/backend/app/services/codex_plan_service.py
@@ -1,0 +1,511 @@
+"""Read-only Codex plan snapshots from update_plan events.
+
+Codex session JSONL can contain prompt text, tool outputs, and instructions.
+This service intentionally extracts only structured update_plan payloads plus
+safe thread metadata needed for filtering and sorting.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable
+
+from app.services.providers.codex_cli import get_codex_home
+
+
+PLAN_SOURCE = "codex-cli"
+PLAN_SOURCE_LABEL = "Codex plan snapshot"
+ALLOWED_STATUSES = {"pending", "in_progress", "completed"}
+MAX_THREAD_ROWS = 1_000
+MAX_FILESYSTEM_FILES = 1_000
+MAX_JSONL_LINES = 100_000
+MAX_PLAN_UPDATES_PER_THREAD = 100
+MAX_PLAN_ITEMS = 30
+MAX_STEP_LENGTH = 240
+MAX_EXPLANATION_LENGTH = 500
+MAX_HISTORY_IN_DETAIL = 20
+
+
+@dataclass(frozen=True)
+class CodexThreadRef:
+    thread_id: str
+    rollout_path: Path
+    cwd: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    git_branch: str | None = None
+    git_sha: str | None = None
+
+
+@dataclass(frozen=True)
+class CodexPlanUpdate:
+    timestamp: str
+    explanation: str | None
+    plan: list[dict[str, str]]
+
+
+class CodexPlanService:
+    """Surface Codex update_plan snapshots as plan-like records."""
+
+    def __init__(self, codex_home: Path | None = None):
+        self.codex_home = (codex_home or get_codex_home()).expanduser()
+
+    def list_plans(self, project_path: str | None = None) -> list[dict[str, Any]]:
+        plans: list[dict[str, Any]] = []
+        for thread in self._iter_thread_refs(project_path):
+            record = self._build_record(thread, include_content=False)
+            if record:
+                plans.append(record)
+
+        plans.sort(key=lambda plan: plan.get("modified_at") or "", reverse=True)
+        return plans
+
+    def get_plan(self, filename: str, project_path: str | None = None) -> dict[str, Any] | None:
+        for thread in self._iter_thread_refs(project_path):
+            record = self._build_record(thread, include_content=True)
+            if record and record["filename"] == filename:
+                return record
+        return None
+
+    def search_plans(self, query: str, project_path: str | None = None) -> list[dict[str, Any]]:
+        query_lower = query.lower()
+        results: list[dict[str, Any]] = []
+        for thread in self._iter_thread_refs(project_path):
+            plan = self._build_record(thread, include_content=True)
+            if not plan:
+                continue
+            fields = [
+                plan.get("title", ""),
+                plan.get("excerpt", ""),
+                plan.get("slug", ""),
+                plan.get("content", ""),
+            ]
+            if not any(query_lower in str(field).lower() for field in fields):
+                continue
+            matches = self._search_matches(plan, query_lower)
+            results.append(
+                {
+                    "filename": plan["filename"],
+                    "slug": plan["slug"],
+                    "title": plan["title"],
+                    "matches": matches,
+                    "modified_at": plan["modified_at"],
+                    "source": PLAN_SOURCE,
+                    "source_label": PLAN_SOURCE_LABEL,
+                }
+            )
+
+        results.sort(key=lambda result: result.get("modified_at") or "", reverse=True)
+        return results
+
+    def get_plan_stats(self, project_path: str | None = None) -> dict[str, Any]:
+        plans = self.list_plans(project_path)
+        if not plans:
+            return {
+                "total_plans": 0,
+                "oldest_date": None,
+                "newest_date": None,
+                "total_size_bytes": 0,
+                "source": PLAN_SOURCE,
+                "source_label": PLAN_SOURCE_LABEL,
+            }
+
+        dates = [plan["modified_at"] for plan in plans if plan.get("modified_at")]
+        return {
+            "total_plans": len(plans),
+            "oldest_date": min(dates) if dates else None,
+            "newest_date": max(dates) if dates else None,
+            "total_size_bytes": sum(int(plan.get("size_bytes") or 0) for plan in plans),
+            "source": PLAN_SOURCE,
+            "source_label": PLAN_SOURCE_LABEL,
+        }
+
+    def _iter_thread_refs(self, project_path: str | None) -> Iterable[CodexThreadRef]:
+        seen_paths: set[Path] = set()
+        refs = self._thread_refs_from_sqlite(project_path)
+        if not refs:
+            refs = self._thread_refs_from_filesystem(project_path)
+
+        for ref in refs:
+            try:
+                rollout_path = ref.rollout_path.expanduser().resolve(strict=False)
+            except OSError:
+                rollout_path = ref.rollout_path.expanduser()
+            if rollout_path in seen_paths:
+                continue
+            seen_paths.add(rollout_path)
+            if rollout_path.exists() and rollout_path.is_file():
+                yield ref
+
+    def _thread_refs_from_sqlite(self, project_path: str | None) -> list[CodexThreadRef]:
+        db_path = self._state_db_path()
+        if not db_path:
+            return []
+
+        refs: list[CodexThreadRef] = []
+        try:
+            conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+            conn.row_factory = sqlite3.Row
+            try:
+                rows = conn.execute(
+                    """
+                    SELECT id, rollout_path, created_at, updated_at, cwd, git_branch, git_sha
+                    FROM threads
+                    WHERE rollout_path IS NOT NULL AND rollout_path <> ''
+                    ORDER BY updated_at DESC
+                    LIMIT ?
+                    """,
+                    (MAX_THREAD_ROWS,),
+                ).fetchall()
+            finally:
+                conn.close()
+        except sqlite3.Error:
+            return []
+
+        for row in rows:
+            cwd = self._clean_optional_text(row["cwd"], max_len=1_000)
+            if not self._matches_project(cwd, project_path):
+                continue
+            rollout_path = Path(str(row["rollout_path"])).expanduser()
+            refs.append(
+                CodexThreadRef(
+                    thread_id=self._clean_optional_text(row["id"], max_len=128)
+                    or rollout_path.stem,
+                    rollout_path=rollout_path,
+                    cwd=cwd,
+                    created_at=self._sqlite_time_to_iso(row["created_at"]),
+                    updated_at=self._sqlite_time_to_iso(row["updated_at"]),
+                    git_branch=self._clean_optional_text(row["git_branch"], max_len=120),
+                    git_sha=self._clean_optional_text(row["git_sha"], max_len=80),
+                )
+            )
+        return refs
+
+    def _thread_refs_from_filesystem(self, project_path: str | None) -> list[CodexThreadRef]:
+        sessions_dir = self.codex_home / "sessions"
+        if not sessions_dir.exists():
+            return []
+
+        files = sorted(
+            sessions_dir.glob("**/*.jsonl"),
+            key=lambda path: path.stat().st_mtime if path.exists() else 0,
+            reverse=True,
+        )[:MAX_FILESYSTEM_FILES]
+
+        refs: list[CodexThreadRef] = []
+        for path in files:
+            meta = self._read_session_meta(path)
+            cwd = meta.get("cwd")
+            if not self._matches_project(cwd, project_path):
+                continue
+            refs.append(
+                CodexThreadRef(
+                    thread_id=meta.get("id") or path.stem,
+                    rollout_path=path,
+                    cwd=cwd,
+                    created_at=meta.get("timestamp"),
+                    updated_at=datetime.fromtimestamp(path.stat().st_mtime).isoformat(),
+                    git_branch=meta.get("git_branch"),
+                    git_sha=meta.get("git_sha"),
+                )
+            )
+        return refs
+
+    def _read_session_meta(self, path: Path) -> dict[str, str | None]:
+        meta: dict[str, str | None] = {}
+        try:
+            with path.open("r", encoding="utf-8", errors="replace") as handle:
+                for index, raw_line in enumerate(handle):
+                    if index >= 100:
+                        break
+                    record = self._parse_json_line(raw_line)
+                    if record.get("type") != "session_meta":
+                        continue
+                    payload = record.get("payload")
+                    if not isinstance(payload, dict):
+                        continue
+                    git = payload.get("git") if isinstance(payload.get("git"), dict) else {}
+                    meta = {
+                        "id": self._clean_optional_text(payload.get("id"), max_len=128),
+                        "timestamp": self._clean_optional_text(payload.get("timestamp"), max_len=80),
+                        "cwd": self._clean_optional_text(payload.get("cwd"), max_len=1_000),
+                        "git_branch": self._clean_optional_text(git.get("branch"), max_len=120),
+                        "git_sha": self._clean_optional_text(git.get("commit_hash"), max_len=80),
+                    }
+                    break
+        except OSError:
+            return {}
+        return meta
+
+    def _build_record(self, thread: CodexThreadRef, *, include_content: bool) -> dict[str, Any] | None:
+        updates = self._read_plan_updates(thread.rollout_path)
+        if not updates:
+            return None
+
+        latest = sorted(updates, key=lambda update: self._timestamp_key(update.timestamp))[-1]
+        counts = self._plan_counts(latest.plan)
+        filename = f"codex-{self._safe_slug(thread.thread_id or thread.rollout_path.stem)}.md"
+        title = self._title_for(thread, latest)
+        excerpt = self._excerpt_for(latest, counts)
+        source_size = self._safe_size(thread.rollout_path)
+
+        record: dict[str, Any] = {
+            "filename": filename,
+            "slug": filename.removesuffix(".md"),
+            "title": title,
+            "excerpt": excerpt,
+            "modified_at": latest.timestamp or thread.updated_at or thread.created_at or "",
+            "size_bytes": source_size,
+            "source": PLAN_SOURCE,
+            "source_label": PLAN_SOURCE_LABEL,
+            "project_path": thread.cwd,
+            "session_id": thread.thread_id,
+            "git_branch": thread.git_branch,
+            "git_sha": thread.git_sha,
+            "step_count": counts["total"],
+            "pending_count": counts["pending"],
+            "in_progress_count": counts["in_progress"],
+            "completed_count": counts["completed"],
+            "history_count": len(updates),
+        }
+        if include_content:
+            record.update(
+                {
+                    "content": self._render_markdown(thread, latest, updates),
+                    "headings": ["Current Snapshot", "Update History"],
+                    "code_block_count": 0,
+                    "table_count": 0,
+                    "linked_sessions": [],
+                }
+            )
+        return record
+
+    def _read_plan_updates(self, path: Path) -> list[CodexPlanUpdate]:
+        updates: list[CodexPlanUpdate] = []
+        try:
+            with path.open("r", encoding="utf-8", errors="replace") as handle:
+                for line_index, raw_line in enumerate(handle):
+                    if line_index >= MAX_JSONL_LINES:
+                        break
+                    record = self._parse_json_line(raw_line)
+                    if not self._is_update_plan_call(record):
+                        continue
+                    update = self._parse_update_plan(record)
+                    if update:
+                        updates.append(update)
+                    if len(updates) >= MAX_PLAN_UPDATES_PER_THREAD:
+                        break
+        except OSError:
+            return []
+        return updates
+
+    def _parse_update_plan(self, record: dict[str, Any]) -> CodexPlanUpdate | None:
+        payload = record.get("payload")
+        if not isinstance(payload, dict):
+            return None
+        args = payload.get("arguments")
+        if isinstance(args, str):
+            try:
+                args = json.loads(args)
+            except json.JSONDecodeError:
+                return None
+        if not isinstance(args, dict):
+            return None
+
+        raw_plan = args.get("plan")
+        if not isinstance(raw_plan, list):
+            return None
+
+        plan: list[dict[str, str]] = []
+        for item in raw_plan[:MAX_PLAN_ITEMS]:
+            if not isinstance(item, dict):
+                continue
+            status = item.get("status")
+            step = self._clean_optional_text(item.get("step"), max_len=MAX_STEP_LENGTH)
+            if not step or status not in ALLOWED_STATUSES:
+                continue
+            plan.append({"step": step, "status": str(status)})
+
+        if not plan:
+            return None
+
+        timestamp = self._clean_optional_text(record.get("timestamp"), max_len=80) or ""
+        explanation = self._clean_optional_text(
+            args.get("explanation"),
+            max_len=MAX_EXPLANATION_LENGTH,
+        )
+        return CodexPlanUpdate(timestamp=timestamp, explanation=explanation, plan=plan)
+
+    def _render_markdown(
+        self,
+        thread: CodexThreadRef,
+        latest: CodexPlanUpdate,
+        updates: list[CodexPlanUpdate],
+    ) -> str:
+        lines = [
+            "# Codex Plan Snapshot",
+            "",
+            "## Current Snapshot",
+            "",
+        ]
+        if latest.explanation:
+            lines.extend([latest.explanation, ""])
+        lines.extend(self._markdown_steps(latest.plan))
+
+        lines.extend(["", "## Update History", ""])
+        for update in sorted(updates, key=lambda item: self._timestamp_key(item.timestamp), reverse=True)[
+            :MAX_HISTORY_IN_DETAIL
+        ]:
+            lines.extend([f"### {update.timestamp or 'Unknown time'}", ""])
+            if update.explanation:
+                lines.extend([update.explanation, ""])
+            lines.extend(self._markdown_steps(update.plan))
+            lines.append("")
+
+        if thread.cwd or thread.git_branch or thread.thread_id:
+            lines.extend(["## Source", ""])
+            if thread.cwd:
+                lines.append(f"- Repo: `{thread.cwd}`")
+            if thread.thread_id:
+                lines.append(f"- Codex thread: `{thread.thread_id}`")
+            if thread.git_branch:
+                lines.append(f"- Git branch: `{thread.git_branch}`")
+            if thread.git_sha:
+                lines.append(f"- Git SHA: `{thread.git_sha}`")
+        return "\n".join(lines).strip() + "\n"
+
+    def _markdown_steps(self, plan: list[dict[str, str]]) -> list[str]:
+        rendered = []
+        for item in plan:
+            marker = "[x]" if item["status"] == "completed" else "[ ]"
+            status = item["status"].replace("_", " ")
+            rendered.append(f"- {marker} {item['step']} ({status})")
+        return rendered
+
+    def _search_matches(self, plan: dict[str, Any], query_lower: str) -> list[str]:
+        matches: list[str] = []
+        for value in (plan.get("title"), plan.get("excerpt"), plan.get("slug")):
+            if isinstance(value, str) and query_lower in value.lower():
+                matches.append(value)
+        content = plan.get("content")
+        if isinstance(content, str):
+            for line in content.splitlines():
+                stripped = line.strip()
+                if stripped and query_lower in stripped.lower():
+                    matches.append(stripped[:160])
+                if len(matches) >= 3:
+                    break
+        return matches[:3]
+
+    def _state_db_path(self) -> Path | None:
+        preferred = self.codex_home / "state_5.sqlite"
+        if preferred.exists():
+            return preferred
+        candidates = sorted(self.codex_home.glob("state_*.sqlite"))
+        return candidates[-1] if candidates else None
+
+    def _matches_project(self, cwd: str | None, project_path: str | None) -> bool:
+        if not project_path:
+            return True
+        if not cwd:
+            return False
+        return self._normalized_path(cwd) == self._normalized_path(project_path)
+
+    def _normalized_path(self, path: str) -> str:
+        try:
+            return str(Path(path).expanduser().resolve(strict=False))
+        except OSError:
+            return str(Path(path).expanduser())
+
+    def _is_update_plan_call(self, record: dict[str, Any]) -> bool:
+        payload = record.get("payload")
+        return (
+            record.get("type") == "response_item"
+            and isinstance(payload, dict)
+            and payload.get("type") == "function_call"
+            and payload.get("name") == "update_plan"
+        )
+
+    def _parse_json_line(self, raw_line: str) -> dict[str, Any]:
+        stripped = raw_line.strip()
+        if not stripped:
+            return {}
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+
+    def _title_for(self, thread: CodexThreadRef, latest: CodexPlanUpdate) -> str:
+        repo_name = Path(thread.cwd).name if thread.cwd else "Codex session"
+        active = next((item["step"] for item in latest.plan if item["status"] == "in_progress"), None)
+        if active:
+            return f"{repo_name} - {active}"
+        return f"{repo_name} - Codex plan snapshot"
+
+    def _excerpt_for(self, latest: CodexPlanUpdate, counts: dict[str, int]) -> str:
+        active = next((item["step"] for item in latest.plan if item["status"] == "in_progress"), None)
+        if active:
+            return f"In progress: {active}"
+        return (
+            f"{counts['total']} steps: {counts['completed']} completed, "
+            f"{counts['in_progress']} in progress, {counts['pending']} pending"
+        )
+
+    def _plan_counts(self, plan: list[dict[str, str]]) -> dict[str, int]:
+        counts = {"total": len(plan), "pending": 0, "in_progress": 0, "completed": 0}
+        for item in plan:
+            status = item.get("status")
+            if status in counts:
+                counts[status] += 1
+        return counts
+
+    def _safe_slug(self, value: str) -> str:
+        slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-")
+        return slug[:120] or "session"
+
+    def _safe_size(self, path: Path) -> int:
+        try:
+            return path.stat().st_size
+        except OSError:
+            return 0
+
+    def _sqlite_time_to_iso(self, value: Any) -> str | None:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            if value.isdigit():
+                value = int(value)
+            else:
+                return self._clean_optional_text(value, max_len=80)
+        if isinstance(value, (int, float)):
+            timestamp = float(value)
+            if timestamp > 10_000_000_000:
+                timestamp = timestamp / 1000
+            try:
+                return datetime.fromtimestamp(timestamp).isoformat()
+            except (OSError, OverflowError, ValueError):
+                return None
+        return None
+
+    def _timestamp_key(self, value: str) -> float:
+        if not value:
+            return 0
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            return 0
+
+    def _clean_optional_text(self, value: Any, *, max_len: int) -> str | None:
+        if not isinstance(value, str):
+            return None
+        cleaned = " ".join(value.split()).strip()
+        if not cleaned:
+            return None
+        if len(cleaned) > max_len:
+            return cleaned[: max_len - 3] + "..."
+        return cleaned

--- a/backend/app/services/providers/capabilities.py
+++ b/backend/app/services/providers/capabilities.py
@@ -26,6 +26,7 @@ CAPABILITY_KEYS = (
     "doctor",
     "backup",
     "restore",
+    "plans",
 )
 SUPPORTED_STATES = {"supported", "read_only", "write_capable"}
 
@@ -59,6 +60,7 @@ PROVIDER_CAPABILITY_MATRIX: dict[str, dict[str, dict[str, str]]] = {
         "doctor": capability("unsupported", "Doctor", "Claude Code does not expose provider doctor diagnostics."),
         "backup": capability("write_capable", "Backup", "Claude Code backup and restore workflows are available."),
         "restore": capability("write_capable", "Restore", "Claude Code backup restore workflows are available."),
+        "plans": capability("read_only", "Plans", "Claude Code markdown plan files are available read-only."),
     },
     "codex-cli": {
         "config": capability("write_capable", "Configuration", "Safe Codex TOML settings can be viewed and edited."),
@@ -81,6 +83,7 @@ PROVIDER_CAPABILITY_MATRIX: dict[str, dict[str, dict[str, str]]] = {
         "doctor": capability("read_only", "Doctor", "Codex doctor diagnostics are available read-only."),
         "backup": capability("read_only", "Backup", "Codex export-only backups are available."),
         "restore": capability("unsupported", "Restore", "Automatic Codex restore is refused without a stable provider-owned restore API."),
+        "plans": capability("read_only", "Plan Snapshots", "Codex update_plan snapshots are available read-only."),
     },
 }
 

--- a/backend/tests/test_codex_plan_service.py
+++ b/backend/tests/test_codex_plan_service.py
@@ -1,0 +1,278 @@
+"""Tests for Codex update_plan snapshot extraction."""
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+def _write_state_db(codex_home: Path, *, thread_id: str, rollout_path: Path, cwd: Path) -> None:
+    codex_home.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(codex_home / "state_5.sqlite")
+    try:
+        conn.execute(
+            """
+            CREATE TABLE threads (
+                id TEXT PRIMARY KEY,
+                rollout_path TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                cwd TEXT NOT NULL,
+                git_branch TEXT,
+                git_sha TEXT,
+                title TEXT NOT NULL,
+                first_user_message TEXT NOT NULL,
+                preview TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO threads (
+                id, rollout_path, created_at, updated_at, cwd, git_branch, git_sha,
+                title, first_user_message, preview
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                thread_id,
+                str(rollout_path),
+                1_779_000_000,
+                1_779_000_100,
+                str(cwd),
+                "main",
+                "abc123",
+                "TITLE_PROMPT_SENTINEL",
+                "FIRST_USER_PROMPT_SENTINEL",
+                "PREVIEW_PROMPT_SENTINEL",
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _write_rollout(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(json.dumps(row) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_codex_plan_snapshots_omit_prompt_like_fields(tmp_path):
+    from app.services.codex_plan_service import CodexPlanService
+
+    codex_home = tmp_path / ".codex"
+    project = tmp_path / "repo"
+    project.mkdir()
+    rollout = codex_home / "sessions" / "2026" / "06" / "16" / "rollout-test.jsonl"
+    _write_state_db(codex_home, thread_id="thread-a", rollout_path=rollout, cwd=project)
+    _write_rollout(
+        rollout,
+        [
+            {
+                "type": "session_meta",
+                "timestamp": "2026-06-16T10:00:00Z",
+                "payload": {
+                    "id": "thread-a",
+                    "cwd": str(project),
+                    "base_instructions": "BASE_INSTRUCTIONS_SENTINEL",
+                },
+            },
+            {
+                "type": "response_item",
+                "timestamp": "2026-06-16T10:01:00Z",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "RAW_PROMPT_SENTINEL"}],
+                },
+            },
+            {
+                "type": "response_item",
+                "timestamp": "2026-06-16T10:02:00Z",
+                "payload": {
+                    "type": "function_call",
+                    "name": "update_plan",
+                    "arguments": json.dumps(
+                        {
+                            "explanation": "Tracking the implementation safely",
+                            "plan": [
+                                {"step": "Inspect plan API", "status": "completed"},
+                                {"step": "Parse Codex snapshots", "status": "in_progress"},
+                                {"step": "Verify privacy boundary", "status": "pending"},
+                            ],
+                        }
+                    ),
+                    "call_id": "call-1",
+                },
+            },
+        ],
+    )
+
+    service = CodexPlanService(codex_home=codex_home)
+    plans = service.list_plans(str(project))
+
+    assert len(plans) == 1
+    assert plans[0]["source"] == "codex-cli"
+    assert plans[0]["step_count"] == 3
+    assert plans[0]["completed_count"] == 1
+    assert plans[0]["in_progress_count"] == 1
+    assert plans[0]["pending_count"] == 1
+    assert "Parse Codex snapshots" in plans[0]["excerpt"]
+
+    detail = service.get_plan(plans[0]["filename"], str(project))
+    serialized = json.dumps({"plans": plans, "detail": detail})
+    assert detail is not None
+    assert "Inspect plan API" in detail["content"]
+    assert "RAW_PROMPT_SENTINEL" not in serialized
+    assert "BASE_INSTRUCTIONS_SENTINEL" not in serialized
+    assert "TITLE_PROMPT_SENTINEL" not in serialized
+    assert "FIRST_USER_PROMPT_SENTINEL" not in serialized
+    assert "PREVIEW_PROMPT_SENTINEL" not in serialized
+
+
+def test_codex_plan_uses_latest_snapshot_and_project_filter(tmp_path):
+    from app.services.codex_plan_service import CodexPlanService
+
+    codex_home = tmp_path / ".codex"
+    project = tmp_path / "repo"
+    other_project = tmp_path / "other"
+    project.mkdir()
+    other_project.mkdir()
+    rollout = codex_home / "sessions" / "2026" / "06" / "16" / "rollout-test.jsonl"
+    _write_state_db(codex_home, thread_id="thread-a", rollout_path=rollout, cwd=project)
+    _write_rollout(
+        rollout,
+        [
+            {
+                "type": "response_item",
+                "timestamp": "2026-06-16T10:00:00Z",
+                "payload": {
+                    "type": "function_call",
+                    "name": "update_plan",
+                    "arguments": json.dumps(
+                        {"plan": [{"step": "Old active step", "status": "in_progress"}]}
+                    ),
+                },
+            },
+            {
+                "type": "response_item",
+                "timestamp": "2026-06-16T10:05:00Z",
+                "payload": {
+                    "type": "function_call",
+                    "name": "update_plan",
+                    "arguments": json.dumps(
+                        {
+                            "plan": [
+                                {"step": "Old active step", "status": "completed"},
+                                {"step": "New active step", "status": "in_progress"},
+                            ]
+                        }
+                    ),
+                },
+            },
+        ],
+    )
+
+    service = CodexPlanService(codex_home=codex_home)
+
+    assert service.list_plans(str(other_project)) == []
+    plans = service.list_plans(str(project))
+    assert len(plans) == 1
+    assert plans[0]["modified_at"] == "2026-06-16T10:05:00Z"
+    assert plans[0]["title"] == "repo - New active step"
+
+
+def test_codex_plan_search_finds_non_active_plan_steps(tmp_path):
+    from app.services.codex_plan_service import CodexPlanService
+
+    codex_home = tmp_path / ".codex"
+    project = tmp_path / "repo"
+    project.mkdir()
+    rollout = codex_home / "sessions" / "2026" / "06" / "16" / "rollout-test.jsonl"
+    _write_state_db(codex_home, thread_id="thread-a", rollout_path=rollout, cwd=project)
+    _write_rollout(
+        rollout,
+        [
+            {
+                "type": "response_item",
+                "timestamp": "2026-06-16T10:00:00Z",
+                "payload": {
+                    "type": "function_call",
+                    "name": "update_plan",
+                    "arguments": json.dumps(
+                        {
+                            "plan": [
+                                {"step": "Active visible step", "status": "in_progress"},
+                                {"step": "Hidden pending searchable step", "status": "pending"},
+                            ]
+                        }
+                    ),
+                },
+            }
+        ],
+    )
+
+    results = CodexPlanService(codex_home=codex_home).search_plans("searchable", str(project))
+
+    assert len(results) == 1
+    assert "Hidden pending searchable step" in results[0]["matches"][0]
+
+
+@pytest.mark.asyncio
+async def test_plan_api_dispatches_codex_provider(monkeypatch, tmp_path):
+    from app.api.v1 import plans as plans_api
+    from app.services.codex_plan_service import CodexPlanService
+
+    codex_home = tmp_path / ".codex"
+    project = tmp_path / "repo"
+    project.mkdir()
+    rollout = codex_home / "sessions" / "2026" / "06" / "16" / "rollout-test.jsonl"
+    _write_state_db(codex_home, thread_id="thread-a", rollout_path=rollout, cwd=project)
+    _write_rollout(
+        rollout,
+        [
+            {
+                "type": "response_item",
+                "timestamp": "2026-06-16T10:00:00Z",
+                "payload": {
+                    "type": "function_call",
+                    "name": "update_plan",
+                    "arguments": json.dumps(
+                        {"plan": [{"step": "Expose Codex plans", "status": "in_progress"}]}
+                    ),
+                },
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        plans_api,
+        "CodexPlanService",
+        lambda: CodexPlanService(codex_home=codex_home),
+    )
+
+    response = await plans_api.list_plans(project_path=str(project), provider="codex-cli")
+
+    assert response["total"] == 1
+    assert response["plans"][0]["source"] == "codex-cli"
+
+
+@pytest.mark.asyncio
+async def test_plan_api_rejects_unknown_provider():
+    from app.api.v1 import plans as plans_api
+
+    with pytest.raises(plans_api.HTTPException) as exc_info:
+        await plans_api.list_plans(project_path=None, provider="missing-provider")
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail["code"] == "unsupported_provider_operation"
+
+
+def test_claude_plan_empty_state_still_works(tmp_path):
+    from app.services.plan_service import PlanService
+
+    assert PlanService.list_plans(tmp_path) == []
+    assert PlanService.get_plan_stats(tmp_path)["total_plans"] == 0

--- a/backend/tests/test_multi_provider_smoke.py
+++ b/backend/tests/test_multi_provider_smoke.py
@@ -16,9 +16,11 @@ def test_provider_registry_smoke_exposes_claude_and_codex_statuses():
 
     assert claude_status["capabilities"]["sessions"] is True
     assert claude_status["capabilities"]["usage"] is True
+    assert claude_status["capabilities"]["plans"] is True
     assert codex_status["capabilities"]["sessions"] is True
     assert codex_status["capabilities"]["doctor"] is True
     assert codex_status["capabilities"]["usage"] is False
+    assert codex_status["capabilities"]["plans"] is True
 
 
 def test_agent_bridge_session_filter_smoke(monkeypatch):

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -64,7 +64,7 @@ const commonNavigation: NavGroup[] = [
     items: [
       { name: 'Agent Mail', href: '/agent-mail', icon: Mail },
       { name: 'Agent Teams', href: '/agent-teams', icon: UsersRound },
-      { name: 'Plans', href: '/plans', icon: ClipboardList },
+      { name: 'Plans', href: '/plans', icon: ClipboardList, capability: 'plans' },
       { name: 'Backup', href: '/backup', icon: Archive, capability: 'backup' },
     ],
   },

--- a/frontend/src/contexts/DashboardContext.tsx
+++ b/frontend/src/contexts/DashboardContext.tsx
@@ -12,6 +12,7 @@ import {
   type ReactNode,
 } from 'react';
 import { useProjectContext } from '@/contexts/ProjectContext';
+import { useProviderContext } from '@/contexts/ProviderContext';
 import { useSessionsApi } from '@/hooks/useSessionsApi';
 import { useContextApi } from '@/hooks/useContextApi';
 import { usePlansApi } from '@/hooks/usePlansApi';
@@ -61,6 +62,7 @@ const DashboardContext = createContext<DashboardContextType | undefined>(undefin
 
 export function DashboardProvider({ children }: { children: ReactNode }) {
   const { activeProject } = useProjectContext();
+  const { selectedProviderId } = useProviderContext();
   const { getDashboardStats } = useSessionsApi();
   const { getActiveSessions } = useContextApi();
   const { getStats: getPlanStats } = usePlansApi();
@@ -70,6 +72,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
   const [error, setError] = useState<string | null>(null);
   const [lastFetched, setLastFetched] = useState<Date | null>(null);
   const prevProjectPath = useRef<string | undefined>(undefined);
+  const prevProviderId = useRef<string | undefined>(undefined);
   const fetchId = useRef(0);
 
   const fetchStats = useCallback(async () => {
@@ -151,18 +154,22 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
       }
     }
   // getDashboardStats and getActiveSessions have stable refs (empty deps).
-  // getPlanStats changes with activeProject?.path but we handle project changes separately.
+  // getPlanStats changes with activeProject?.path and selectedProviderId; those are handled below.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeProject?.path]);
+  }, [activeProject?.path, selectedProviderId]);
 
-  // Re-fetch when active project changes (but not on initial mount)
+  // Re-fetch when active project or provider changes (but not on initial mount)
   useEffect(() => {
     const currentPath = activeProject?.path;
-    if (prevProjectPath.current !== undefined && prevProjectPath.current !== currentPath) {
+    const currentProvider = selectedProviderId;
+    const projectChanged = prevProjectPath.current !== undefined && prevProjectPath.current !== currentPath;
+    const providerChanged = prevProviderId.current !== undefined && prevProviderId.current !== currentProvider;
+    if (projectChanged || providerChanged) {
       fetchStats();
     }
     prevProjectPath.current = currentPath;
-  }, [activeProject?.path, fetchStats]);
+    prevProviderId.current = currentProvider;
+  }, [activeProject?.path, selectedProviderId, fetchStats]);
 
   return (
     <DashboardContext.Provider

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -279,11 +279,13 @@ export function DashboardPage() {
 
           <Card>
             <CardHeader className="pb-2">
-              <CardDescription>Plans</CardDescription>
+              <CardDescription>{selectedProviderId === 'codex-cli' ? 'Plan Snapshots' : 'Plans'}</CardDescription>
               <CardTitle className="text-3xl">{stats.planCount}</CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="text-xs text-muted-foreground">Execution plans</p>
+              <p className="text-xs text-muted-foreground">
+                {selectedProviderId === 'codex-cli' ? 'Codex update_plan snapshots' : 'Execution plans'}
+              </p>
               <Button
                 variant="link"
                 className="p-0 h-auto mt-2"

--- a/frontend/src/features/plans/PlanDetailPage.tsx
+++ b/frontend/src/features/plans/PlanDetailPage.tsx
@@ -1,12 +1,13 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
-import { ArrowLeft, FileText, Calendar, HardDrive, Code, Table, GitBranch } from 'lucide-react'
+import { ArrowLeft, FileText, Calendar, HardDrive, Code, Table, GitBranch, ListChecks } from 'lucide-react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { MarkdownRenderer } from '@/components/shared/MarkdownRenderer'
 import { RefreshButton } from '@/components/shared/RefreshButton'
 import { usePlansApi } from '@/hooks/usePlansApi'
+import { useProviderContext } from '@/contexts/ProviderContext'
 import { formatBytes } from '@/types/backup'
 import type { PlanDetail } from '@/types/plans'
 
@@ -14,9 +15,18 @@ export function PlanDetailPage() {
   const { filename } = useParams<{ filename: string }>()
   const navigate = useNavigate()
   const { getPlan } = usePlansApi()
+  const { selectedProviderId } = useProviderContext()
+  const previousProviderId = useRef(selectedProviderId)
   const [plan, setPlan] = useState<PlanDetail | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (previousProviderId.current !== selectedProviderId) {
+      previousProviderId.current = selectedProviderId
+      navigate('/plans', { replace: true })
+    }
+  }, [navigate, selectedProviderId])
 
   const fetchPlan = useCallback(async () => {
     if (!filename) return
@@ -70,6 +80,8 @@ export function PlanDetailPage() {
     )
   }
 
+  const isCodex = plan.source === 'codex-cli'
+
   return (
     <div className="space-y-6">
       {/* Header */}
@@ -80,6 +92,14 @@ export function PlanDetailPage() {
             <FileText className="h-8 w-8" />
             {plan.title}
           </h1>
+          <div className="flex flex-wrap gap-2 mt-2">
+            <Badge variant="outline">{plan.source_label}</Badge>
+            {isCodex && plan.step_count != null && (
+              <Badge variant="secondary">
+                {plan.step_count} step{plan.step_count !== 1 ? 's' : ''}
+              </Badge>
+            )}
+          </div>
           <div className="flex items-center gap-3 mt-2 text-sm text-muted-foreground">
             <span className="flex items-center gap-1" title={new Date(plan.modified_at).toLocaleString()}>
               <Calendar className="h-3 w-3" />
@@ -89,6 +109,12 @@ export function PlanDetailPage() {
               <HardDrive className="h-3 w-3" />
               {formatBytes(plan.size_bytes)}
             </span>
+            {isCodex && plan.history_count != null && (
+              <span className="flex items-center gap-1">
+                <ListChecks className="h-3 w-3" />
+                {plan.history_count} update{plan.history_count !== 1 ? 's' : ''}
+              </span>
+            )}
             {plan.code_block_count > 0 && (
               <span className="flex items-center gap-1">
                 <Code className="h-3 w-3" />
@@ -103,7 +129,7 @@ export function PlanDetailPage() {
             )}
           </div>
           <p className="text-xs text-muted-foreground mt-1 font-mono">
-            {plan.filename}
+            {isCodex ? plan.session_id ?? plan.filename : plan.filename}
           </p>
         </div>
         <RefreshButton onClick={fetchPlan} loading={loading} />
@@ -139,14 +165,39 @@ export function PlanDetailPage() {
         <CardHeader>
           <CardTitle className="text-sm flex items-center gap-2">
             <GitBranch className="h-4 w-4" />
-            Linked Sessions
+            {isCodex ? 'Source Session' : 'Linked Sessions'}
           </CardTitle>
           <CardDescription>
-            Sessions that used this plan (matched by slug: {plan.slug})
+            {isCodex
+              ? 'Codex thread metadata used to locate this update_plan snapshot'
+              : `Sessions that used this plan (matched by slug: ${plan.slug})`}
           </CardDescription>
         </CardHeader>
         <CardContent>
-          {plan.linked_sessions.length === 0 ? (
+          {isCodex ? (
+            <div className="space-y-3">
+              <div className="flex items-center justify-between p-3 border rounded-lg gap-4">
+                <div className="space-y-1 min-w-0">
+                  <p className="text-sm font-mono truncate">
+                    {plan.session_id ?? 'Unknown Codex thread'}
+                  </p>
+                  {plan.project_path && (
+                    <p className="text-xs text-muted-foreground truncate">
+                      {plan.project_path}
+                    </p>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  {plan.git_branch && (
+                    <Badge variant="outline" className="text-xs">
+                      <GitBranch className="h-3 w-3 mr-1" />
+                      {plan.git_branch}
+                    </Badge>
+                  )}
+                </div>
+              </div>
+            </div>
+          ) : plan.linked_sessions.length === 0 ? (
             <p className="text-sm text-muted-foreground">No linked sessions found</p>
           ) : (
             <div className="space-y-3">

--- a/frontend/src/features/plans/PlansPage.tsx
+++ b/frontend/src/features/plans/PlansPage.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input'
 import { Badge } from '@/components/ui/badge'
 import { RefreshButton } from '@/components/shared/RefreshButton'
 import { usePlansApi } from '@/hooks/usePlansApi'
+import { useProviderContext } from '@/contexts/ProviderContext'
 import { CLICKABLE_CARD } from '@/lib/constants'
 import { formatBytes } from '@/types/backup'
 import type { PlanSummary, PlanStatsResponse } from '@/types/plans'
@@ -55,6 +56,7 @@ function groupByDate(plans: PlanSummary[]): { label: string; plans: PlanSummary[
 export function PlansPage() {
   const navigate = useNavigate()
   const { listPlans, getStats } = usePlansApi()
+  const { selectedProviderId } = useProviderContext()
   const [plans, setPlans] = useState<PlanSummary[]>([])
   const [stats, setStats] = useState<PlanStatsResponse | null>(null)
   const [loading, setLoading] = useState(true)
@@ -82,18 +84,36 @@ export function PlansPage() {
     fetchData()
   }, [fetchData])
 
+  const providerPlans = useMemo(
+    () => plans.filter((plan) => (plan.source ?? 'claude-code') === selectedProviderId),
+    [plans, selectedProviderId],
+  )
+  const providerStats = stats?.source === selectedProviderId ? stats : null
+
   // Client-side filtering by search query
   const filteredPlans = useMemo(() => {
-    if (!searchQuery.trim()) return plans
+    if (!searchQuery.trim()) return providerPlans
     const q = searchQuery.toLowerCase()
-    return plans.filter(
+    return providerPlans.filter(
       p => p.title.toLowerCase().includes(q) ||
            p.excerpt.toLowerCase().includes(q) ||
            p.slug.toLowerCase().includes(q)
     )
-  }, [plans, searchQuery])
+  }, [providerPlans, searchQuery])
 
   const grouped = useMemo(() => groupByDate(filteredPlans), [filteredPlans])
+  const isCodex = selectedProviderId === 'codex-cli'
+  const sourceDescription = isCodex
+    ? 'Browse Codex update_plan snapshots from local session history'
+    : 'Browse and search your Claude Code execution plans'
+  const planNoun = isCodex ? 'Plan Snapshots' : 'Total Plans'
+  const sizeDescription = isCodex ? 'Source JSONL data' : 'Combined plan files'
+  const emptyText = isCodex
+    ? 'No Codex plan snapshots found'
+    : 'No plans found'
+  const searchPlaceholder = isCodex
+    ? 'Search snapshots by step, repo, or session...'
+    : 'Search plans by title, content, or slug...'
 
   return (
     <div className="space-y-6">
@@ -104,7 +124,7 @@ export function PlansPage() {
             Plans
           </h1>
           <p className="text-muted-foreground">
-            Browse and search your Claude Code execution plans
+            {sourceDescription}
           </p>
         </div>
         <RefreshButton onClick={fetchData} loading={loading} />
@@ -120,16 +140,16 @@ export function PlansPage() {
       )}
 
       {/* Stats Row */}
-      {stats && (
+      {providerStats && (
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <Card>
             <CardHeader className="pb-2">
-              <CardDescription>Total Plans</CardDescription>
-              <CardTitle className="text-3xl">{stats.total_plans}</CardTitle>
+              <CardDescription>{planNoun}</CardDescription>
+              <CardTitle className="text-3xl">{providerStats.total_plans}</CardTitle>
             </CardHeader>
             <CardContent>
               <p className="text-xs text-muted-foreground">
-                Execution plan files
+                {isCodex ? 'Latest snapshots per Codex thread' : 'Execution plan files'}
               </p>
             </CardContent>
           </Card>
@@ -138,28 +158,28 @@ export function PlansPage() {
             <CardHeader className="pb-2">
               <CardDescription>Date Range</CardDescription>
               <CardTitle className="text-lg">
-                {stats.oldest_date
-                  ? `${new Date(stats.oldest_date).toLocaleDateString()} — ${new Date(stats.newest_date!).toLocaleDateString()}`
+                {providerStats.oldest_date
+                  ? `${new Date(providerStats.oldest_date).toLocaleDateString()} — ${new Date(providerStats.newest_date!).toLocaleDateString()}`
                   : 'No plans'}
               </CardTitle>
             </CardHeader>
             <CardContent>
               <div className="flex items-center gap-1 text-xs text-muted-foreground">
                 <Calendar className="h-3 w-3" />
-                <span>First to latest plan</span>
+                <span>{isCodex ? 'First to latest snapshot' : 'First to latest plan'}</span>
               </div>
             </CardContent>
           </Card>
 
           <Card>
             <CardHeader className="pb-2">
-              <CardDescription>Total Size</CardDescription>
-              <CardTitle className="text-3xl">{formatBytes(stats.total_size_bytes)}</CardTitle>
+              <CardDescription>{isCodex ? 'Source Size' : 'Total Size'}</CardDescription>
+              <CardTitle className="text-3xl">{formatBytes(providerStats.total_size_bytes)}</CardTitle>
             </CardHeader>
             <CardContent>
               <div className="flex items-center gap-1 text-xs text-muted-foreground">
                 <HardDrive className="h-3 w-3" />
-                <span>Combined plan files</span>
+                <span>{sizeDescription}</span>
               </div>
             </CardContent>
           </Card>
@@ -170,7 +190,7 @@ export function PlansPage() {
       <div className="relative">
         <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
         <Input
-          placeholder="Search plans by title, content, or slug..."
+          placeholder={searchPlaceholder}
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           className="pl-10"
@@ -178,7 +198,7 @@ export function PlansPage() {
       </div>
 
       {/* Plan List */}
-      {loading && plans.length === 0 ? (
+      {loading && providerPlans.length === 0 ? (
         <Card>
           <CardContent className="py-8">
             <p className="text-center text-muted-foreground">Loading plans...</p>
@@ -188,7 +208,7 @@ export function PlansPage() {
         <Card>
           <CardContent className="py-8">
             <p className="text-center text-muted-foreground">
-              {searchQuery ? 'No plans match your search' : 'No plans found'}
+              {searchQuery ? 'No plans match your search' : emptyText}
             </p>
           </CardContent>
         </Card>
@@ -222,6 +242,22 @@ export function PlansPage() {
                           <p className="text-sm text-muted-foreground line-clamp-2">
                             {plan.excerpt}
                           </p>
+                          {isCodex && plan.step_count != null && (
+                            <div className="flex flex-wrap gap-2 mt-2">
+                              <Badge variant="secondary" className="text-xs">
+                                {plan.step_count} step{plan.step_count !== 1 ? 's' : ''}
+                              </Badge>
+                              <Badge variant="outline" className="text-xs">
+                                {plan.completed_count ?? 0} completed
+                              </Badge>
+                              <Badge variant="outline" className="text-xs">
+                                {plan.in_progress_count ?? 0} active
+                              </Badge>
+                              <Badge variant="outline" className="text-xs">
+                                {plan.pending_count ?? 0} pending
+                              </Badge>
+                            </div>
+                          )}
                         </div>
                         <div className="flex flex-col items-end gap-1 flex-shrink-0">
                           <span
@@ -231,7 +267,7 @@ export function PlansPage() {
                             {formatRelativeDate(plan.modified_at)}
                           </span>
                           <Badge variant="outline" className="text-xs">
-                            {formatBytes(plan.size_bytes)}
+                            {isCodex ? plan.source_label : formatBytes(plan.size_bytes)}
                           </Badge>
                         </div>
                       </div>

--- a/frontend/src/hooks/usePlansApi.ts
+++ b/frontend/src/hooks/usePlansApi.ts
@@ -4,6 +4,7 @@
 import { useCallback } from 'react'
 import { apiClient, buildEndpoint } from '@/lib/api'
 import { useProjectContext } from '@/contexts/ProjectContext'
+import { useProviderContext } from '@/contexts/ProviderContext'
 import type {
   PlanListResponse,
   PlanDetailResponse,
@@ -13,35 +14,44 @@ import type {
 
 export function usePlansApi() {
   const { activeProject } = useProjectContext()
+  const { selectedProviderId } = useProviderContext()
 
   const listPlans = useCallback(async () => {
     return apiClient<PlanListResponse>(
-      buildEndpoint('plans', { project_path: activeProject?.path })
+      buildEndpoint('plans', {
+        project_path: activeProject?.path,
+        provider: selectedProviderId,
+      })
     )
-  }, [activeProject?.path])
+  }, [activeProject?.path, selectedProviderId])
 
   const getPlan = useCallback(async (filename: string) => {
     return apiClient<PlanDetailResponse>(
       buildEndpoint(`plans/${encodeURIComponent(filename)}`, {
         project_path: activeProject?.path,
+        provider: selectedProviderId,
       })
     )
-  }, [activeProject?.path])
+  }, [activeProject?.path, selectedProviderId])
 
   const searchPlans = useCallback(async (query: string) => {
     return apiClient<PlanSearchResponse>(
       buildEndpoint('plans/search', {
         q: query,
         project_path: activeProject?.path,
+        provider: selectedProviderId,
       })
     )
-  }, [activeProject?.path])
+  }, [activeProject?.path, selectedProviderId])
 
   const getStats = useCallback(async () => {
     return apiClient<PlanStatsResponse>(
-      buildEndpoint('plans/stats', { project_path: activeProject?.path })
+      buildEndpoint('plans/stats', {
+        project_path: activeProject?.path,
+        provider: selectedProviderId,
+      })
     )
-  }, [activeProject?.path])
+  }, [activeProject?.path, selectedProviderId])
 
   return {
     listPlans,

--- a/frontend/src/types/plans.ts
+++ b/frontend/src/types/plans.ts
@@ -7,6 +7,16 @@ export interface PlanSummary {
   excerpt: string
   modified_at: string
   size_bytes: number
+  source: string
+  source_label: string
+  project_path?: string | null
+  session_id?: string | null
+  git_branch?: string | null
+  step_count?: number | null
+  pending_count?: number | null
+  in_progress_count?: number | null
+  completed_count?: number | null
+  history_count?: number | null
 }
 
 export interface PlanLinkedSession {
@@ -29,6 +39,17 @@ export interface PlanDetail {
   code_block_count: number
   table_count: number
   linked_sessions: PlanLinkedSession[]
+  source: string
+  source_label: string
+  project_path?: string | null
+  session_id?: string | null
+  git_branch?: string | null
+  git_sha?: string | null
+  step_count?: number | null
+  pending_count?: number | null
+  in_progress_count?: number | null
+  completed_count?: number | null
+  history_count?: number | null
 }
 
 export interface PlanSearchResult {
@@ -37,6 +58,8 @@ export interface PlanSearchResult {
   title: string
   matches: string[]
   modified_at: string
+  source: string
+  source_label: string
 }
 
 export interface PlanListResponse {
@@ -59,4 +82,6 @@ export interface PlanStatsResponse {
   oldest_date: string | null
   newest_date: string | null
   total_size_bytes: number
+  source: string
+  source_label: string
 }

--- a/frontend/src/types/providers.ts
+++ b/frontend/src/types/providers.ts
@@ -20,6 +20,7 @@ export interface AgentProviderCapabilities {
   context: boolean
   doctor: boolean
   backup: boolean
+  plans: boolean
 }
 
 export type AgentProviderCapabilityState = 'supported' | 'read_only' | 'write_capable' | 'unsupported' | 'unknown'


### PR DESCRIPTION
## Summary
- add provider-aware Plans API support for Codex update_plan snapshots
- surface Codex snapshots with source-specific copy, step counts, and detail rendering
- add a read-only plans provider capability and privacy-focused backend tests

## Verification
- backend/venv/bin/pytest backend/tests
- npm run build
- npx eslint src/features/plans/PlansPage.tsx src/features/plans/PlanDetailPage.tsx src/hooks/usePlansApi.ts src/contexts/DashboardContext.tsx src/components/layout/Sidebar.tsx src/features/dashboard/DashboardPage.tsx src/types/plans.ts src/types/providers.ts

Closes #200