### PR TITLE
Support same-repo Agent Mail participants

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -57,46 +57,233 @@ async def get_db() -> AsyncSession:
             await session.close()
 
 
+def _sqlite_ident(name: str) -> str:
+    return '"' + name.replace('"', '""') + '"'
+
+
+async def _sqlite_columns(conn, table_name: str) -> set[str]:
+    result = await conn.execute(text(f"PRAGMA table_info({_sqlite_ident(table_name)})"))
+    return {row[1] for row in result.fetchall()}
+
+
+async def _sqlite_has_unique_repo_id_index(conn) -> bool:
+    result = await conn.execute(text("PRAGMA index_list(mail_team_members)"))
+    for row in result.fetchall():
+        index_name = row[1]
+        is_unique = bool(row[2])
+        if not is_unique:
+            continue
+        info = await conn.execute(text(f"PRAGMA index_info({_sqlite_ident(index_name)})"))
+        if [index_row[2] for index_row in info.fetchall()] == ["repo_id"]:
+            return True
+    return False
+
+
+async def _sqlite_rebuild_mail_team_members(conn, columns: set[str]) -> None:
+    """Replace the legacy repo-unique table without losing referencing rows."""
+    await conn.commit()
+    await conn.execute(text("PRAGMA foreign_keys=OFF"))
+    await conn.commit()
+
+    identity_expr = (
+        "COALESCE(NULLIF(identity_key, ''), 'repo:' || repo_id)"
+        if "identity_key" in columns
+        else "'repo:' || repo_id"
+    )
+    participant_kind_expr = (
+        "COALESCE(NULLIF(participant_kind, ''), 'repo')"
+        if "participant_kind" in columns
+        else "'repo'"
+    )
+    team_preset_expr = "team_preset_id" if "team_preset_id" in columns else "NULL"
+    team_slot_expr = "team_slot_id" if "team_slot_id" in columns else "NULL"
+    last_inbox_expr = (
+        "last_inbox_checked_at" if "last_inbox_checked_at" in columns else "NULL"
+    )
+
+    await conn.execute(text("DROP TABLE IF EXISTS mail_team_members_new"))
+    await conn.execute(
+        text(
+            """
+            CREATE TABLE mail_team_members_new (
+                id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+                identity_key VARCHAR NOT NULL,
+                repo_id VARCHAR NOT NULL,
+                repo_path VARCHAR NOT NULL,
+                repo_name VARCHAR NOT NULL,
+                display_name VARCHAR NOT NULL,
+                participant_kind VARCHAR NOT NULL,
+                team_preset_id INTEGER,
+                team_slot_id INTEGER,
+                role VARCHAR,
+                charter VARCHAR,
+                last_inbox_checked_at DATETIME,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL,
+                FOREIGN KEY(team_preset_id) REFERENCES agent_team_presets (id) ON DELETE SET NULL,
+                FOREIGN KEY(team_slot_id) REFERENCES agent_team_slots (id) ON DELETE SET NULL
+            )
+            """
+        )
+    )
+    await conn.execute(
+        text(
+            f"""
+            INSERT INTO mail_team_members_new (
+                id,
+                identity_key,
+                repo_id,
+                repo_path,
+                repo_name,
+                display_name,
+                participant_kind,
+                team_preset_id,
+                team_slot_id,
+                role,
+                charter,
+                last_inbox_checked_at,
+                created_at,
+                updated_at
+            )
+            SELECT
+                id,
+                {identity_expr},
+                repo_id,
+                repo_path,
+                repo_name,
+                display_name,
+                {participant_kind_expr},
+                {team_preset_expr},
+                {team_slot_expr},
+                role,
+                charter,
+                {last_inbox_expr},
+                created_at,
+                updated_at
+            FROM mail_team_members
+            """
+        )
+    )
+    await conn.execute(text("DROP TABLE mail_team_members"))
+    await conn.execute(text("ALTER TABLE mail_team_members_new RENAME TO mail_team_members"))
+    await conn.execute(
+        text(
+            "CREATE UNIQUE INDEX ix_mail_team_members_identity_key "
+            "ON mail_team_members (identity_key)"
+        )
+    )
+    await conn.execute(text("CREATE INDEX ix_mail_team_members_repo_id ON mail_team_members (repo_id)"))
+    await conn.execute(
+        text("CREATE INDEX ix_mail_team_members_team_preset_id ON mail_team_members (team_preset_id)")
+    )
+    await conn.execute(
+        text("CREATE INDEX ix_mail_team_members_team_slot_id ON mail_team_members (team_slot_id)")
+    )
+    await conn.commit()
+    await conn.execute(text("PRAGMA foreign_keys=ON"))
+    await conn.commit()
+
+
+async def _run_sqlite_compat_migrations(conn) -> None:
+    columns = await _sqlite_columns(conn, "mail_team_members")
+    if columns:
+        if await _sqlite_has_unique_repo_id_index(conn):
+            await _sqlite_rebuild_mail_team_members(conn, columns)
+            columns = await _sqlite_columns(conn, "mail_team_members")
+        if "identity_key" not in columns:
+            await conn.execute(text("ALTER TABLE mail_team_members ADD COLUMN identity_key VARCHAR"))
+        if "participant_kind" not in columns:
+            await conn.execute(
+                text(
+                    "ALTER TABLE mail_team_members "
+                    "ADD COLUMN participant_kind VARCHAR DEFAULT 'repo'"
+                )
+            )
+        if "team_preset_id" not in columns:
+            await conn.execute(text("ALTER TABLE mail_team_members ADD COLUMN team_preset_id INTEGER"))
+        if "team_slot_id" not in columns:
+            await conn.execute(text("ALTER TABLE mail_team_members ADD COLUMN team_slot_id INTEGER"))
+        if "last_inbox_checked_at" not in columns:
+            await conn.execute(
+                text("ALTER TABLE mail_team_members ADD COLUMN last_inbox_checked_at DATETIME")
+            )
+        await conn.execute(
+            text(
+                "UPDATE mail_team_members "
+                "SET identity_key = 'repo:' || repo_id "
+                "WHERE identity_key IS NULL OR identity_key = ''"
+            )
+        )
+        await conn.execute(
+            text(
+                "UPDATE mail_team_members "
+                "SET participant_kind = 'repo' "
+                "WHERE participant_kind IS NULL OR participant_kind = ''"
+            )
+        )
+        await conn.execute(
+            text(
+                "CREATE UNIQUE INDEX IF NOT EXISTS ix_mail_team_members_identity_key "
+                "ON mail_team_members (identity_key)"
+            )
+        )
+        await conn.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS ix_mail_team_members_repo_id "
+                "ON mail_team_members (repo_id)"
+            )
+        )
+        await conn.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS ix_mail_team_members_team_preset_id "
+                "ON mail_team_members (team_preset_id)"
+            )
+        )
+        await conn.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS ix_mail_team_members_team_slot_id "
+                "ON mail_team_members (team_slot_id)"
+            )
+        )
+
+    result = await conn.execute(text("PRAGMA table_info(mail_agent_sessions)"))
+    session_columns = {row[1] for row in result.fetchall()}
+    if session_columns and "team_preset_id" not in session_columns:
+        await conn.execute(
+            text("ALTER TABLE mail_agent_sessions ADD COLUMN team_preset_id INTEGER")
+        )
+    if session_columns and "team_slot_id" not in session_columns:
+        await conn.execute(text("ALTER TABLE mail_agent_sessions ADD COLUMN team_slot_id INTEGER"))
+
+    result = await conn.execute(text("PRAGMA table_info(agent_team_slots)"))
+    slot_columns = {row[1] for row in result.fetchall()}
+    if slot_columns and "bootstrap_prompt" not in slot_columns:
+        await conn.execute(
+            text("ALTER TABLE agent_team_slots ADD COLUMN bootstrap_prompt VARCHAR")
+        )
+
+    result = await conn.execute(text("PRAGMA table_info(agent_team_launch_items)"))
+    launch_item_columns = {row[1] for row in result.fetchall()}
+    if launch_item_columns and "message" not in launch_item_columns:
+        await conn.execute(
+            text("ALTER TABLE agent_team_launch_items ADD COLUMN message VARCHAR")
+        )
+    if launch_item_columns and "block_code" not in launch_item_columns:
+        await conn.execute(
+            text("ALTER TABLE agent_team_launch_items ADD COLUMN block_code VARCHAR")
+        )
+
+    result = await conn.execute(text("PRAGMA table_info(mail_messages)"))
+    message_columns = {row[1] for row in result.fetchall()}
+    if message_columns and "sender_actor_id" not in message_columns:
+        await conn.execute(text("ALTER TABLE mail_messages ADD COLUMN sender_actor_id INTEGER"))
+    await conn.commit()
+
+
 async def init_db() -> None:
     """Initialize database tables."""
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
-        if settings.database_url.startswith("sqlite"):
-            result = await conn.execute(text("PRAGMA table_info(mail_team_members)"))
-            columns = {row[1] for row in result.fetchall()}
-            if columns and "last_inbox_checked_at" not in columns:
-                await conn.execute(
-                    text("ALTER TABLE mail_team_members ADD COLUMN last_inbox_checked_at DATETIME")
-                )
-            result = await conn.execute(text("PRAGMA table_info(mail_agent_sessions)"))
-            session_columns = {row[1] for row in result.fetchall()}
-            if session_columns and "team_preset_id" not in session_columns:
-                await conn.execute(
-                    text("ALTER TABLE mail_agent_sessions ADD COLUMN team_preset_id INTEGER")
-                )
-            if session_columns and "team_slot_id" not in session_columns:
-                await conn.execute(
-                    text("ALTER TABLE mail_agent_sessions ADD COLUMN team_slot_id INTEGER")
-                )
-            result = await conn.execute(text("PRAGMA table_info(agent_team_slots)"))
-            slot_columns = {row[1] for row in result.fetchall()}
-            if slot_columns and "bootstrap_prompt" not in slot_columns:
-                await conn.execute(
-                    text("ALTER TABLE agent_team_slots ADD COLUMN bootstrap_prompt VARCHAR")
-                )
-            result = await conn.execute(text("PRAGMA table_info(agent_team_launch_items)"))
-            launch_item_columns = {row[1] for row in result.fetchall()}
-            if launch_item_columns and "message" not in launch_item_columns:
-                await conn.execute(
-                    text("ALTER TABLE agent_team_launch_items ADD COLUMN message VARCHAR")
-                )
-            if launch_item_columns and "block_code" not in launch_item_columns:
-                await conn.execute(
-                    text("ALTER TABLE agent_team_launch_items ADD COLUMN block_code VARCHAR")
-                )
-            result = await conn.execute(text("PRAGMA table_info(mail_messages)"))
-            message_columns = {row[1] for row in result.fetchall()}
-            if message_columns and "sender_actor_id" not in message_columns:
-                await conn.execute(
-                    text("ALTER TABLE mail_messages ADD COLUMN sender_actor_id INTEGER")
-                )
+    if settings.database_url.startswith("sqlite"):
+        async with engine.connect() as conn:
+            await _run_sqlite_compat_migrations(conn)

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -252,15 +252,23 @@ class AgentTeamLaunchItem(Base):
 
 
 class MailTeamMember(Base):
