### PR TITLE
Fix Agent Mail wakeability for Claude Code tmux sessions

### DIFF
--- a/backend/app/services/agent_mail_service.py
+++ b/backend/app/services/agent_mail_service.py
@@ -40,6 +40,7 @@ OBSERVED_TTL_SECONDS = 300
 STALE_REQUEST_MINUTES = 15
 AUTO_NUDGE_COOLDOWN_SECONDS = 30
 TMUX_ENTER_DELAY_SECONDS = 0.25
+TMUX_WAKE_PROVIDERS = {"claude-code", "codex-cli"}
 INBOX_CHECK_PROMPT = (
     "Claude Deck Agent Mail: please call `deck_check_inbox(unread_only=False)` now, "
     "then answer any pending context requests or handoffs before continuing."
@@ -495,7 +496,7 @@ class AgentMailService:
     def _session_can_nudge(self, session: MailAgentSession, now: datetime) -> bool:
         return bool(
             session.source == "observed"
-            and session.provider == "codex-cli"
+            and session.provider in TMUX_WAKE_PROVIDERS
             and session.tmux_target
             and self._effective_status(session, now) == "observed"
         )
@@ -929,7 +930,7 @@ class AgentMailService:
             .where(
                 MailAgentSession.member_id == member_id,
                 MailAgentSession.source == "observed",
-                MailAgentSession.provider == "codex-cli",
+                MailAgentSession.provider.in_(sorted(TMUX_WAKE_PROVIDERS)),
                 MailAgentSession.tmux_target.is_not(None),
             )
             .order_by(MailAgentSession.last_seen_at.desc())
@@ -941,7 +942,7 @@ class AgentMailService:
 
     def _send_tmux_inbox_check(self, session: MailAgentSession) -> dict[str, str]:
         if not session.tmux_target:
-            raise ValueError("No live Codex tmux session is available for this member")
+            raise ValueError("No live tmux session is available for this member")
         try:
             subprocess.run(
                 ["tmux", "send-keys", "-t", session.tmux_target, "-l", INBOX_CHECK_PROMPT],
@@ -979,7 +980,7 @@ class AgentMailService:
         return None
 
     async def auto_nudge_members(self, db: AsyncSession, member_ids: set[int]) -> list[dict[str, str | int]]:
-        """Best-effort delivery wakeup for visible tmux-observed Codex recipients."""
+        """Best-effort delivery wakeup for visible tmux-observed recipients."""
         if not member_ids:
             return []
         await self.sync_observed_sessions(db)

--- a/backend/tests/agent_mail/test_external_api.py
+++ b/backend/tests/agent_mail/test_external_api.py
@@ -171,12 +171,13 @@ async def test_external_actor_cannot_read_other_actor_threads(client, db):
 
 
 @pytest.mark.asyncio
-async def test_external_delivery_reports_non_tmux_codex_as_delivered_waiting(client, db):
+@pytest.mark.parametrize("provider", ["codex-cli", "claude-code"])
+async def test_external_delivery_reports_non_tmux_agent_as_delivered_waiting(client, db, provider):
     recipient = await _member(db, "repo-beta", "beta")
     db.add(
         MailAgentSession(
             member_id=recipient.id,
-            provider="codex-cli",
+            provider=provider,
             source="mcp",
             session_key="mcp:beta",
             cwd=recipient.repo_path,
@@ -206,13 +207,24 @@ async def test_external_delivery_reports_non_tmux_codex_as_delivered_waiting(cli
 
 
 @pytest.mark.asyncio
-async def test_external_delivery_reports_tmux_wake_success(client, db, tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    ("provider", "display_name"),
+    [("codex-cli", "Codex"), ("claude-code", "Claude Code")],
+)
+async def test_external_delivery_reports_tmux_wake_success(
+    client,
+    db,
+    tmp_path,
+    monkeypatch,
+    provider,
+    display_name,
+):
     cwd = tmp_path / "repo-beta"
     cwd.mkdir()
     fake = [
         {
-            "provider": "codex-cli",
-            "provider_display_name": "Codex",
+            "provider": provider,
+            "provider_display_name": display_name,
             "tmux_target": "deck:0.1",
             "session_name": "deck",
             "window_name": "main",

--- a/backend/tests/agent_mail/test_registry.py
+++ b/backend/tests/agent_mail/test_registry.py
@@ -462,13 +462,13 @@ async def test_sync_does_not_preserve_team_slot_when_observed_pid_changes(db, sv
 
 
 @pytest.mark.asyncio
-async def test_observed_non_codex_session_cannot_be_nudged(db, svc, tmp_path):
+async def test_observed_unsupported_provider_session_cannot_be_nudged(db, svc, tmp_path):
     cwd = tmp_path / "obs"
     cwd.mkdir()
     fake = [
         {
-            "provider": "claude-code",
-            "provider_display_name": "Claude Code",
+            "provider": "unknown-agent",
+            "provider_display_name": "Unknown Agent",
             "tmux_target": "w:0.1",
             "session_name": "w",
             "window_name": "main",
@@ -488,13 +488,24 @@ async def test_observed_non_codex_session_cannot_be_nudged(db, svc, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_queue_inbox_check_sends_prompt_to_tmux_observed_codex(db, svc, tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    ("provider", "display_name"),
+    [("codex-cli", "Codex"), ("claude-code", "Claude Code")],
+)
+async def test_queue_inbox_check_sends_prompt_to_tmux_observed_agent(
+    db,
+    svc,
+    tmp_path,
+    monkeypatch,
+    provider,
+    display_name,
+):
     cwd = tmp_path / "obs"
     cwd.mkdir()
     fake = [
         {
-            "provider": "codex-cli",
-            "provider_display_name": "Codex",
+            "provider": provider,
+            "provider_display_name": display_name,
             "tmux_target": "w:0.1",
             "session_name": "w",
             "window_name": "main",
@@ -528,13 +539,24 @@ async def test_queue_inbox_check_sends_prompt_to_tmux_observed_codex(db, svc, tm
 
 
 @pytest.mark.asyncio
-async def test_send_message_auto_nudges_tmux_observed_codex_recipient(db, svc, tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    ("provider", "display_name"),
+    [("codex-cli", "Codex"), ("claude-code", "Claude Code")],
+)
+async def test_send_message_auto_nudges_tmux_observed_recipient(
+    db,
+    svc,
+    tmp_path,
+    monkeypatch,
+    provider,
+    display_name,
+):
     cwd = tmp_path / "obs"
     cwd.mkdir()
     fake = [
         {
-            "provider": "codex-cli",
-            "provider_display_name": "Codex",
+            "provider": provider,
+            "provider_display_name": display_name,
             "tmux_target": "w:0.1",
             "session_name": "w",
             "window_name": "main",
@@ -770,12 +792,13 @@ async def test_dead_mcp_process_reports_offline_even_before_ttl(db, svc, tmp_pat
 
 
 @pytest.mark.asyncio
-async def test_connected_codex_mcp_session_without_tmux_is_delivered_waiting(db, svc, tmp_path):
+@pytest.mark.parametrize("provider", ["codex-cli", "claude-code"])
+async def test_connected_mcp_session_without_tmux_is_delivered_waiting(db, svc, tmp_path, provider):
     cwd = tmp_path / "r"
     cwd.mkdir()
     await svc.register_session(
         db,
-        _register(str(cwd), session_key="mcp:abc", source="mcp", provider="codex-cli"),
+        _register(str(cwd), session_key="mcp:abc", source="mcp", provider=provider),
     )
 
     members = await svc.list_team(db)

--- a/docs/features/agent-mail.md
+++ b/docs/features/agent-mail.md
@@ -17,17 +17,17 @@ Claude Code gets both MCP tools and command hooks:
 - Session and prompt hooks inject state-based mailbox context into the agent conversation.
 - Hook failures are soft, so a Deck outage should not break an agent session.
 
-Codex CLI gets the MCP server through `codex mcp add`. Claude Deck also installs Codex `SessionStart` and `UserPromptSubmit` lifecycle hooks so Codex can receive mailbox reminders at turn boundaries.
+Codex CLI gets the MCP server through `codex mcp add`. Codex lifecycle hooks are not part of the integration, so Codex agents should check their inbox through the MCP tools when starting and finishing work.
 
 ## Delivery Nudges
 
-When a message is delivered to a reachable Codex member, Claude Deck tries to wake it with an inbox-check prompt. The automatic nudge is best-effort and throttled per recipient, so rapid message bursts do not keep injecting prompts into the same session. The **Queue inbox check** button remains available for a manual retry when the UI shows unread or pending mail.
+When a message is delivered to a reachable Claude Code or Codex member, Claude Deck tries to wake it with an inbox-check prompt. The automatic nudge is best-effort and throttled per recipient, so rapid message bursts do not keep injecting prompts into the same session. The **Queue inbox check** button remains available for a manual retry when the UI shows unread or pending mail.
 
-Claude Deck uses one visible Codex wake path:
+Claude Deck uses one visible wake path:
 
 - tmux-observed sessions can be nudged through Agent Bridge by sending text and `Enter` to the pane.
 
-Non-tmux Codex sessions can still receive and send Agent Mail through MCP, but Claude Deck cannot wake their visible terminal session yet. Messages for those sessions remain delivered and unread until the agent calls `deck_check_inbox` or reaches a hook boundary. Agents should still call `deck_check_inbox` before major work and after finishing a task.
+Non-tmux Claude Code and Codex sessions can still receive and send Agent Mail through MCP, but Claude Deck cannot wake their visible terminal session yet. Messages for those sessions remain delivered and unread until the agent calls `deck_check_inbox` or reaches a provider hook boundary. Agents should still call `deck_check_inbox` before major work and after finishing a task.
 
 ## External Local Callers
 

--- a/docs/features/external-agent-orchestration.md
+++ b/docs/features/external-agent-orchestration.md
@@ -2,7 +2,7 @@
 
 Claude Deck exposes a local Agent Mail API for tools such as OpenClaw to coordinate installed agents without pretending to be a repo agent or a UI user.
 
-This API is for same-machine automation. It does not replace Agent Teams preset launch APIs, and it does not add a new wake path for non-tmux Codex sessions.
+This API is for same-machine automation. It does not replace Agent Teams preset launch APIs, and it does not add a new wake path for non-tmux agent sessions.
 
 ## Setup
 
@@ -39,7 +39,7 @@ The response includes each Agent Mail participant's repo, role, charter, connect
 
 Wake states mean:
 
-- `wakeable`: Claude Deck has a visible wake path, currently tmux-observed Codex through Agent Bridge.
+- `wakeable`: Claude Deck has a visible wake path, currently tmux-observed Claude Code or Codex through Agent Bridge.
 - `delivered_waiting`: the message can be stored and read through Agent Mail, but Claude Deck cannot wake the visible session.
 - `offline`: no live session is available.
 
@@ -150,6 +150,6 @@ Once agents register through Agent Mail, use `/external/agent-mail/members` to d
 ## Safeguards
 
 - External actor tokens are distinct from Agent Mail members and are shown by name in the Agent Mail UI.
-- Non-tmux Codex sessions return `delivered_waiting`; they are not falsely reported as woken.
+- Non-tmux Claude Code and Codex sessions return `delivered_waiting`; they are not falsely reported as woken.
 - Per-actor message rate limits return `429` with a `Retry-After` header.
 - This is a local trust boundary, not a general network authentication system.

--- a/frontend/src/features/agent-mail/AgentMailHelpDialog.tsx
+++ b/frontend/src/features/agent-mail/AgentMailHelpDialog.tsx
@@ -59,11 +59,11 @@ export function AgentMailHelpDialog({ open, onOpenChange }: AgentMailHelpDialogP
             </ol>
           </HelpSection>
 
-          <HelpSection icon={Terminal} title="Non-tmux Codex delivery">
+          <HelpSection icon={Terminal} title="Non-tmux delivery">
             <p>
-              Codex sessions outside tmux can receive mail through MCP, but Claude Deck cannot
-              wake their visible terminal session yet. Those messages stay unread until the agent
-              checks its inbox or reaches a hook boundary.
+              Claude Code and Codex sessions outside tmux can receive mail through MCP, but
+              Claude Deck cannot wake their visible terminal session yet. Those messages stay
+              unread until the agent checks its inbox or reaches a hook boundary.
             </p>
           </HelpSection>
 


### PR DESCRIPTION
## Summary

- Fixes #204.
- Allows Agent Mail tmux wake nudges for Claude Code as well as Codex.
- Keeps unsupported providers and non-tmux sessions non-wakeable.
- Updates Agent Mail and external orchestration docs/help copy to remove Codex-only wake wording.

## Validation

- `backend/venv/bin/pytest backend/tests/agent_mail/test_registry.py backend/tests/agent_mail/test_external_api.py -q`
- `npx eslint src/features/agent-mail/AgentMailHelpDialog.tsx`

## Note

`npm --prefix frontend run lint` still fails on pre-existing project-wide lint errors outside this change, including `frontend/src/components/ui/chart.tsx`, `frontend/src/contexts/ProviderContext.tsx`, and several React hook memoization warnings.