### PR TITLE
Disable legacy Presence ingestion by default

### DIFF
--- a/backend/app/api/v1/presence.py
+++ b/backend/app/api/v1/presence.py
@@ -1,9 +1,10 @@
-"""API endpoints for Presence Dashboard — webhook receiver, REST, and WebSocket."""
+"""API endpoints for legacy Presence diagnostics."""
 import json
 
-from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import settings
 from app.database import get_db
 from app.models.constants import SessionStatus
 from app.models.schemas import (
@@ -24,7 +25,13 @@ async def receive_event(
     payload: PresenceEventIn,
     db: AsyncSession = Depends(get_db),
 ):
-    """Webhook receiver for Claude Code HTTP hooks. Always returns {} with 200."""
+    """Legacy Claude Code hook receiver.
+
+    Disabled by default so old Presence hooks fail soft without writing events.
+    """
+    if not settings.enable_presence:
+        return {}
+
     dumped = payload.model_dump()
     updated_session = await service.process_event(dumped, db)
 
@@ -90,6 +97,12 @@ async def clear_all_sessions(db: AsyncSession = Depends(get_db)):
 @router.get("/config-snippet", response_model=PresenceConfigSnippet)
 async def get_config_snippet():
     """Generate the settings.json snippet for hooking up Claude Code."""
+    if not settings.enable_presence:
+        raise HTTPException(
+            status_code=404,
+            detail="Presence ingestion is disabled. Set CLAUDE_DECK_ENABLE_PRESENCE=true to enable legacy Presence hooks.",
+        )
+
     url = "http://localhost:8000/api/v1/presence/events"
     events = [
         "Notification", "PreToolUse", "PostToolUse", "Stop",
@@ -115,6 +128,10 @@ async def presence_websocket(
     db: AsyncSession = Depends(get_db),
 ):
     """WebSocket for live presence updates. On connect, sends all current sessions."""
+    if not settings.enable_presence:
+        await ws.close(code=4403, reason="Presence disabled")
+        return
+
     await manager.connect(ws)
     try:
         # Send initial state

--- a/backend/app/api/v1/status.py
+++ b/backend/app/api/v1/status.py
@@ -3,14 +3,10 @@ import asyncio
 import time
 from typing import Any, Optional
 
-from fastapi import APIRouter, Depends
-from sqlalchemy.ext.asyncio import AsyncSession
+from fastapi import APIRouter
 
-from app.database import get_db
-from app.models.constants import SessionStatus
 from app.models.schemas import SystemStatusResponse
 from app.services.instance_identity import get_instance_identity
-from app.services.presence_service import PresenceService
 from app.services.providers import get_provider, get_providers
 
 router = APIRouter()
@@ -39,12 +35,6 @@ async def _get_claude_code_version() -> Optional[str]:
         return version
 
 
-async def _get_active_count(db: AsyncSession) -> int:
-    service = PresenceService()
-    sessions = await service.get_all_sessions(db)
-    return sum(1 for s in sessions if s.status == SessionStatus.ACTIVE)
-
-
 async def _get_provider_statuses() -> dict[str, Any]:
     statuses = await asyncio.gather(
         *(asyncio.to_thread(provider.get_status) for provider in get_providers())
@@ -53,17 +43,16 @@ async def _get_provider_statuses() -> dict[str, Any]:
 
 
 @router.get("/status", response_model=SystemStatusResponse)
-async def get_system_status(db: AsyncSession = Depends(get_db)):
+async def get_system_status():
     """Return system status for header indicators."""
-    version, active_count, provider_statuses = await asyncio.gather(
+    version, provider_statuses = await asyncio.gather(
         _get_claude_code_version(),
-        _get_active_count(db),
         _get_provider_statuses(),
     )
 
     return SystemStatusResponse(
         claude_code_version=version,
-        active_sessions=active_count,
+        active_sessions=0,
         providers=provider_statuses,
         instance=get_instance_identity(),
     )

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -28,6 +28,10 @@ class Settings(BaseSettings):
     # Database settings
     database_url: str = "sqlite+aiosqlite:///./claude_registry.db"
 
+    # Legacy Presence telemetry is disabled by default. Agent Mail and Agent
+    # Bridge now own live agent availability; enable only for old diagnostics.
+    enable_presence: bool = False
+
     # Server settings
     host: str = "0.0.0.0"
     port: int = 8000

--- a/backend/tests/test_presence_api.py
+++ b/backend/tests/test_presence_api.py
@@ -1,0 +1,89 @@
+"""Legacy Presence API behavior."""
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+import app.models.database  # noqa: F401
+from app.config import settings
+from app.database import Base, get_db
+from app.main import app
+from app.models.database import PresenceEvent, PresenceSession
+
+
+@pytest_asyncio.fixture
+async def db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(db):
+    async def _override():
+        yield db
+
+    app.dependency_overrides[get_db] = _override
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+async def _count(db, model) -> int:
+    return (await db.execute(select(func.count()).select_from(model))).scalar_one()
+
+
+@pytest.mark.asyncio
+async def test_presence_events_noop_when_disabled_by_default(client, db, monkeypatch):
+    monkeypatch.setattr(settings, "enable_presence", False)
+
+    resp = await client.post(
+        "/api/v1/presence/events",
+        json={
+            "session_id": "s1",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "cwd": "/tmp/repo",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {}
+    assert await _count(db, PresenceEvent) == 0
+    assert await _count(db, PresenceSession) == 0
+
+
+@pytest.mark.asyncio
+async def test_presence_config_snippet_hidden_when_disabled(client, monkeypatch):
+    monkeypatch.setattr(settings, "enable_presence", False)
+
+    resp = await client.get("/api/v1/presence/config-snippet")
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_presence_events_process_when_explicitly_enabled(client, db, monkeypatch):
+    monkeypatch.setattr(settings, "enable_presence", True)
+
+    resp = await client.post(
+        "/api/v1/presence/events",
+        json={
+            "session_id": "s1",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "cwd": "/tmp/repo",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {}
+    assert await _count(db, PresenceEvent) == 1
+    assert await _count(db, PresenceSession) == 1

--- a/docs/plans/agent-mail/2026-06-13-presence-feature-usability-review.md
+++ b/docs/plans/agent-mail/2026-06-13-presence-feature-usability-review.md
@@ -22,6 +22,8 @@ Recommended direction:
 
 **Rationale:** Agent Mail should become the center of gravity for team coordination and agent availability. Presence remains useful as telemetry infrastructure, but the current standalone card dashboard is not strong enough to sit beside Agent Mail as a primary Operations feature.
 
+**2026-06-18 update:** Disable Presence ingestion by default and remove legacy Presence HTTP hooks from active Claude Code user settings. The hidden frontend was not enough: installed Presence hooks still posted every hook event to `/api/v1/presence/events`, causing extra HTTP proxy traffic, SQLite writes, session aggregation, and WebSocket broadcast attempts during active Claude Code use. The backend should now no-op Presence event ingestion unless `CLAUDE_DECK_ENABLE_PRESENCE=true` is set. Agent Mail hooks remain installed.
+
 **Revisit after usage:** Re-evaluate after Agent Mail has been used in normal multi-agent work for a while. The review question should be: "Do users still need a dedicated activity/diagnostics timeline, or are Agent Mail and Agent Bridge enough?"
 
 Possible revisit outcomes:
@@ -42,7 +44,7 @@ That can still be useful, but only if the feature gives the user actionable obse
 
 Presence is implemented as a Claude Code hook telemetry dashboard:
 
-- `POST /api/v1/presence/events` receives Claude Code HTTP hook payloads.
+- `POST /api/v1/presence/events` receives Claude Code HTTP hook payloads only when legacy Presence ingestion is explicitly enabled.
 - `PresenceEvent` stores raw hook events.
 - `PresenceSession` stores aggregated per-session state.
 - The frontend shows a page with session counts, active/error totals, and one card per session.

--- a/frontend/src/types/hooks.ts
+++ b/frontend/src/types/hooks.ts
@@ -378,11 +378,4 @@ export const HOOK_TEMPLATES: HookTemplate[] = [
     model: "haiku",
     once: true,
   },
-  {
-    name: "Presence Dashboard Logger",
-    description: "Send events to Presence Dashboard via HTTP hook",
-    event: "PostToolUse",
-    type: "http",
-    url: "http://localhost:8000/api/v1/presence/events",
-  },
 ];


### PR DESCRIPTION
## Summary

- Removes the legacy Presence hook template from the Hooks wizard.
- Makes `/api/v1/presence/events` a soft no-op unless `CLAUDE_DECK_ENABLE_PRESENCE=true` is set.
- Stops `/api/v1/status` from querying Presence tables on every header poll.
- Records the decision in the Agent Mail Presence review note.

## Operational cleanup already applied

- Removed Presence HTTP hooks from the laptop Claude Code user settings.
- Removed Presence HTTP hooks from this machine Claude Code user settings.
- Verified both machines now have `0` Presence hooks and `4` Agent Mail hooks.

## Validation

- `backend/venv/bin/pytest backend/tests/test_presence_api.py backend/tests/test_instance_identity.py -q`
- `npx eslint src/types/hooks.ts`
- `git diff --check`

Fixes #207