-    """Durable Agent Mail team identity, keyed by repository."""
+    """Durable Agent Mail routable participant, grouped by repository."""
 
     __tablename__ = "mail_team_members"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    repo_id: Mapped[str] = mapped_column(String, unique=True, index=True, nullable=False)
+    identity_key: Mapped[str] = mapped_column(String, unique=True, index=True, nullable=False)
+    repo_id: Mapped[str] = mapped_column(String, index=True, nullable=False)
     repo_path: Mapped[str] = mapped_column(String, nullable=False)
     repo_name: Mapped[str] = mapped_column(String, nullable=False)
     display_name: Mapped[str] = mapped_column(String, nullable=False)
+    participant_kind: Mapped[str] = mapped_column(String, default="repo", nullable=False)
+    team_preset_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("agent_team_presets.id", ondelete="SET NULL"), nullable=True
+    )
+    team_slot_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("agent_team_slots.id", ondelete="SET NULL"), nullable=True
+    )
     role: Mapped[str | None] = mapped_column(String, nullable=True)
     charter: Mapped[str | None] = mapped_column(String, nullable=True)
     last_inbox_checked_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1891,10 +1891,16 @@ class MailMemberResponse(BaseModel):
     """Durable team member with derived status and inbox counts."""
 
     id: int
+    identity_key: str
     repo_id: str
     repo_path: str
     repo_name: str
     display_name: str
+    participant_kind: str = "repo"
+    team_preset_id: Optional[int] = None
+    team_preset_name: Optional[str] = None
+    team_slot_id: Optional[int] = None
+    team_slot_name: Optional[str] = None
     role: Optional[str] = None
     charter: Optional[str] = None
     status: str

--- a/backend/app/services/agent_mail_service.py
+++ b/backend/app/services/agent_mail_service.py
@@ -52,33 +52,125 @@ class AgentMailService:
     def __init__(self) -> None:
         self._last_auto_nudge_at: dict[int, datetime] = {}
 
-    async def _get_or_create_member(self, db: AsyncSession, cwd: str) -> MailTeamMember:
+    def _repo_member_values(self, cwd: str) -> dict[str, str | int | None]:
         ident = derive_repo_identity(cwd)
+        return {
+            "identity_key": f"repo:{ident['repo_id']}",
+            "repo_id": ident["repo_id"],
+            "repo_path": ident["repo_root"],
+            "repo_name": ident["repo_name"],
+            "display_name": ident["repo_name"],
+            "participant_kind": "repo",
+            "team_preset_id": None,
+            "team_slot_id": None,
+            "role": None,
+            "charter": None,
+        }
+
+    def _slot_identity_key(self, slot: AgentTeamSlot) -> str:
+        created_at = slot.created_at.isoformat(timespec="microseconds")
+        return f"slot:{slot.preset_id}:{slot.id}:{created_at}"
+
+    def _slot_member_values(self, slot: AgentTeamSlot) -> dict[str, str | int | None]:
+        return {
+            "identity_key": self._slot_identity_key(slot),
+            "repo_id": slot.repo_id,
+            "repo_path": slot.repo_path,
+            "repo_name": slot.repo_name,
+            "display_name": slot.display_name,
+            "participant_kind": "team_slot",
+            "team_preset_id": slot.preset_id,
+            "team_slot_id": slot.id,
+            "role": slot.role,
+            "charter": slot.charter,
+        }
+
+    async def _registration_member_values(
+        self,
+        db: AsyncSession,
+        request: MailAgentRegisterRequest,
+        team_preset_id: int | None,
+        team_slot_id: int | None,
+    ) -> dict[str, str | int | None]:
+        if team_slot_id is not None:
+            slot = await db.get(AgentTeamSlot, team_slot_id)
+            if slot is not None and self._slot_matches_registration(slot, request):
+                return self._slot_member_values(slot)
+        values = self._repo_member_values(request.cwd)
+        if team_preset_id is not None:
+            values["team_preset_id"] = team_preset_id
+        return values
+
+    async def _get_or_create_member_by_values(
+        self,
+        db: AsyncSession,
+        values: dict[str, str | int | None],
+    ) -> MailTeamMember:
         result = await db.execute(
-            select(MailTeamMember).where(MailTeamMember.repo_id == ident["repo_id"])
+            select(MailTeamMember).where(MailTeamMember.identity_key == values["identity_key"])
         )
         member = result.scalar_one_or_none()
         if member is None:
-            member = MailTeamMember(
-                repo_id=ident["repo_id"],
-                repo_path=ident["repo_root"],
-                repo_name=ident["repo_name"],
-                display_name=ident["repo_name"],
-            )
+            member = MailTeamMember(**values)
             db.add(member)
             await db.flush()
+        else:
+            member.repo_id = str(values["repo_id"])
+            member.repo_path = str(values["repo_path"])
+            member.repo_name = str(values["repo_name"])
+            member.participant_kind = str(values["participant_kind"])
+            member.team_preset_id = values["team_preset_id"]  # type: ignore[assignment]
+            member.team_slot_id = values["team_slot_id"]  # type: ignore[assignment]
+            if member.participant_kind == "team_slot":
+                member.display_name = str(values["display_name"])
+                member.role = values["role"]  # type: ignore[assignment]
+                member.charter = values["charter"]  # type: ignore[assignment]
+            member.updated_at = datetime.utcnow()
         return member
+
+    async def _get_or_create_repo_member(self, db: AsyncSession, cwd: str) -> MailTeamMember:
+        return await self._get_or_create_member_by_values(db, self._repo_member_values(cwd))
+
+    async def get_or_create_repo_member(self, db: AsyncSession, cwd: str) -> MailTeamMember:
+        return await self._get_or_create_repo_member(db, cwd)
+
+    async def get_or_create_slot_member(
+        self,
+        db: AsyncSession,
+        slot: AgentTeamSlot,
+    ) -> MailTeamMember:
+        return await self._get_or_create_member_by_values(db, self._slot_member_values(slot))
 
     async def register_session(
         self, db: AsyncSession, request: MailAgentRegisterRequest
     ) -> tuple[MailTeamMember, MailAgentSession]:
-        member = await self._get_or_create_member(db, request.cwd)
         has_team_context = request.team_preset_id is not None or request.team_slot_id is not None
         team_preset_id, team_slot_id = await self._resolve_team_context(db, request)
         result = await db.execute(
             select(MailAgentSession).where(MailAgentSession.session_key == request.session_key)
         )
         session = result.scalar_one_or_none()
+        if not has_team_context and session is not None and session.team_slot_id is not None:
+            existing_member = await db.get(MailTeamMember, session.member_id)
+            if existing_member is not None and await self._session_team_context_matches_registration(
+                db,
+                session,
+                existing_member,
+                request,
+            ):
+                member = existing_member
+                team_preset_id = session.team_preset_id
+                team_slot_id = session.team_slot_id
+            else:
+                member = await self._get_or_create_member_by_values(
+                    db,
+                    await self._registration_member_values(db, request, team_preset_id, team_slot_id),
+                )
+        else:
+            member = await self._get_or_create_member_by_values(
+                db,
+                await self._registration_member_values(db, request, team_preset_id, team_slot_id),
+            )
         if session is None:
             session = MailAgentSession(
                 member_id=member.id,
@@ -90,15 +182,33 @@ class AgentMailService:
         session.provider = request.provider
         session.cwd = request.cwd
         session.pid = request.pid
-        if has_team_context:
-            session.team_preset_id = team_preset_id
-            session.team_slot_id = team_slot_id
+        session.team_preset_id = team_preset_id
+        session.team_slot_id = team_slot_id
         session.mailbox_status = "connected"
         session.last_seen_at = datetime.utcnow()
         await db.commit()
         await db.refresh(member)
         await db.refresh(session)
         return member, session
+
+    async def _session_team_context_matches_registration(
+        self,
+        db: AsyncSession,
+        session: MailAgentSession,
+        member: MailTeamMember,
+        request: MailAgentRegisterRequest,
+    ) -> bool:
+        if session.team_slot_id is None or member.participant_kind != "team_slot":
+            return False
+        if member.team_slot_id != session.team_slot_id:
+            return False
+        slot = await db.get(AgentTeamSlot, session.team_slot_id)
+        if slot is None or slot.provider != request.provider:
+            return False
+        try:
+            return derive_repo_identity(request.cwd)["repo_id"] == slot.repo_id
+        except Exception:
+            return False
 
     async def _resolve_team_context(
         self,
@@ -110,19 +220,26 @@ class AgentMailService:
             if slot is not None and (
                 request.team_preset_id is None or request.team_preset_id == slot.preset_id
             ):
-                if request.provider != slot.provider:
-                    return None, None
-                try:
-                    if derive_repo_identity(request.cwd)["repo_id"] == slot.repo_id:
-                        return slot.preset_id, slot.id
-                except Exception:
-                    return None, None
+                if self._slot_matches_registration(slot, request):
+                    return slot.preset_id, slot.id
             return None, None
         if request.team_preset_id is not None:
             preset = await db.get(AgentTeamPreset, request.team_preset_id)
             if preset is not None:
                 return preset.id, None
         return None, None
+
+    def _slot_matches_registration(
+        self,
+        slot: AgentTeamSlot,
+        request: MailAgentRegisterRequest,
+    ) -> bool:
+        if request.provider != slot.provider:
+            return False
+        try:
+            return derive_repo_identity(request.cwd)["repo_id"] == slot.repo_id
+        except Exception:
+            return False
 
     async def heartbeat_session(
         self, db: AsyncSession, session_key: str, activity: Optional[str] = None
@@ -175,18 +292,21 @@ class AgentMailService:
             logger.warning("agent bridge discovery failed: %s", exc)
             return
         active_observed_keys: set[str] = set()
+        affected_member_ids: set[int] = set()
         for info in discovered:
             pane_id = info.get("pane_id")
             cwd = info.get("cwd")
             if not pane_id or not cwd:
                 continue
-            member = await self._get_or_create_member(db, cwd)
             session_key = f"tmux:{pane_id}"
             active_observed_keys.add(session_key)
             result = await db.execute(
                 select(MailAgentSession).where(MailAgentSession.session_key == session_key)
             )
             session = result.scalar_one_or_none()
+            member = await self._member_for_existing_observed_session(db, session, info)
+            if member is None:
+                member = await self._member_for_observed_session(db, info)
             if session is None:
                 session = MailAgentSession(
                     member_id=member.id,
@@ -194,6 +314,8 @@ class AgentMailService:
                     session_key=session_key,
                 )
                 db.add(session)
+            elif session.member_id != member.id:
+                affected_member_ids.add(session.member_id)
             session.member_id = member.id
             session.provider = info.get("provider", "unknown")
             session.cwd = cwd
@@ -203,10 +325,107 @@ class AgentMailService:
                 session.pid = int(info.get("pid") or 0) or None
             except (TypeError, ValueError):
                 session.pid = None
+            session.team_preset_id = member.team_preset_id
+            session.team_slot_id = member.team_slot_id
             session.mailbox_status = "observed"
             session.last_seen_at = datetime.utcnow()
         await self._remove_stale_observed_sessions(db, active_observed_keys)
+        for member_id in affected_member_ids:
+            await self._remove_empty_observed_member(db, member_id)
         await db.commit()
+
+    async def _member_for_observed_session(
+        self,
+        db: AsyncSession,
+        info: dict,
+    ) -> MailTeamMember:
+        cwd = str(info.get("cwd") or "")
+        provider = str(info.get("provider") or "unknown")
+        pid = None
+        try:
+            pid = int(info.get("pid") or 0) or None
+        except (TypeError, ValueError):
+            pid = None
+
+        if pid is not None:
+            now = datetime.utcnow()
+            result = await db.execute(
+                select(MailAgentSession)
+                .where(
+                    MailAgentSession.source != "observed",
+                    MailAgentSession.provider == provider,
+                    MailAgentSession.pid == pid,
+                )
+                .order_by(MailAgentSession.last_seen_at.desc())
+                .limit(1)
+            )
+            registered_session = result.scalar_one_or_none()
+            if registered_session is not None and self._registered_session_matches_observed(
+                registered_session,
+                info,
+                now,
+            ):
+                member = await db.get(MailTeamMember, registered_session.member_id)
+                if member is not None:
+                    return member
+
+        return await self._get_or_create_repo_member(db, cwd)
+
+    async def _member_for_existing_observed_session(
+        self,
+        db: AsyncSession,
+        session: MailAgentSession | None,
+        info: dict,
+    ) -> MailTeamMember | None:
+        if session is None or session.source != "observed" or session.team_slot_id is None:
+            return None
+        if session.provider != str(info.get("provider") or "unknown"):
+            return None
+        if session.pane_id and session.pane_id != info.get("pane_id"):
+            return None
+        if session.tmux_target and session.tmux_target != info.get("tmux_target"):
+            return None
+        try:
+            discovered_pid = int(info.get("pid") or 0) or None
+        except (TypeError, ValueError):
+            discovered_pid = None
+        if session.pid is not None and discovered_pid is not None and session.pid != discovered_pid:
+            return None
+        cwd = str(info.get("cwd") or "")
+        if not session.cwd or not cwd:
+            return None
+        try:
+            if derive_repo_identity(session.cwd)["repo_id"] != derive_repo_identity(cwd)["repo_id"]:
+                return None
+        except Exception:
+            if os.path.realpath(session.cwd) != os.path.realpath(cwd):
+                return None
+        slot = await db.get(AgentTeamSlot, session.team_slot_id)
+        if slot is None or slot.provider != session.provider:
+            return None
+        member = await db.get(MailTeamMember, session.member_id)
+        if member is None or member.team_slot_id != slot.id:
+            return None
+        return member
+
+    def _registered_session_matches_observed(
+        self,
+        session: MailAgentSession,
+        info: dict,
+        now: datetime,
+    ) -> bool:
+        cwd = str(info.get("cwd") or "")
+        if not session.cwd or not cwd:
+            return False
+        try:
+            if derive_repo_identity(session.cwd)["repo_id"] != derive_repo_identity(cwd)["repo_id"]:
+                return False
+        except Exception:
+            if os.path.realpath(session.cwd) != os.path.realpath(cwd):
+                return False
+        if session.last_seen_at < now - timedelta(seconds=HEARTBEAT_TTL_SECONDS):
+            return False
+        return self._effective_status(session, now) != "offline"
 
     async def _remove_stale_observed_sessions(
         self, db: AsyncSession, active_observed_keys: set[str]
@@ -233,6 +452,8 @@ class AgentMailService:
         """Remove auto-observed members only when they have no durable user/mail state."""
         member = await db.get(MailTeamMember, member_id)
         if member is None:
+            return
+        if member.participant_kind != "repo":
             return
         if member.role or member.charter or member.display_name != member.repo_name:
             return
@@ -370,17 +591,56 @@ class AgentMailService:
             }
         return context
 
+    async def _team_context_by_member(
+        self,
+        db: AsyncSession,
+        members: list[MailTeamMember],
+    ) -> dict[int, dict[str, str | int | None]]:
+        slot_ids = {member.team_slot_id for member in members if member.team_slot_id is not None}
+        preset_ids = {
+            member.team_preset_id for member in members if member.team_preset_id is not None
+        }
+        slots: dict[int, AgentTeamSlot] = {}
+        if slot_ids:
+            slots = {
+                slot.id: slot
+                for slot in (
+                    await db.execute(select(AgentTeamSlot).where(AgentTeamSlot.id.in_(slot_ids)))
+                ).scalars().all()
+            }
+            preset_ids.update(slot.preset_id for slot in slots.values())
+        presets: dict[int, AgentTeamPreset] = {}
+        if preset_ids:
+            presets = {
+                preset.id: preset
+                for preset in (
+                    await db.execute(select(AgentTeamPreset).where(AgentTeamPreset.id.in_(preset_ids)))
+                ).scalars().all()
+            }
+        context: dict[int, dict[str, str | int | None]] = {}
+        for member in members:
+            slot = slots.get(member.team_slot_id) if member.team_slot_id is not None else None
+            preset_id = slot.preset_id if slot is not None else member.team_preset_id
+            preset = presets.get(preset_id) if preset_id is not None else None
+            context[member.id] = {
+                "team_preset_name": preset.name if preset is not None else None,
+                "team_slot_name": slot.display_name if slot is not None else None,
+            }
+        return context
+
     async def list_team(self, db: AsyncSession) -> List[MailMemberResponse]:
         now = datetime.utcnow()
         members = (await db.execute(select(MailTeamMember))).scalars().all()
         sessions = (await db.execute(select(MailAgentSession))).scalars().all()
         team_context = await self._team_context_by_session(db, sessions)
+        member_team_context = await self._team_context_by_member(db, members)
         by_member: dict[int, list[MailAgentSession]] = {}
         for session in sessions:
             by_member.setdefault(session.member_id, []).append(session)
 
         responses: List[MailMemberResponse] = []
         for member in members:
+            member_context = member_team_context.get(member.id, {})
             session_responses = [
                 self._session_response(session, now, team_context)
                 for session in by_member.get(member.id, [])
@@ -409,10 +669,16 @@ class AgentMailService:
             responses.append(
                 MailMemberResponse(
                     id=member.id,
+                    identity_key=member.identity_key,
                     repo_id=member.repo_id,
                     repo_path=member.repo_path,
                     repo_name=member.repo_name,
                     display_name=member.display_name,
+                    participant_kind=member.participant_kind,
+                    team_preset_id=member.team_preset_id,
+                    team_preset_name=member_context.get("team_preset_name"),
+                    team_slot_id=member.team_slot_id,
+                    team_slot_name=member_context.get("team_slot_name"),
                     role=member.role,
                     charter=member.charter,
                     status=status,

--- a/backend/app/services/agent_team_service.py
+++ b/backend/app/services/agent_team_service.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 from dataclasses import fields
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import delete, or_, select, update
+from sqlalchemy import delete, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.database import (
@@ -84,7 +85,6 @@ class AgentTeamService:
             self._normalize_slot_create(slot, index)
             for index, slot in enumerate(request.slots)
         ]
-        self._validate_enabled_repo_uniqueness(normalized_slots)
         for slot_data in normalized_slots:
             db.add(AgentTeamSlot(preset_id=preset.id, **slot_data))
 
@@ -115,15 +115,13 @@ class AgentTeamService:
         preset = await self._require_preset(db, preset_id)
         slots = await self._slots_for_preset(db, preset_id)
         slot_ids = [slot.id for slot in slots]
-        statement = update(MailAgentSession).where(MailAgentSession.team_preset_id == preset_id)
+        session_condition = MailAgentSession.team_preset_id == preset_id
         if slot_ids:
-            statement = update(MailAgentSession).where(
-                or_(
-                    MailAgentSession.team_preset_id == preset_id,
-                    MailAgentSession.team_slot_id.in_(slot_ids),
-                )
+            session_condition = or_(
+                MailAgentSession.team_preset_id == preset_id,
+                MailAgentSession.team_slot_id.in_(slot_ids),
             )
-        await db.execute(statement.values(team_preset_id=None, team_slot_id=None))
+        await self._move_sessions_to_repo_members(db, session_condition)
         launch_ids = (
             await db.execute(select(AgentTeamLaunch.id).where(AgentTeamLaunch.preset_id == preset_id))
         ).scalars().all()
@@ -244,7 +242,6 @@ class AgentTeamService:
             ),
         )
         slot_requests: list[AgentTeamSlotCreate] = []
-        seen_repo_ids: set[str] = set()
 
         for session in sessions:
             provider = self._clean_optional(session.get("provider"))
@@ -255,9 +252,6 @@ class AgentTeamService:
                 repo_path, identity = self._normalize_repo(cwd)
             except ValueError:
                 continue
-            if identity["repo_id"] in seen_repo_ids:
-                continue
-            seen_repo_ids.add(identity["repo_id"])
 
             slot_requests.append(
                 AgentTeamSlotCreate(
@@ -290,12 +284,6 @@ class AgentTeamService:
         slot_data = self._normalize_slot_create(
             request,
             await self._next_slot_position(db, preset_id) if request.position is None else request.position,
-        )
-        await self._ensure_enabled_repo_is_unique(
-            db,
-            preset_id,
-            repo_id=slot_data["repo_id"],
-            enabled=slot_data["enabled"],
         )
         db.add(AgentTeamSlot(preset_id=preset.id, **slot_data))
         preset.updated_at = datetime.utcnow()
@@ -339,26 +327,12 @@ class AgentTeamService:
         if request.position is not None:
             updates["position"] = request.position
 
-        final_repo_id = updates.get("repo_id", slot.repo_id)
-        final_enabled = updates.get("enabled", slot.enabled)
-        await self._ensure_enabled_repo_is_unique(
-            db,
-            slot.preset_id,
-            repo_id=final_repo_id,
-            enabled=final_enabled,
-            exclude_slot_id=slot.id,
-        )
-
         identity_changed = (
             ("repo_id" in updates and updates["repo_id"] != slot.repo_id)
             or ("provider" in updates and updates["provider"] != slot.provider)
         )
         if identity_changed:
-            await db.execute(
-                update(MailAgentSession)
-                .where(MailAgentSession.team_slot_id == slot.id)
-                .values(team_preset_id=None, team_slot_id=None)
-            )
+            await self._move_sessions_to_repo_members(db, MailAgentSession.team_slot_id == slot.id)
 
         for key, value in updates.items():
             setattr(slot, key, value)
@@ -371,11 +345,7 @@ class AgentTeamService:
     async def delete_slot(self, db: AsyncSession, slot_id: int) -> AgentTeamPresetResponse:
         slot = await self._require_slot(db, slot_id)
         preset = await self._require_preset(db, slot.preset_id)
-        await db.execute(
-            update(MailAgentSession)
-            .where(MailAgentSession.team_slot_id == slot.id)
-            .values(team_preset_id=None, team_slot_id=None)
-        )
+        await self._move_sessions_to_repo_members(db, MailAgentSession.team_slot_id == slot.id)
         await db.delete(slot)
         preset.updated_at = datetime.utcnow()
         await db.commit()
@@ -418,10 +388,22 @@ class AgentTeamService:
         await agent_mail_service.sync_observed_sessions(db)
         discovered = self._discover_sessions()
         install_status = await agent_mail_install_service.get_install_status()
+        reuse_group_counts = self._reuse_group_counts(slots)
 
         items: list[AgentTeamLaunchPlanItem] = []
+        used_matching_sessions: set[str] = set()
         for slot in slots:
-            matching = self._matching_session(slot, discovered) if request.reuse_existing else None
+            matching = (
+                await self._matching_session(
+                    db,
+                    slot,
+                    discovered,
+                    used_matching_sessions,
+                    requires_disambiguation=reuse_group_counts.get((slot.provider, slot.repo_id), 0) > 1,
+                )
+                if request.reuse_existing and slot.enabled
+                else None
+            )
             item = self._plan_slot(slot, matching, install_status)
             items.append(item)
 
@@ -733,25 +715,152 @@ class AgentTeamService:
             return "blocked_agent_mail_not_configured"
         return "failed"
 
-    def _matching_session(
+    def _reuse_group_counts(self, slots: list[AgentTeamSlot]) -> dict[tuple[str, str], int]:
+        counts: dict[tuple[str, str], int] = {}
+        for slot in slots:
+            if not slot.enabled:
+                continue
+            key = (slot.provider, slot.repo_id)
+            counts[key] = counts.get(key, 0) + 1
+        return counts
+
+    async def _matching_session(
+        self,
+        db: AsyncSession,
+        slot: AgentTeamSlot,
+        discovered: list[dict[str, Any]],
+        used_matching_sessions: set[str],
+        *,
+        requires_disambiguation: bool,
+    ) -> dict[str, Any] | None:
+        attached = await self._matching_attached_session(db, slot, discovered, used_matching_sessions)
+        if attached is not None:
+            return attached
+        named = self._matching_named_session(slot, discovered, used_matching_sessions)
+        if named is not None:
+            return named
+        if requires_disambiguation:
+            return None
+        for session in discovered:
+            match_key = self._matching_session_key(session)
+            if match_key in used_matching_sessions:
+                continue
+            if self._discovered_session_matches_slot(session, slot):
+                used_matching_sessions.add(match_key)
+                return self._matching_session_payload(session)
+        return None
+
+    async def _matching_attached_session(
+        self,
+        db: AsyncSession,
+        slot: AgentTeamSlot,
+        discovered: list[dict[str, Any]],
+        used_matching_sessions: set[str],
+    ) -> dict[str, Any] | None:
+        result = await db.execute(
+            select(MailAgentSession)
+            .where(
+                MailAgentSession.team_slot_id == slot.id,
+                MailAgentSession.provider == slot.provider,
+            )
+            .order_by(MailAgentSession.last_seen_at.desc())
+        )
+        attached_sessions = result.scalars().all()
+        now = datetime.utcnow()
+        for attached in attached_sessions:
+            if agent_mail_service._effective_status(attached, now) == "offline":
+                continue
+            for session in discovered:
+                match_key = self._matching_session_key(session)
+                if match_key in used_matching_sessions:
+                    continue
+                if not self._discovered_session_matches_slot(session, slot):
+                    continue
+                if self._discovered_session_matches_registered(session, attached):
+                    used_matching_sessions.add(match_key)
+                    return self._matching_session_payload(session)
+        return None
+
+    def _matching_named_session(
         self,
         slot: AgentTeamSlot,
         discovered: list[dict[str, Any]],
+        used_matching_sessions: set[str],
     ) -> dict[str, Any] | None:
         for session in discovered:
-            if session.get("provider") != slot.provider:
+            match_key = self._matching_session_key(session)
+            if match_key in used_matching_sessions:
                 continue
-            cwd = session.get("cwd")
-            if cwd and derive_repo_identity(cwd)["repo_id"] == slot.repo_id:
-                return {
-                    "source": "bridge",
-                    "provider": session.get("provider"),
-                    "session_name": session.get("session_name"),
-                    "tmux_target": session.get("tmux_target"),
-                    "cwd": cwd,
-                    "pid": session.get("pid"),
-                }
+            if not self._discovered_session_matches_slot(session, slot):
+                continue
+            if self._session_name_matches_slot(session, slot):
+                used_matching_sessions.add(match_key)
+                return self._matching_session_payload(session)
         return None
+
+    def _session_name_matches_slot(self, session: dict[str, Any], slot: AgentTeamSlot) -> bool:
+        slot_terms = [slot.display_name, slot.role]
+        session_terms = [session.get("session_name"), session.get("tmux_target")]
+        slot_tokens = {
+            token for term in slot_terms if term for token in self._match_tokens(term)
+        }
+        session_tokens = {
+            token for term in session_terms if term for token in self._match_tokens(term)
+        }
+        return bool(slot_tokens & session_tokens)
+
+    def _match_tokens(self, value: Any) -> list[str]:
+        return [token for token in re.split(r"[^a-z0-9]+", str(value).lower()) if len(token) >= 3]
+
+    def _discovered_session_matches_slot(
+        self,
+        session: dict[str, Any],
+        slot: AgentTeamSlot,
+    ) -> bool:
+        if session.get("provider") != slot.provider:
+            return False
+        cwd = session.get("cwd")
+        return bool(cwd and derive_repo_identity(cwd)["repo_id"] == slot.repo_id)
+
+    def _discovered_session_matches_registered(
+        self,
+        session: dict[str, Any],
+        registered: MailAgentSession,
+    ) -> bool:
+        payload = self._matching_session_payload(session)
+        if registered.session_key and payload.get("session_key") == registered.session_key:
+            return True
+        if registered.tmux_target and payload.get("tmux_target") == registered.tmux_target:
+            return True
+        if registered.pane_id and payload.get("pane_id") == registered.pane_id:
+            return True
+        if registered.pid and payload.get("pid"):
+            try:
+                return registered.pid == int(str(payload["pid"]))
+            except (TypeError, ValueError):
+                return False
+        return False
+
+    def _matching_session_payload(self, session: dict[str, Any]) -> dict[str, Any]:
+        pane_id = session.get("pane_id")
+        session_key = session.get("session_key") or (f"tmux:{pane_id}" if pane_id else None)
+        return {
+            "source": "bridge",
+            "provider": session.get("provider"),
+            "session_key": session_key,
+            "session_name": session.get("session_name"),
+            "tmux_target": session.get("tmux_target"),
+            "pane_id": pane_id,
+            "cwd": session.get("cwd"),
+            "pid": session.get("pid"),
+        }
+
+    def _matching_session_key(self, session: dict[str, Any]) -> str:
+        for key in ("session_key", "tmux_target", "pane_id", "pid", "session_name"):
+            value = session.get(key)
+            if value:
+                return f"{key}:{value}"
+        return f"{session.get('provider')}:{session.get('cwd')}"
 
     async def _attach_team_context_to_existing_session(
         self,
@@ -770,6 +879,8 @@ class AgentTeamService:
             statement = statement.where(MailAgentSession.session_key == matching_session["session_key"])
         elif matching_session.get("tmux_target"):
             statement = statement.where(MailAgentSession.tmux_target == matching_session["tmux_target"])
+        elif matching_session.get("pane_id"):
+            statement = statement.where(MailAgentSession.pane_id == matching_session["pane_id"])
         else:
             return None
         result = await db.execute(
@@ -779,10 +890,28 @@ class AgentTeamService:
         for session, member in result.all():
             if agent_mail_service._effective_status(session, now) == "offline":
                 continue
+            slot_member = await agent_mail_service.get_or_create_slot_member(db, slot)
+            if member.id != slot_member.id:
+                old_member_id = member.id
+                session.member_id = slot_member.id
+                await db.flush()
+                await agent_mail_service._remove_empty_observed_member(db, old_member_id)
             session.team_preset_id = slot.preset_id
             session.team_slot_id = slot.id
-            return member.id
+            return slot_member.id
         return None
+
+    async def _move_sessions_to_repo_members(self, db: AsyncSession, condition: Any) -> None:
+        sessions = (await db.execute(select(MailAgentSession).where(condition))).scalars().all()
+        for session in sessions:
+            if session.cwd:
+                try:
+                    repo_member = await agent_mail_service.get_or_create_repo_member(db, session.cwd)
+                    session.member_id = repo_member.id
+                except Exception:
+                    pass
+            session.team_preset_id = None
+            session.team_slot_id = None
 
     def _validate_spawn_options(self, slot: AgentTeamSlot) -> str | None:
         try:
@@ -936,28 +1065,6 @@ class AgentTeamService:
         slots = await self._slots_for_preset(db, preset_id)
         return (max((slot.position for slot in slots), default=-1) + 1)
 
-    async def _ensure_enabled_repo_is_unique(
-        self,
-        db: AsyncSession,
-        preset_id: int,
-        *,
-        repo_id: str,
-        enabled: bool,
-        exclude_slot_id: int | None = None,
-    ) -> None:
-        if not enabled:
-            return
-        statement = select(AgentTeamSlot).where(
-            AgentTeamSlot.preset_id == preset_id,
-            AgentTeamSlot.repo_id == repo_id,
-            AgentTeamSlot.enabled.is_(True),
-        )
-        if exclude_slot_id is not None:
-            statement = statement.where(AgentTeamSlot.id != exclude_slot_id)
-        existing = (await db.execute(statement)).scalar_one_or_none()
-        if existing is not None:
-            raise ValueError("A team preset cannot have duplicate enabled slots for the same repo")
-
     async def _ensure_preset_name_is_unique(
         self,
         db: AsyncSession,
@@ -971,16 +1078,6 @@ class AgentTeamService:
         existing = (await db.execute(statement)).scalar_one_or_none()
         if existing is not None:
             raise ValueError("An Agent Team preset with this name already exists")
-
-    def _validate_enabled_repo_uniqueness(self, slots: list[dict[str, Any]]) -> None:
-        seen: set[str] = set()
-        for slot in slots:
-            if not slot["enabled"]:
-                continue
-            repo_id = slot["repo_id"]
-            if repo_id in seen:
-                raise ValueError("A team preset cannot have duplicate enabled slots for the same repo")
-            seen.add(repo_id)
 
     def _normalize_slot_create(
         self,

--- a/backend/mcp_shim/agent_mail_server.py
+++ b/backend/mcp_shim/agent_mail_server.py
@@ -130,9 +130,9 @@ def _guard() -> Optional[dict]:
 
 @mcp.tool()
 def deck_whoami() -> dict:
-    """Register with Claude Deck Agent Mail and return your team identity, role, charter,
-    repo, live status, and unread/pending inbox counts. Call this once when starting
-    coordinated work."""
+    """Register with Claude Deck Agent Mail and return your participant identity, role,
+    charter, repo, live status, and unread/pending inbox counts. Call this once when
+    starting coordinated work."""
     err = _guard()
     if err:
         return err
@@ -148,8 +148,8 @@ def deck_whoami() -> dict:
 
 @mcp.tool()
 def deck_list_team() -> dict:
-    """List all local team members Claude Deck knows about across repositories, including
-    member ids, display names, roles, repos, charters, and live statuses."""
+    """List all local Agent Mail participants Claude Deck knows about, including member
+    ids, display names, roles, repos, team slots, charters, and live statuses."""
     err = _guard()
     if err:
         return err
@@ -158,8 +158,18 @@ def deck_list_team() -> dict:
         return result
     members = [
         {
-            key: member[key]
-            for key in ("id", "display_name", "role", "repo_name", "status", "charter")
+            key: member.get(key)
+            for key in (
+                "id",
+                "display_name",
+                "participant_kind",
+                "role",
+                "repo_name",
+                "status",
+                "charter",
+                "team_preset_name",
+                "team_slot_name",
+            )
         }
         for member in result["data"]["members"]
     ]
@@ -267,7 +277,7 @@ def deck_request_context(
     why_needed: str = "",
     files_or_symbols: Optional[list[str]] = None,
 ) -> dict:
-    """Ask another repository's agent a structured question about something they know.
+    """Ask another Agent Mail participant a structured question about something they know.
     Creates a pending context request they will be nudged to answer."""
     err = _guard()
     if err:
@@ -300,7 +310,7 @@ def deck_create_handoff(
     files: Optional[list[str]] = None,
     next_steps: Optional[list[str]] = None,
 ) -> dict:
-    """Hand work over to another team member with a summary, touched files, and next
+    """Hand work over to another Agent Mail participant with a summary, touched files, and next
     steps. The recipient acknowledges it to accept the handoff."""
     err = _guard()
     if err:

--- a/backend/tests/agent_mail/test_api.py
+++ b/backend/tests/agent_mail/test_api.py
@@ -24,6 +24,7 @@ async def client(db):
 
 async def _member(db, repo_id, name):
     member = MailTeamMember(
+        identity_key=f"repo:{repo_id}",
         repo_id=repo_id,
         repo_path=f"/tmp/{name}",
         repo_name=name,

--- a/backend/tests/agent_mail/test_context.py
+++ b/backend/tests/agent_mail/test_context.py
@@ -13,6 +13,7 @@ def svc():
 
 async def _member(db, repo_id, name, role=None, charter=None):
     member = MailTeamMember(
+        identity_key=f"repo:{repo_id}",
         repo_id=repo_id,
         repo_path=f"/tmp/{name}",
         repo_name=name,

--- a/backend/tests/agent_mail/test_external_api.py
+++ b/backend/tests/agent_mail/test_external_api.py
@@ -31,6 +31,7 @@ def clean_external_rate_limits(monkeypatch):
 
 async def _member(db, repo_id, name):
     member = MailTeamMember(
+        identity_key=f"repo:{repo_id}",
         repo_id=repo_id,
         repo_path=f"/tmp/{name}",
         repo_name=name,

--- a/backend/tests/agent_mail/test_hooks_api.py
+++ b/backend/tests/agent_mail/test_hooks_api.py
@@ -85,6 +85,7 @@ async def test_user_prompt_submit_injects_only_when_inbox_nonempty(client, db, t
     team = await agent_mail_service.list_team(db)
     me = team[0]
     other = MailTeamMember(
+        identity_key="repo:other",
         repo_id="other",
         repo_path="/tmp/o",
         repo_name="o",

--- a/backend/tests/agent_mail/test_messaging.py
+++ b/backend/tests/agent_mail/test_messaging.py
@@ -15,6 +15,7 @@ def svc():
 
 async def _member(db, repo_id, name):
     member = MailTeamMember(
+        identity_key=f"repo:{repo_id}",
         repo_id=repo_id,
         repo_path=f"/tmp/{name}",
         repo_name=name,

--- a/backend/tests/agent_mail/test_models.py
+++ b/backend/tests/agent_mail/test_models.py
@@ -7,6 +7,7 @@ from app.models.database import MailAgentSession, MailMessage, MailReceipt, Mail
 @pytest.mark.asyncio
 async def test_tables_create_and_accept_rows(db):
     member = MailTeamMember(
+        identity_key="repo:abc123",
         repo_id="abc123",
         repo_path="/tmp/r",
         repo_name="r",

--- a/backend/tests/agent_mail/test_registry.py
+++ b/backend/tests/agent_mail/test_registry.py
@@ -5,8 +5,15 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+from sqlalchemy import select
 
-from app.models.database import MailMessage, MailTeamMember
+from app.models.database import (
+    AgentTeamPreset,
+    AgentTeamSlot,
+    MailAgentSession,
+    MailMessage,
+    MailTeamMember,
+)
 from app.models.schemas import MailAgentRegisterRequest, MailMessageCreate
 from app.services.agent_mail_service import (
     HEARTBEAT_TTL_SECONDS,
@@ -15,6 +22,7 @@ from app.services.agent_mail_service import (
     TMUX_ENTER_DELAY_SECONDS,
     AgentMailService,
 )
+from app.utils.repo_utils import derive_repo_identity
 
 
 @pytest.fixture
@@ -30,6 +38,30 @@ def _register(cwd, session_key="cc:s1", source="hook", provider="claude-code", p
         session_key=session_key,
         pid=pid,
     )
+
+
+async def _slot(db, cwd, name, *, preset=None, position=0, role=None, charter=None):
+    if preset is None:
+        preset = AgentTeamPreset(name="Project team")
+        db.add(preset)
+        await db.flush()
+    ident = derive_repo_identity(cwd)
+    slot = AgentTeamSlot(
+        preset_id=preset.id,
+        position=position,
+        display_name=name,
+        provider="codex-cli",
+        repo_id=ident["repo_id"],
+        repo_path=ident["repo_root"],
+        repo_name=ident["repo_name"],
+        role=role,
+        charter=charter,
+    )
+    db.add(slot)
+    await db.commit()
+    await db.refresh(preset)
+    await db.refresh(slot)
+    return preset, slot
 
 
 @pytest.mark.asyncio
@@ -53,6 +85,149 @@ async def test_second_session_same_repo_reuses_member(db, svc, tmp_path):
     )
     assert m1.id == m2.id
     assert s2.session_key == "mcp:abc"
+
+
+@pytest.mark.asyncio
+async def test_same_repo_team_slots_are_distinct_mail_participants(db, svc, tmp_path):
+    cwd = tmp_path / "r"
+    cwd.mkdir()
+    planner_preset, planner_slot = await _slot(
+        db,
+        str(cwd),
+        "Planner",
+        position=0,
+        role="planner/reviewer",
+    )
+    _, implementer_slot = await _slot(
+        db,
+        str(cwd),
+        "Implementer",
+        preset=planner_preset,
+        position=1,
+        role="implementer",
+    )
+
+    planner, _ = await svc.register_session(
+        db,
+        MailAgentRegisterRequest(
+            source="mcp",
+            provider="codex-cli",
+            cwd=str(cwd),
+            session_key="mcp:planner",
+            team_preset_id=planner_preset.id,
+            team_slot_id=planner_slot.id,
+        ),
+    )
+    implementer, _ = await svc.register_session(
+        db,
+        MailAgentRegisterRequest(
+            source="mcp",
+            provider="codex-cli",
+            cwd=str(cwd),
+            session_key="mcp:implementer",
+            team_preset_id=planner_preset.id,
+            team_slot_id=implementer_slot.id,
+        ),
+    )
+
+    assert planner.id != implementer.id
+    assert planner.repo_id == implementer.repo_id
+    assert planner.identity_key == svc._slot_identity_key(planner_slot)
+    assert implementer.identity_key == svc._slot_identity_key(implementer_slot)
+
+    message = await svc.send_message(
+        db,
+        MailMessageCreate(
+            kind="handoff",
+            sender_member_id=planner.id,
+            recipient_member_id=implementer.id,
+            body_markdown="Please implement plan v1.",
+        ),
+        auto_nudge=False,
+    )
+    planner_inbox = await svc.get_inbox(db, planner.id)
+    implementer_inbox = await svc.get_inbox(db, implementer.id)
+
+    assert planner_inbox.pending_count == 0
+    assert implementer_inbox.pending_count == 1
+    assert [item.id for item in implementer_inbox.messages] == [message.id]
+
+
+@pytest.mark.asyncio
+async def test_reused_session_key_clears_stale_team_slot_context(db, svc, tmp_path):
+    repo_a = tmp_path / "repo-a"
+    repo_b = tmp_path / "repo-b"
+    repo_a.mkdir()
+    repo_b.mkdir()
+    preset, slot = await _slot(db, str(repo_a), "Planner")
+    slot_member, session = await svc.register_session(
+        db,
+        MailAgentRegisterRequest(
+            source="mcp",
+            provider="codex-cli",
+            cwd=str(repo_a),
+            session_key="mcp:reused",
+            team_preset_id=preset.id,
+            team_slot_id=slot.id,
+        ),
+    )
+
+    preserved_member, preserved_session = await svc.register_session(
+        db,
+        MailAgentRegisterRequest(
+            source="mcp",
+            provider="codex-cli",
+            cwd=str(repo_a),
+            session_key="mcp:reused",
+        ),
+    )
+
+    assert preserved_member.id == slot_member.id
+    assert preserved_session.id == session.id
+    assert preserved_session.team_slot_id == slot.id
+
+    moved_member, moved_session = await svc.register_session(
+        db,
+        MailAgentRegisterRequest(
+            source="mcp",
+            provider="codex-cli",
+            cwd=str(repo_b),
+            session_key="mcp:reused",
+        ),
+    )
+
+    assert moved_member.participant_kind == "repo"
+    assert moved_member.repo_path == str(repo_b)
+    assert moved_session.id == session.id
+    assert moved_session.member_id == moved_member.id
+    assert moved_session.team_preset_id is None
+    assert moved_session.team_slot_id is None
+
+
+@pytest.mark.asyncio
+async def test_register_ignores_mismatched_team_slot_context(db, svc, tmp_path):
+    repo_a = tmp_path / "repo-a"
+    repo_b = tmp_path / "repo-b"
+    repo_a.mkdir()
+    repo_b.mkdir()
+    preset, slot = await _slot(db, str(repo_a), "Planner")
+
+    member, session = await svc.register_session(
+        db,
+        MailAgentRegisterRequest(
+            source="mcp",
+            provider="codex-cli",
+            cwd=str(repo_b),
+            session_key="mcp:mismatch",
+            team_preset_id=preset.id,
+            team_slot_id=slot.id,
+        ),
+    )
+
+    assert member.participant_kind == "repo"
+    assert member.repo_path == str(repo_b)
+    assert session.team_preset_id is None
+    assert session.team_slot_id is None
 
 
 @pytest.mark.asyncio
@@ -101,6 +276,189 @@ async def test_sync_observed_creates_observed_sessions(db, svc, tmp_path):
     assert members[0].status == "observed"
     assert members[0].sessions[0].session_key == "tmux:%7"
     assert members[0].can_nudge is True
+
+
+@pytest.mark.asyncio
+async def test_observed_session_attaches_to_matching_team_slot_participant(db, svc, tmp_path):
+    cwd = tmp_path / "obs"
+    cwd.mkdir()
+    preset, slot = await _slot(db, str(cwd), "Implementer", role="implementer")
+    member, _ = await svc.register_session(
+        db,
+        MailAgentRegisterRequest(
+            source="hook",
+            provider="codex-cli",
+            cwd=str(cwd),
+            session_key="codex:s1",
+            pid=4242,
+            team_preset_id=preset.id,
+            team_slot_id=slot.id,
+        ),
+    )
+    fake = [
+        {
+            "provider": "codex-cli",
+            "provider_display_name": "Codex",
+            "tmux_target": "w:0.1",
+            "session_name": "w",
+            "window_name": "main",
+            "pane_id": "%7",
+            "cwd": str(cwd),
+            "pid": "4242",
+            "status": "active",
+        }
+    ]
+    with patch("app.services.agent_mail_service.discover_agent_sessions", return_value=fake):
+        await svc.sync_observed_sessions(db)
+
+    members = await svc.list_team(db)
+
+    assert [candidate.id for candidate in members] == [member.id]
+    assert members[0].participant_kind == "team_slot"
+    assert members[0].team_slot_id == slot.id
+    assert members[0].can_nudge is True
+    assert {session.source for session in members[0].sessions} == {"hook", "observed"}
+
+
+@pytest.mark.asyncio
+async def test_observed_session_ignores_stale_pid_match(db, svc, tmp_path):
+    old_cwd = tmp_path / "old"
+    new_cwd = tmp_path / "new"
+    old_cwd.mkdir()
+    new_cwd.mkdir()
+    preset, slot = await _slot(db, str(old_cwd), "Old slot")
+    _member, stale_session = await svc.register_session(
+        db,
+        MailAgentRegisterRequest(
+            source="hook",
+            provider="codex-cli",
+            cwd=str(old_cwd),
+            session_key="codex:old",
+            pid=4242,
+            team_preset_id=preset.id,
+            team_slot_id=slot.id,
+        ),
+    )
+    stale_session.last_seen_at = datetime.utcnow() - timedelta(seconds=HEARTBEAT_TTL_SECONDS + 30)
+    await db.commit()
+    fake = [
+        {
+            "provider": "codex-cli",
+            "provider_display_name": "Codex",
+            "tmux_target": "w:0.1",
+            "session_name": "w",
+            "window_name": "main",
+            "pane_id": "%7",
+            "cwd": str(new_cwd),
+            "pid": "4242",
+            "status": "active",
+        }
+    ]
+    with patch("app.services.agent_mail_service.discover_agent_sessions", return_value=fake):
+        await svc.sync_observed_sessions(db)
+
+    members = await svc.list_team(db)
+    observed_member = next(member for member in members if member.repo_path == str(new_cwd))
+
+    assert observed_member.participant_kind == "repo"
+    assert observed_member.repo_name == "new"
+    assert observed_member.sessions[0].session_key == "tmux:%7"
+
+
+@pytest.mark.asyncio
+async def test_sync_preserves_observed_session_team_slot_attachment(db, svc, tmp_path):
+    cwd = tmp_path / "obs"
+    cwd.mkdir()
+    preset, slot = await _slot(db, str(cwd), "Reused slot")
+    slot_member = await svc.get_or_create_slot_member(db, slot)
+    db.add(
+        MailAgentSession(
+            member_id=slot_member.id,
+            source="observed",
+            provider="codex-cli",
+            session_key="tmux:%7",
+            cwd=str(cwd),
+            tmux_target="w:0.1",
+            pane_id="%7",
+            team_preset_id=preset.id,
+            team_slot_id=slot.id,
+            mailbox_status="observed",
+        )
+    )
+    await db.commit()
+    fake = [
+        {
+            "provider": "codex-cli",
+            "provider_display_name": "Codex",
+            "tmux_target": "w:0.1",
+            "session_name": "w",
+            "window_name": "main",
+            "pane_id": "%7",
+            "cwd": str(cwd),
+            "pid": "4242",
+            "status": "active",
+        }
+    ]
+    with patch("app.services.agent_mail_service.discover_agent_sessions", return_value=fake):
+        await svc.sync_observed_sessions(db)
+
+    members = await svc.list_team(db)
+
+    assert len(members) == 1
+    assert members[0].id == slot_member.id
+    assert members[0].participant_kind == "team_slot"
+    assert members[0].team_slot_id == slot.id
+    assert members[0].sessions[0].team_slot_id == slot.id
+
+
+@pytest.mark.asyncio
+async def test_sync_does_not_preserve_team_slot_when_observed_pid_changes(db, svc, tmp_path):
+    cwd = tmp_path / "obs"
+    cwd.mkdir()
+    preset, slot = await _slot(db, str(cwd), "Reused slot")
+    slot_member = await svc.get_or_create_slot_member(db, slot)
+    db.add(
+        MailAgentSession(
+            member_id=slot_member.id,
+            source="observed",
+            provider="codex-cli",
+            session_key="tmux:%7",
+            cwd=str(cwd),
+            tmux_target="w:0.1",
+            pane_id="%7",
+            pid=111,
+            team_preset_id=preset.id,
+            team_slot_id=slot.id,
+            mailbox_status="observed",
+        )
+    )
+    await db.commit()
+    fake = [
+        {
+            "provider": "codex-cli",
+            "provider_display_name": "Codex",
+            "tmux_target": "w:0.1",
+            "session_name": "w",
+            "window_name": "main",
+            "pane_id": "%7",
+            "cwd": str(cwd),
+            "pid": "222",
+            "status": "active",
+        }
+    ]
+    with patch("app.services.agent_mail_service.discover_agent_sessions", return_value=fake):
+        await svc.sync_observed_sessions(db)
+
+    members = await svc.list_team(db)
+    session = (
+        await db.execute(select(MailAgentSession).where(MailAgentSession.session_key == "tmux:%7"))
+    ).scalar_one()
+
+    assert session.pid == 222
+    assert session.team_slot_id is None
+    assert session.member_id != slot_member.id
+    assert members[0].participant_kind == "repo"
+    assert members[0].sessions[0].session_key == "tmux:%7"
 
 
 @pytest.mark.asyncio
@@ -199,6 +557,7 @@ async def test_send_message_auto_nudges_tmux_observed_codex_recipient(db, svc, t
     await svc.sync_observed_sessions(db)
     recipient = (await svc.list_team(db))[0]
     sender = MailTeamMember(
+        identity_key="repo:sender",
         repo_id="sender",
         repo_path="/tmp/sender",
         repo_name="sender",

--- a/backend/tests/agent_teams/test_agent_team_service.py
+++ b/backend/tests/agent_teams/test_agent_team_service.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 import pytest
 from sqlalchemy import select
 
-from app.models.database import AgentTeamSlot
+from app.models.database import AgentTeamSlot, MailAgentSession, MailTeamMember
 from app.models.schemas import (
     AgentTeamCreateFromMailRequest,
     AgentTeamCreateFromBridgeRequest,
@@ -70,7 +70,7 @@ def no_real_process_boundaries(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_duplicate_enabled_repo_slots_are_rejected(db, tmp_path):
+async def test_duplicate_enabled_repo_slots_are_allowed(db, tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
     preset = await agent_team_service.create_preset(
@@ -87,16 +87,16 @@ async def test_duplicate_enabled_repo_slots_are_rejected(db, tmp_path):
         ),
     )
 
-    with pytest.raises(ValueError, match="duplicate enabled slots"):
-        await agent_team_service.add_slot(
-            db,
-            preset.id,
-            AgentTeamSlotCreate(
-                display_name="Duplicate",
-                provider="codex-cli",
-                repo_path=str(repo),
-            ),
-        )
+    updated = await agent_team_service.add_slot(
+        db,
+        preset.id,
+        AgentTeamSlotCreate(
+            display_name="Implementer",
+            provider="codex-cli",
+            repo_path=str(repo),
+        ),
+    )
+    assert [slot.display_name for slot in updated.slots] == ["Primary", "Implementer"]
 
     updated = await agent_team_service.add_slot(
         db,
@@ -108,7 +108,7 @@ async def test_duplicate_enabled_repo_slots_are_rejected(db, tmp_path):
             enabled=False,
         ),
     )
-    assert len(updated.slots) == 2
+    assert len(updated.slots) == 3
 
 
 @pytest.mark.asyncio
@@ -263,7 +263,7 @@ async def test_create_from_agent_bridge_imports_current_bridge_sessions(db, tmp_
 
 
 @pytest.mark.asyncio
-async def test_create_from_agent_bridge_deduplicates_repo_sessions(db, tmp_path, monkeypatch):
+async def test_create_from_agent_bridge_keeps_same_repo_sessions(db, tmp_path, monkeypatch):
     repo = tmp_path / "repo"
     repo.mkdir()
     monkeypatch.setattr(
@@ -289,8 +289,323 @@ async def test_create_from_agent_bridge_deduplicates_repo_sessions(db, tmp_path,
         AgentTeamCreateFromBridgeRequest(name="Bridge team"),
     )
 
-    assert len(preset.slots) == 1
-    assert preset.slots[0].display_name == "repo-a"
+    assert [slot.display_name for slot in preset.slots] == ["repo-a", "repo-b"]
+
+
+@pytest.mark.asyncio
+async def test_plan_launch_reuses_distinct_same_repo_sessions(db, tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    preset = await agent_team_service.create_preset(
+        db,
+        AgentTeamPresetCreate(
+            name="Same repo team",
+            slots=[
+                AgentTeamSlotCreate(
+                    display_name="Planner",
+                    provider="codex-cli",
+                    repo_path=str(repo),
+                ),
+                AgentTeamSlotCreate(
+                    display_name="Implementer",
+                    provider="codex-cli",
+                    repo_path=str(repo),
+                ),
+            ],
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.agent_team_service.discover_agent_sessions",
+        lambda: [
+            {
+                "provider": "codex-cli",
+                "session_name": "implementer",
+                "tmux_target": "implementer:0.0",
+                "cwd": str(repo),
+            },
+            {
+                "provider": "codex-cli",
+                "session_name": "planner",
+                "tmux_target": "planner:0.0",
+                "cwd": str(repo),
+            },
+        ],
+    )
+
+    plan = await agent_team_service.plan_launch(db, preset.id)
+
+    assert [item.action for item in plan.items] == ["reuse", "reuse"]
+    assert [item.matching_session["tmux_target"] for item in plan.items] == [
+        "planner:0.0",
+        "implementer:0.0",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_plan_launch_does_not_reuse_ambiguous_same_repo_sessions(db, tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    preset = await agent_team_service.create_preset(
+        db,
+        AgentTeamPresetCreate(
+            name="Same repo team",
+            slots=[
+                AgentTeamSlotCreate(
+                    display_name="A",
+                    provider="codex-cli",
+                    repo_path=str(repo),
+                ),
+                AgentTeamSlotCreate(
+                    display_name="B",
+                    provider="codex-cli",
+                    repo_path=str(repo),
+                ),
+            ],
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.agent_team_service.discover_agent_sessions",
+        lambda: [
+            {
+                "provider": "codex-cli",
+                "session_name": "main",
+                "tmux_target": "main:0.0",
+                "cwd": str(repo),
+            },
+            {
+                "provider": "codex-cli",
+                "session_name": "backup",
+                "tmux_target": "backup:0.0",
+                "cwd": str(repo),
+            },
+        ],
+    )
+
+    plan = await agent_team_service.plan_launch(db, preset.id)
+
+    assert [item.action for item in plan.items] == ["spawn", "spawn"]
+
+
+@pytest.mark.asyncio
+async def test_plan_launch_prefers_existing_same_repo_slot_attachment(db, tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    preset = await agent_team_service.create_preset(
+        db,
+        AgentTeamPresetCreate(
+            name="Same repo team",
+            slots=[
+                AgentTeamSlotCreate(
+                    display_name="Planner",
+                    provider="codex-cli",
+                    repo_path=str(repo),
+                ),
+                AgentTeamSlotCreate(
+                    display_name="Implementer",
+                    provider="codex-cli",
+                    repo_path=str(repo),
+                ),
+            ],
+        ),
+    )
+    planner_slot = await db.get(AgentTeamSlot, preset.slots[0].id)
+    implementer_slot = await db.get(AgentTeamSlot, preset.slots[1].id)
+    planner_member = await agent_mail_service.get_or_create_slot_member(db, planner_slot)
+    implementer_member = await agent_mail_service.get_or_create_slot_member(db, implementer_slot)
+    db.add_all(
+        [
+            MailAgentSession(
+                member_id=planner_member.id,
+                source="observed",
+                provider="codex-cli",
+                session_key="tmux:%1",
+                tmux_target="planner:0.0",
+                pane_id="%1",
+                cwd=str(repo),
+                team_preset_id=preset.id,
+                team_slot_id=planner_slot.id,
+                mailbox_status="observed",
+            ),
+            MailAgentSession(
+                member_id=implementer_member.id,
+                source="observed",
+                provider="codex-cli",
+                session_key="tmux:%2",
+                tmux_target="implementer:0.0",
+                pane_id="%2",
+                cwd=str(repo),
+                team_preset_id=preset.id,
+                team_slot_id=implementer_slot.id,
+                mailbox_status="observed",
+            ),
+        ]
+    )
+    await db.commit()
+    monkeypatch.setattr(
+        "app.services.agent_team_service.discover_agent_sessions",
+        lambda: [
+            {
+                "provider": "codex-cli",
+                "session_name": "implementer",
+                "tmux_target": "implementer:0.0",
+                "pane_id": "%2",
+                "cwd": str(repo),
+            },
+            {
+                "provider": "codex-cli",
+                "session_name": "planner",
+                "tmux_target": "planner:0.0",
+                "pane_id": "%1",
+                "cwd": str(repo),
+            },
+        ],
+    )
+
+    plan = await agent_team_service.plan_launch(db, preset.id)
+
+    assert [item.action for item in plan.items] == ["reuse", "reuse"]
+    assert [item.matching_session["tmux_target"] for item in plan.items] == [
+        "planner:0.0",
+        "implementer:0.0",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_launch_reuses_distinct_same_repo_sessions(db, tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    preset = await agent_team_service.create_preset(
+        db,
+        AgentTeamPresetCreate(
+            name="Same repo team",
+            slots=[
+                AgentTeamSlotCreate(
+                    display_name="Planner",
+                    provider="codex-cli",
+                    repo_path=str(repo),
+                ),
+                AgentTeamSlotCreate(
+                    display_name="Implementer",
+                    provider="codex-cli",
+                    repo_path=str(repo),
+                ),
+            ],
+        ),
+    )
+    repo_member = await agent_mail_service.get_or_create_repo_member(db, str(repo))
+    db.add_all(
+        [
+            MailAgentSession(
+                member_id=repo_member.id,
+                source="observed",
+                provider="codex-cli",
+                session_key="tmux:%1",
+                tmux_target="planner:0.0",
+                pane_id="%1",
+                cwd=str(repo),
+                mailbox_status="observed",
+            ),
+            MailAgentSession(
+                member_id=repo_member.id,
+                source="observed",
+                provider="codex-cli",
+                session_key="tmux:%2",
+                tmux_target="implementer:0.0",
+                pane_id="%2",
+                cwd=str(repo),
+                mailbox_status="observed",
+            ),
+        ]
+    )
+    await db.commit()
+    discovered_sessions = [
+        {
+            "provider": "codex-cli",
+            "session_name": "planner",
+            "tmux_target": "planner:0.0",
+            "pane_id": "%1",
+            "cwd": str(repo),
+            "pid": "101",
+        },
+        {
+            "provider": "codex-cli",
+            "session_name": "implementer",
+            "tmux_target": "implementer:0.0",
+            "pane_id": "%2",
+            "cwd": str(repo),
+            "pid": "102",
+        },
+    ]
+    monkeypatch.setattr(
+        "app.services.agent_team_service.discover_agent_sessions",
+        lambda: discovered_sessions,
+    )
+
+    plan = await agent_team_service.plan_launch(db, preset.id)
+    assert [item.matching_session["session_key"] for item in plan.items] == ["tmux:%1", "tmux:%2"]
+
+    result = await agent_team_service.launch(
+        db,
+        preset.id,
+        AgentTeamLaunchRequest(confirm_plan_hash=plan.plan_hash),
+    )
+    sessions = (
+        await db.execute(
+            select(MailAgentSession).where(MailAgentSession.session_key.in_(["tmux:%1", "tmux:%2"]))
+        )
+    ).scalars().all()
+    sessions_by_key = {session.session_key: session for session in sessions}
+
+    assert [item.status for item in result.items] == ["reused", "reused"]
+    assert result.items[0].agent_mail_member_id != result.items[1].agent_mail_member_id
+    assert sessions_by_key["tmux:%1"].team_slot_id == preset.slots[0].id
+    assert sessions_by_key["tmux:%2"].team_slot_id == preset.slots[1].id
+    assert await db.get(MailTeamMember, repo_member.id) is None
+
+
+@pytest.mark.asyncio
+async def test_disabled_same_repo_slot_does_not_consume_reuse_match(db, tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    preset = await agent_team_service.create_preset(
+        db,
+        AgentTeamPresetCreate(
+            name="Same repo team",
+            slots=[
+                AgentTeamSlotCreate(
+                    display_name="Disabled",
+                    provider="codex-cli",
+                    repo_path=str(repo),
+                    enabled=False,
+                ),
+                AgentTeamSlotCreate(
+                    display_name="Enabled",
+                    provider="codex-cli",
+                    repo_path=str(repo),
+                ),
+            ],
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.agent_team_service.discover_agent_sessions",
+        lambda: [
+            {
+                "provider": "codex-cli",
+                "session_name": "repo",
+                "tmux_target": "repo:0.0",
+                "cwd": str(repo),
+            }
+        ],
+    )
+
+    plan = await agent_team_service.plan_launch(
+        db,
+        preset.id,
+        AgentTeamLaunchRequest(include_disabled=True),
+    )
+
+    assert [item.action for item in plan.items] == ["skip", "reuse"]
+    assert plan.items[1].matching_session["tmux_target"] == "repo:0.0"
 
 
 @pytest.mark.asyncio
@@ -810,6 +1125,55 @@ async def test_deleting_slot_or_preset_clears_session_team_context(db, tmp_path)
     assert session_b.team_preset_id is None
     assert session_b.team_slot_id is None
     assert orphaned_slots == []
+
+
+@pytest.mark.asyncio
+async def test_deleting_slot_clears_context_when_session_cwd_cannot_resolve(
+    db,
+    tmp_path,
+    monkeypatch,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    preset = await agent_team_service.create_preset(
+        db,
+        AgentTeamPresetCreate(
+            name="Cleanup team",
+            slots=[
+                AgentTeamSlotCreate(
+                    display_name="A",
+                    provider="codex-cli",
+                    repo_path=str(repo),
+                )
+            ],
+        ),
+    )
+    slot = preset.slots[0]
+    _member, session = await agent_mail_service.register_session(
+        db,
+        MailAgentRegisterRequest(
+            source="mcp",
+            provider="codex-cli",
+            cwd=str(repo),
+            session_key="mcp:a",
+            team_preset_id=preset.id,
+            team_slot_id=slot.id,
+        ),
+    )
+
+    async def fail_repo_member(_db, _cwd):
+        raise FileNotFoundError("missing cwd")
+
+    monkeypatch.setattr(
+        "app.services.agent_team_service.agent_mail_service.get_or_create_repo_member",
+        fail_repo_member,
+    )
+
+    await agent_team_service.delete_slot(db, slot.id)
+    await db.refresh(session)
+
+    assert session.team_preset_id is None
+    assert session.team_slot_id is None
 
 
 @pytest.mark.asyncio

--- a/docs/features/agent-mail.md
+++ b/docs/features/agent-mail.md
@@ -1,12 +1,12 @@
 # Agent Mail
 
-Agent Mail lets local Claude Code and Codex CLI sessions coordinate as a user-directed team. Claude Deck keeps durable team identities per repository, tracks ephemeral sessions under those identities, and gives agents a shared mailbox for structured context requests, handoffs, broadcasts, and replies.
+Agent Mail lets local Claude Code and Codex CLI sessions coordinate as a user-directed team. Claude Deck keeps durable mail participants, groups them by repository, tracks ephemeral sessions under those participants, and gives agents structured mailboxes for context requests, handoffs, broadcasts, and replies.
 
 ## What It Is For
 
 - Ask the agent that knows one repository to explain a local API, component, convention, or failure mode to another agent.
 - Hand work from one repository agent to another with touched files and next steps.
-- Keep short-lived agent sessions attached to a durable repo member, so role and charter survive restarts and context compaction.
+- Keep short-lived agent sessions attached to a durable repo or Agent Team slot participant, so role and charter survive restarts and context compaction.
 - Inspect team communication from Claude Deck without turning the product into a general chat app.
 
 ## How Agents Connect
@@ -31,7 +31,7 @@ Non-tmux Codex sessions can still receive and send Agent Mail through MCP, but C
 
 ## External Local Callers
 
-Local tools such as OpenClaw can use the external Agent Mail API to authenticate as a named local actor, discover members, send direct messages, request context, create handoffs, and poll request status.
+Local tools such as OpenClaw can use the external Agent Mail API to authenticate as a named local actor, discover participants, send direct messages, request context, create handoffs, and poll request status.
 
 See [External Agent Orchestration](./external-agent-orchestration.md) for token setup, endpoint examples, delivery result semantics, and Agent Teams launch integration.
 
@@ -47,8 +47,8 @@ Without this setup, the page can still show install status, but agents cannot ex
 
 ## Current Limits
 
-- Visibility is machine-global. Every local member is visible to every other member.
-- MVP identity is one team member per repository. Git worktrees of the same repository share the same member.
+- Visibility is machine-global. Every local participant is visible to every other participant.
+- Sessions without Agent Team slot context use one repo-level participant. Agent Team slots can create multiple distinct participants in the same repo, such as planner/reviewer and implementer.
 - External Agent Mail calls use local actor bearer tokens. Token creation is loopback-only and follows Claude Deck's local trust model.
 - External callers should only use the API from the same trusted machine until a broader Claude Deck auth model exists.
 - Agent Mail is coordination state, not source control. Handoffs should still reference files, branches, issues, or commits when durable provenance matters.

--- a/docs/features/agent-teams.md
+++ b/docs/features/agent-teams.md
@@ -20,9 +20,9 @@ Agent Teams do not create a second messaging system. Once agents are launched or
 
 You can create a team manually, import selected Agent Mail members, or snapshot currently visible Agent Bridge sessions.
 
-`From Mail` uses Agent Mail members and copies their current role and charter into slot-specific values. This is a snapshot; editing a team slot does not update the global Agent Mail member.
+`From Mail` uses Agent Mail participants and copies their current role and charter into slot-specific values. This is a snapshot; editing a team slot does not update existing mail history.
 
-`From Bridge` uses live Agent Bridge tmux sessions. If multiple sessions are visible for the same repo, v1 keeps one enabled slot because Agent Mail currently has one durable identity per repo.
+`From Bridge` uses live Agent Bridge tmux sessions. If multiple sessions are visible for the same repo, Claude Deck keeps each session as a separate slot so the resulting team can have distinct same-repo roles.
 
 ## Launch Planning
 
@@ -34,7 +34,7 @@ Before launch, Claude Deck computes a plan. The plan checks:
 - disabled slots
 - provider launch option validity
 
-By default, launch only includes enabled slots and only reuses wakeable sessions observed through Agent Bridge. Connected non-tmux Agent Mail sessions can still communicate, but they are not reliable team launch/reuse targets in v1.
+By default, launch only includes enabled slots and only reuses wakeable sessions observed through Agent Bridge. Connected non-tmux Agent Mail sessions can still communicate, but they are not reliable team launch/reuse targets.
 
 ## External Local Agents
 
@@ -47,4 +47,4 @@ Local external agents can use the JSON API:
 
 Launch accepts a reviewed `confirm_plan_hash`, or `skip_plan_confirmation: true` for explicit single-step local automation. If a plan hash is stale, the API returns `409` with the updated plan.
 
-After a launch, use the [External Agent Orchestration](./external-agent-orchestration.md) Agent Mail API to discover registered members, send context requests, create handoffs, and poll for answers.
+After a launch, use the [External Agent Orchestration](./external-agent-orchestration.md) Agent Mail API to discover registered participants, send context requests, create handoffs, and poll for answers.

--- a/docs/features/external-agent-orchestration.md
+++ b/docs/features/external-agent-orchestration.md
@@ -28,14 +28,14 @@ export DECK_API='http://127.0.0.1:8000/api/v1'
 
 Actor registration is loopback-only. External Agent Mail endpoints require `Authorization: Bearer ...`.
 
-## Discover Members
+## Discover Participants
 
 ```bash
 curl -s "$DECK_API/external/agent-mail/members" \
   -H "Authorization: Bearer $DECK_EXTERNAL_AGENT_TOKEN"
 ```
 
-The response includes each Agent Mail member's repo, role, charter, connection status, inbox load, `wake_state`, `wake_methods`, and current Agent Team preset/slot context when present.
+The response includes each Agent Mail participant's repo, role, charter, connection status, inbox load, `wake_state`, `wake_methods`, and current Agent Team preset/slot context when present. A repository can have multiple participants when Agent Team slots represent distinct same-repo roles.
 
 Wake states mean:
 
@@ -145,7 +145,7 @@ curl -s -X POST "$DECK_API/agent-teams/presets/3/launch" \
   }'
 ```
 
-Once agents register through Agent Mail, use `/external/agent-mail/members` to discover their member ids, then send context requests or handoffs through the external Agent Mail endpoints.
+Once agents register through Agent Mail, use `/external/agent-mail/members` to discover their participant/member ids, then send context requests or handoffs through the external Agent Mail endpoints.
 
 ## Safeguards
 

--- a/frontend/src/features/agent-mail/AgentMailHelpDialog.tsx
+++ b/frontend/src/features/agent-mail/AgentMailHelpDialog.tsx
@@ -78,9 +78,9 @@ export function AgentMailHelpDialog({ open, onOpenChange }: AgentMailHelpDialogP
 
           <HelpSection icon={ShieldAlert} title="MVP limits">
             <p>
-              Visibility is machine-global, members are keyed one-per-repo, and Claude Deck must
-              be running for agents to use the mailbox. Git worktrees of the same repository share
-              a member identity.
+              Visibility is machine-global, sessions without Agent Team slot context share a
+              repo-level participant, and Claude Deck must be running for agents to use the mailbox.
+              Use Agent Team slots when separate same-repo agents need distinct inboxes.
             </p>
           </HelpSection>
         </div>

--- a/frontend/src/features/agent-mail/AgentMailPage.tsx
+++ b/frontend/src/features/agent-mail/AgentMailPage.tsx
@@ -152,9 +152,9 @@ export function AgentMailPage() {
     try {
       await updateAgentMailMember(memberId, update)
       await loadOperationalData()
-      toast.success('Member updated')
+      toast.success('Participant updated')
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to update member')
+      toast.error(error instanceof Error ? error.message : 'Failed to update participant')
       throw error
     }
   }
@@ -233,7 +233,7 @@ export function AgentMailPage() {
               <p>
                 {!hasConfiguredIntegration
                   ? 'Install the Agent Mail MCP server for Claude Code or Codex before agents can send, receive, or answer mailbox requests.'
-                  : 'Start or resume an agent in a repository, then have it call deck_whoami once so Claude Deck can attach it to a team member.'}
+                  : 'Start or resume an agent in a repository, then have it call deck_whoami once so Claude Deck can attach it to a participant.'}
               </p>
               <div className="flex shrink-0 flex-wrap gap-2">
                 <Button size="sm" variant="outline" onClick={() => setHelpOpen(true)}>
@@ -265,7 +265,7 @@ export function AgentMailPage() {
       <div className="grid gap-4 md:grid-cols-4">
         <Card className="rounded-lg">
           <CardHeader className="pb-3">
-            <CardDescription>Members</CardDescription>
+            <CardDescription>Participants</CardDescription>
             <CardTitle className="flex items-center gap-2 text-3xl">
               <Users className="h-5 w-5 text-muted-foreground" />
               {members.length}

--- a/frontend/src/features/agent-mail/ComposeDialog.tsx
+++ b/frontend/src/features/agent-mail/ComposeDialog.tsx
@@ -43,6 +43,12 @@ const composeKinds: Array<Exclude<MailMessageKind, 'answer'>> = [
   'handoff',
 ]
 
+function recipientLabel(member: MailMemberResponse): string {
+  const role = member.role ? `, ${member.role}` : ''
+  const team = member.team_preset_name ? `, ${member.team_preset_name}` : ''
+  return `${member.display_name} (${member.repo_name}${role}${team})`
+}
+
 export function ComposeDialog({ open, members, preset, onOpenChange, onSend }: ComposeDialogProps) {
   const [kind, setKind] = useState<Exclude<MailMessageKind, 'answer'>>('message')
   const [recipient, setRecipient] = useState('')
@@ -135,12 +141,12 @@ export function ComposeDialog({ open, members, preset, onOpenChange, onSend }: C
                 <Label>Recipient</Label>
                 <Select value={recipient} onValueChange={setRecipient}>
                   <SelectTrigger>
-                    <SelectValue placeholder="Select a member" />
+                    <SelectValue placeholder="Select a participant" />
                   </SelectTrigger>
                   <SelectContent>
                     {members.map((member) => (
                       <SelectItem key={member.id} value={String(member.id)}>
-                        {member.display_name}
+                        {recipientLabel(member)}
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/frontend/src/features/agent-mail/MemberEditDialog.tsx
+++ b/frontend/src/features/agent-mail/MemberEditDialog.tsx
@@ -61,7 +61,7 @@ export function MemberEditDialog({ member, open, onOpenChange, onSave }: MemberE
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className={MODAL_SIZES.SM}>
         <DialogHeader>
-          <DialogTitle>Edit team member</DialogTitle>
+          <DialogTitle>Edit participant</DialogTitle>
         </DialogHeader>
         <form className="space-y-4" onSubmit={handleSubmit}>
           <div className="space-y-2">

--- a/frontend/src/features/agent-mail/TeamTab.tsx
+++ b/frontend/src/features/agent-mail/TeamTab.tsx
@@ -121,6 +121,9 @@ export function TeamTab({
       member.charter ?? '',
       member.repo_name,
       member.repo_path,
+      member.team_preset_name ?? '',
+      member.team_slot_name ?? '',
+      member.participant_kind,
     ].join(' ').toLowerCase()
     return matchesStatus && (!normalizedSearch || haystack.includes(normalizedSearch))
   })
@@ -175,8 +178,22 @@ export function TeamTab({
                 <CardHeader className="pb-3">
                   <div className="flex items-start justify-between gap-4">
                     <div className="min-w-0">
-                      <CardTitle className="truncate text-lg">{member.display_name}</CardTitle>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <CardTitle className="truncate text-lg">{member.display_name}</CardTitle>
+                        {member.participant_kind === 'team_slot' && (
+                          <Badge variant="outline" title={member.team_preset_name ?? undefined}>
+                            Team slot
+                          </Badge>
+                        )}
+                      </div>
                       <p className="truncate text-sm text-muted-foreground">{member.repo_path}</p>
+                      {member.team_preset_name && (
+                        <p className="truncate text-xs text-muted-foreground">
+                          {member.team_slot_name
+                            ? `${member.team_preset_name} / ${member.team_slot_name}`
+                            : member.team_preset_name}
+                        </p>
+                      )}
                     </div>
                     <div className="flex shrink-0 flex-wrap justify-end gap-2">
                       <Badge
@@ -296,7 +313,7 @@ export function TeamTab({
                       </div>
                     ) : (
                       <div className="rounded-lg border border-dashed px-3 py-4 text-sm text-muted-foreground">
-                        No sessions observed for this member.
+                        No sessions observed for this participant.
                       </div>
                     )}
                   </div>
@@ -338,7 +355,7 @@ export function TeamTab({
       ) : (
         <Card className="rounded-lg border-dashed">
           <CardContent className="py-12 text-center text-sm text-muted-foreground">
-            {loading ? 'Loading team members...' : 'No team members match the current filters.'}
+            {loading ? 'Loading participants...' : 'No participants match the current filters.'}
           </CardContent>
         </Card>
       )}

--- a/frontend/src/features/agent-mail/ThreadDialog.tsx
+++ b/frontend/src/features/agent-mail/ThreadDialog.tsx
@@ -234,7 +234,7 @@ export function ThreadDialog({
                 <Label>Reply as</Label>
                 <Select value={sender} onValueChange={setSender}>
                   <SelectTrigger>
-                    <SelectValue placeholder="Select member" />
+                    <SelectValue placeholder="Select participant" />
                   </SelectTrigger>
                   <SelectContent>
                     {members.map((member) => (

--- a/frontend/src/types/agentMail.ts
+++ b/frontend/src/types/agentMail.ts
@@ -23,10 +23,16 @@ export interface MailSessionResponse {
 
 export interface MailMemberResponse {
   id: number
+  identity_key: string
   repo_id: string
   repo_path: string
   repo_name: string
   display_name: string
+  participant_kind: 'repo' | 'team_slot' | string
+  team_preset_id?: number | null
+  team_preset_name?: string | null
+  team_slot_id?: number | null
+  team_slot_name?: string | null
   role?: string | null
   charter?: string | null
   status: MailMemberStatus


### PR DESCRIPTION
Closes #202.

## Summary
- adds routable Agent Mail participant identities so Agent Team slots can create distinct mailboxes in the same repository
- updates registration, observed tmux attachment, nudging, MCP roster output, and Agent Teams reuse/import behavior for same-repo slots
- updates UI labels/docs from repo-only members toward participants while preserving existing member id API routing
- adds SQLite compatibility migration that removes the old repo_id uniqueness and backfills identity keys

## Verification
- `backend/venv/bin/pytest backend/tests -q`
- `backend/venv/bin/pytest backend/tests/agent_mail/test_registry.py backend/tests/agent_teams/test_agent_team_service.py -q`
- `npm run build` from `frontend/`
- copied current SQLite DB and ran `init_db()`: member/session/receipt counts preserved, no repo_id unique index remained, identity keys populated, `foreign_key_check` clean