### PR TITLE
Add Codex model and profile selectors

### DIFF
--- a/backend/app/api/v1/providers.py
+++ b/backend/app/api/v1/providers.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from app.models.schemas import CLIExecuteRequest, CLIResult
 from app.services.cli_executor import ProviderCLIExecutor
+from app.services.codex_config_service import CodexConfigService
 from app.services.codex_history_service import CodexHistoryService
 from app.services.codex_usage_context_service import CodexUsageContextService
 from app.services.providers import get_provider, get_providers
@@ -151,6 +152,12 @@ def get_provider_capabilities(provider_id: str):
         "capabilities": provider.get_capabilities(),
         "capability_matrix": provider.get_capability_matrix(),
     }
+
+
+@router.get("/providers/{provider_id}/launch-options")
+def get_provider_launch_options(provider_id: str):
+    _require_codex_provider(provider_id, "launch options")
+    return CodexConfigService().get_launch_options()
 
 
 def _get_provider_or_404(provider_id: str):

--- a/backend/app/services/codex_config_service.py
+++ b/backend/app/services/codex_config_service.py
@@ -6,6 +6,7 @@ import tempfile
 import tomllib
 import re
 import copy
+import json
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -30,6 +31,7 @@ SAFE_SCALAR_FIELDS = {
 SENSITIVE_KEY_PATTERN = re.compile(r"(token|secret|password|credential|api[_-]?key|auth|cookie|session)", re.I)
 PROFILE_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
 PROFILE_V2_KEYS = ("profile-v2", "profile_v2")
+MAX_MODELS_CACHE_BYTES = 5 * 1024 * 1024
 
 
 class CodexConfigService:
@@ -41,6 +43,10 @@ class CodexConfigService:
     @property
     def config_file(self) -> Path:
         return self.codex_home / "config.toml"
+
+    @property
+    def models_cache_file(self) -> Path:
+        return self.codex_home / "models_cache.json"
 
     def parse_toml_file(self, path: Path) -> tuple[dict[str, Any], str | None]:
         if not path.exists():
@@ -259,6 +265,193 @@ class CodexConfigService:
                 for source in sources if source["parse_error"]
             ],
             "effective_summary": effective_summary,
+        }
+
+    def _read_models_cache(self) -> tuple[dict[str, Any], str | None]:
+        path = self.models_cache_file
+        if not path.exists():
+            return {}, None
+
+        try:
+            if path.stat().st_size > MAX_MODELS_CACHE_BYTES:
+                return {}, "models_cache.json exceeds read limit"
+            with path.open("r", encoding="utf-8") as file:
+                data = json.load(file)
+        except json.JSONDecodeError as exc:
+            return {}, str(exc)
+        except OSError as exc:
+            return {}, str(exc)
+
+        if not isinstance(data, dict):
+            return {}, "models_cache.json root is not an object"
+        return data, None
+
+    @staticmethod
+    def _model_option_from_mapping(value: str, metadata: Any, source: str) -> dict[str, Any] | None:
+        if not value or "\x00" in value:
+            return None
+
+        label = value
+        description = None
+        priority = None
+        if isinstance(metadata, dict):
+            display_name = metadata.get("display_name")
+            if isinstance(display_name, str) and display_name.strip():
+                label = display_name.strip()
+            description_value = metadata.get("description")
+            if isinstance(description_value, str) and description_value.strip():
+                description = description_value.strip()
+            priority_value = metadata.get("priority")
+            if isinstance(priority_value, int):
+                priority = priority_value
+
+        option = {
+            "value": value,
+            "label": label,
+            "source": source,
+        }
+        if description is not None:
+            option["description"] = description
+        if priority is not None:
+            option["priority"] = priority
+        return option
+
+    def _get_model_options(
+        self,
+        config: dict[str, Any],
+        effective_summary: dict[str, Any],
+    ) -> tuple[list[dict[str, Any]], str | None]:
+        cache, parse_error = self._read_models_cache()
+        options: list[dict[str, Any]] = []
+        seen: set[str] = set()
+
+        def add_option(option: dict[str, Any] | None) -> None:
+            if not option:
+                return
+            value = option["value"]
+            if value in seen:
+                return
+            seen.add(value)
+            options.append(option)
+
+        models = cache.get("models")
+        if isinstance(models, list):
+            for item in models:
+                if isinstance(item, str):
+                    add_option(self._model_option_from_mapping(item, {}, "models_cache"))
+                elif isinstance(item, dict):
+                    slug = item.get("slug") or item.get("id") or item.get("name") or item.get("model")
+                    if isinstance(slug, str):
+                        add_option(self._model_option_from_mapping(slug, item, "models_cache"))
+        elif isinstance(models, dict):
+            for value, metadata in sorted(models.items()):
+                if isinstance(value, str):
+                    slug = metadata.get("slug") if isinstance(metadata, dict) else None
+                    add_option(
+                        self._model_option_from_mapping(
+                            slug if isinstance(slug, str) else value,
+                            metadata,
+                            "models_cache",
+                        )
+                    )
+
+        for source, value in (
+            ("effective_config", effective_summary.get("model")),
+            ("config", config.get("model")),
+        ):
+            if isinstance(value, str) and value.strip():
+                add_option({
+                    "value": value.strip(),
+                    "label": value.strip(),
+                    "source": source,
+                })
+
+        return options, parse_error
+
+    def _get_profile_options(
+        self,
+        profile_resolution: dict[str, Any] | None,
+        config: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        options_by_name: dict[str, dict[str, Any]] = {}
+
+        def add_profile(
+            name: Any,
+            source: str,
+            *,
+            parse_error: str | None = None,
+            active: bool = False,
+        ) -> None:
+            if not isinstance(name, str) or not name.strip():
+                return
+            clean_name = name.strip()
+            option = options_by_name.setdefault(
+                clean_name,
+                {
+                    "value": clean_name,
+                    "label": clean_name,
+                    "sources": [],
+                    "active": False,
+                    "parse_error": None,
+                },
+            )
+            if source not in option["sources"]:
+                option["sources"].append(source)
+            if active:
+                option["active"] = True
+            if parse_error and not option["parse_error"]:
+                option["parse_error"] = parse_error
+
+        if profile_resolution:
+            active_names = {
+                profile_resolution.get("active_profile"),
+                profile_resolution.get("active_profile_v2"),
+            }
+            for source in profile_resolution.get("profiles", []):
+                if not isinstance(source, dict):
+                    continue
+                name = source.get("name")
+                add_profile(
+                    name,
+                    str(source.get("source") or "profile"),
+                    parse_error=source.get("parse_error") if isinstance(source.get("parse_error"), str) else None,
+                    active=name in active_names,
+                )
+            for missing in profile_resolution.get("missing_references", []):
+                if isinstance(missing, dict):
+                    add_profile(missing.get("name"), "missing_reference", active=True)
+
+        add_profile(config.get("profile"), "config", active=True)
+        active_profile_v2 = self._get_profile_v2_reference(config)
+        add_profile(active_profile_v2, "config", active=True)
+
+        return sorted(options_by_name.values(), key=lambda option: option["value"].lower())
+
+    def get_launch_options(self) -> dict[str, Any]:
+        """Return non-secret Codex values useful when launching new sessions."""
+        config, parse_error = self.parse_toml_file(self.config_file)
+        profile_resolution = self.resolve_profiles(config) if not parse_error else None
+        effective_summary = profile_resolution["effective_summary"] if profile_resolution else {}
+        default_profile = None
+        if profile_resolution:
+            default_profile = (
+                profile_resolution.get("active_profile")
+                or profile_resolution.get("active_profile_v2")
+            )
+        model_options, models_parse_error = self._get_model_options(config, effective_summary)
+
+        return {
+            "provider": "codex-cli",
+            "config_path": str(self.config_file),
+            "models_cache_path": str(self.models_cache_file),
+            "config_exists": self.config_file.exists(),
+            "config_parse_error": parse_error,
+            "models_cache_exists": self.models_cache_file.exists(),
+            "models_cache_parse_error": models_parse_error,
+            "default_model": effective_summary.get("model") or config.get("model"),
+            "default_profile": default_profile,
+            "model_options": model_options,
+            "profile_options": self._get_profile_options(profile_resolution, config),
         }
 
     def get_all_config_files(self) -> list[dict[str, Any]]:

--- a/backend/tests/test_codex_config_service.py
+++ b/backend/tests/test_codex_config_service.py
@@ -190,6 +190,126 @@ def test_codex_profile_resolution_handles_default_config_without_profile(tmp_pat
     assert resolution["effective_summary"]["features"]["search"] is True
 
 
+def test_codex_launch_options_include_models_and_profiles(tmp_path):
+    from app.services.codex_config_service import CodexConfigService
+
+    (tmp_path / "config.toml").write_text(
+        '\n'.join([
+            'model = "configured-model"',
+            'profile = "work"',
+            '',
+            '[profiles.work]',
+            'model = "profile-model"',
+            '',
+            '[profiles.review]',
+            'approval_policy = "on-request"',
+        ]),
+        encoding="utf-8",
+    )
+    (tmp_path / "work.config.toml").write_text('sandbox_mode = "workspace-write"\n', encoding="utf-8")
+    (tmp_path / "models_cache.json").write_text(
+        """{
+          "models": [
+            {
+              "slug": "gpt-5.1-codex",
+              "display_name": "GPT-5.1 Codex",
+              "description": "Code model",
+              "priority": 10
+            },
+            {"slug": "profile-model", "display_name": "Profile Model"}
+          ]
+        }""",
+        encoding="utf-8",
+    )
+
+    options = CodexConfigService(codex_home=tmp_path).get_launch_options()
+
+    assert options["provider"] == "codex-cli"
+    assert options["default_model"] == "profile-model"
+    assert options["default_profile"] == "work"
+    assert options["models_cache_parse_error"] is None
+    assert [model["value"] for model in options["model_options"]] == [
+        "gpt-5.1-codex",
+        "profile-model",
+        "configured-model",
+    ]
+    assert options["model_options"][0]["label"] == "GPT-5.1 Codex"
+    assert options["profile_options"] == [
+        {
+            "value": "review",
+            "label": "review",
+            "sources": ["inline"],
+            "active": False,
+            "parse_error": None,
+        },
+        {
+            "value": "work",
+            "label": "work",
+            "sources": ["inline", "file", "config"],
+            "active": True,
+            "parse_error": None,
+        },
+    ]
+
+
+def test_codex_launch_options_handle_model_cache_dict_and_errors(tmp_path):
+    from app.services.codex_config_service import CodexConfigService
+
+    (tmp_path / "config.toml").write_text('model = "configured-model"\n', encoding="utf-8")
+    (tmp_path / "models_cache.json").write_text(
+        """{
+          "models": {
+            "gpt-5-codex": {"display_name": "GPT-5 Codex"},
+            "gpt-5.1-codex": {"slug": "gpt-5.1-codex", "display_name": "GPT-5.1 Codex"}
+          }
+        }""",
+        encoding="utf-8",
+    )
+
+    options = CodexConfigService(codex_home=tmp_path).get_launch_options()
+
+    assert [model["value"] for model in options["model_options"]] == [
+        "gpt-5-codex",
+        "gpt-5.1-codex",
+        "configured-model",
+    ]
+    assert options["models_cache_parse_error"] is None
+
+    (tmp_path / "models_cache.json").write_text("not json", encoding="utf-8")
+
+    options = CodexConfigService(codex_home=tmp_path).get_launch_options()
+
+    assert options["model_options"] == [
+        {
+            "value": "configured-model",
+            "label": "configured-model",
+            "source": "effective_config",
+        }
+    ]
+    assert options["models_cache_parse_error"]
+
+
+def test_codex_launch_options_uses_profile_v2_as_default_profile(tmp_path):
+    from app.services.codex_config_service import CodexConfigService
+
+    (tmp_path / "config.toml").write_text('profile-v2 = "reviewer"\n', encoding="utf-8")
+    (tmp_path / "reviewer.config.toml").write_text('model = "review-model"\n', encoding="utf-8")
+
+    options = CodexConfigService(codex_home=tmp_path).get_launch_options()
+
+    assert options["default_profile"] == "reviewer"
+    assert options["default_model"] == "review-model"
+    assert options["profile_options"] == [
+        {
+            "value": "reviewer",
+            "label": "reviewer",
+            "sources": ["file", "config"],
+            "active": True,
+            "parse_error": None,
+        }
+    ]
+
+
 def test_codex_profile_resolution_does_not_build_paths_for_unsafe_references(tmp_path):
     from app.services.codex_config_service import CodexConfigService
 

--- a/backend/tests/test_provider_contract_api.py
+++ b/backend/tests/test_provider_contract_api.py
@@ -44,6 +44,39 @@ def test_provider_mcp_inventory_wrong_provider_returns_contract_error():
     assert exc_info.value.detail["supported_providers"] == ["codex-cli"]
 
 
+def test_provider_launch_options_wrong_provider_returns_contract_error():
+    from app.api.v1 import providers as providers_api
+
+    with pytest.raises(providers_api.HTTPException) as exc_info:
+        providers_api.get_provider_launch_options("claude-code")
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail["code"] == "unsupported_provider_operation"
+    assert exc_info.value.detail["provider"] == "claude-code"
+    assert exc_info.value.detail["operation"] == "launch options"
+    assert exc_info.value.detail["supported_providers"] == ["codex-cli"]
+
+
+def test_provider_launch_options_uses_codex_config_service(monkeypatch):
+    from app.api.v1 import providers as providers_api
+
+    class FakeCodexConfigService:
+        def get_launch_options(self):
+            return {
+                "provider": "codex-cli",
+                "model_options": [{"value": "gpt-5-codex", "label": "GPT-5 Codex"}],
+                "profile_options": [{"value": "reviewer", "label": "reviewer"}],
+            }
+
+    monkeypatch.setattr(providers_api, "CodexConfigService", FakeCodexConfigService)
+
+    response = providers_api.get_provider_launch_options("codex-cli")
+
+    assert response["provider"] == "codex-cli"
+    assert response["model_options"][0]["value"] == "gpt-5-codex"
+    assert response["profile_options"][0]["value"] == "reviewer"
+
+
 def test_provider_cli_disallowed_command_returns_contract_error(monkeypatch):
     from app.api.v1 import providers as providers_api
     from app.models.schemas import CLIExecuteRequest

--- a/frontend/src/features/cc-bridge/NewSessionDialog.tsx
+++ b/frontend/src/features/cc-bridge/NewSessionDialog.tsx
@@ -22,12 +22,17 @@ import { MODAL_SIZES } from '@/lib/constants'
 import { claudeProjectFolderFromPath, cn } from '@/lib/utils'
 import { formatTimestamp } from '@/features/usage/utils'
 import type { ProjectResponse } from '@/types/projects'
-import { spawnSession } from './api'
+import { fetchCodexLaunchOptions, spawnSession } from './api'
 import { useSessionsApi } from '@/hooks/useSessionsApi'
 import { useProjectContext } from '@/contexts/ProjectContext'
 import { useProviderContext } from '@/contexts/ProviderContext'
 import type { AgentProviderId } from '@/types/providers'
-import type { SpawnSessionRequest } from './types'
+import type {
+  CodexLaunchModelOption,
+  CodexLaunchOptionsResponse,
+  CodexLaunchProfileOption,
+  SpawnSessionRequest,
+} from './types'
 import type { SessionSummary } from '@/types/sessions'
 
 type Mode = 'plain' | 'worktree' | 'resume' | 'fork'
@@ -52,6 +57,10 @@ const CODEX_MODE_OPTIONS: { value: Mode; label: string }[] = [
 ]
 
 const PLATFORM_STORAGE_KEY = 'cc-bridge.platform'
+const DEFAULT_SELECT_VALUE = '__default__'
+const CUSTOM_SELECT_VALUE = '__custom__'
+const EMPTY_MODEL_OPTIONS: CodexLaunchModelOption[] = []
+const EMPTY_PROFILE_OPTIONS: CodexLaunchProfileOption[] = []
 
 type Platform = 'anthropic' | 'bedrock'
 
@@ -92,6 +101,20 @@ function matchesProjectSearch(project: ProjectResponse, query: string) {
   return terms.every((term) => searchable.includes(term))
 }
 
+function optionValues<T extends { value: string }>(options: T[]) {
+  return new Set(options.map((option) => option.value))
+}
+
+function formatModelOption(option: CodexLaunchModelOption) {
+  return option.label && option.label !== option.value
+    ? `${option.label} (${option.value})`
+    : option.value
+}
+
+function formatProfileOption(option: CodexLaunchProfileOption) {
+  return option.active ? `${option.label} (active)` : option.label
+}
+
 export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvider }: NewSessionDialogProps) {
   const { providers, selectedProviderId } = useProviderContext()
   const defaultProvider = initialProvider ?? selectedProviderId
@@ -103,7 +126,9 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
   const [skipPermissions, setSkipPermissions] = useState(false)
   const [prompt, setPrompt] = useState('')
   const [model, setModel] = useState('')
+  const [customModel, setCustomModel] = useState(false)
   const [profile, setProfile] = useState('')
+  const [customProfile, setCustomProfile] = useState(false)
   const [sandbox, setSandbox] = useState('')
   const [approvalPolicy, setApprovalPolicy] = useState('')
   const [search, setSearch] = useState(false)
@@ -121,6 +146,8 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
   const [recentSessions, setRecentSessions] = useState<SessionSummary[]>([])
   const [selectedSession, setSelectedSession] = useState<SessionSummary | null>(null)
   const [loadingSessions, setLoadingSessions] = useState(false)
+  const [codexLaunchOptions, setCodexLaunchOptions] = useState<CodexLaunchOptionsResponse | null>(null)
+  const [codexLaunchOptionsError, setCodexLaunchOptionsError] = useState<string | null>(null)
   const projectSearchRef = useRef<HTMLInputElement>(null)
   const projectOptionRefs = useRef<Array<HTMLButtonElement | null>>([])
 
@@ -132,6 +159,22 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
     () => projects.filter((project) => matchesProjectSearch(project, projectSearch)),
     [projects, projectSearch],
   )
+  const modelOptions = codexLaunchOptions?.model_options ?? EMPTY_MODEL_OPTIONS
+  const profileOptions = codexLaunchOptions?.profile_options ?? EMPTY_PROFILE_OPTIONS
+  const knownModelValues = useMemo(() => optionValues(modelOptions), [modelOptions])
+  const knownProfileValues = useMemo(() => optionValues(profileOptions), [profileOptions])
+  const modelSelectValue = customModel || (model && !knownModelValues.has(model))
+    ? CUSTOM_SELECT_VALUE
+    : model || DEFAULT_SELECT_VALUE
+  const profileSelectValue = customProfile || (profile && !knownProfileValues.has(profile))
+    ? CUSTOM_SELECT_VALUE
+    : profile || DEFAULT_SELECT_VALUE
+  const defaultModelLabel = codexLaunchOptions?.default_model
+    ? `Default (${codexLaunchOptions.default_model})`
+    : 'Default'
+  const defaultProfileLabel = codexLaunchOptions?.default_profile
+    ? `Default (${codexLaunchOptions.default_profile})`
+    : 'Default'
   const resumeProjectPath = directory.trim()
   const resumeProjectFolder = resumeProjectPath
     ? claudeProjectFolderFromPath(resumeProjectPath)
@@ -177,6 +220,36 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
     }
   }
 
+  function handleModelSelect(value: string) {
+    if (value === DEFAULT_SELECT_VALUE) {
+      setCustomModel(false)
+      setModel('')
+      return
+    }
+    if (value === CUSTOM_SELECT_VALUE) {
+      setCustomModel(true)
+      setModel('')
+      return
+    }
+    setCustomModel(false)
+    setModel(value)
+  }
+
+  function handleProfileSelect(value: string) {
+    if (value === DEFAULT_SELECT_VALUE) {
+      setCustomProfile(false)
+      setProfile('')
+      return
+    }
+    if (value === CUSTOM_SELECT_VALUE) {
+      setCustomProfile(true)
+      setProfile('')
+      return
+    }
+    setCustomProfile(false)
+    setProfile(value)
+  }
+
   useEffect(() => {
     if (open && !directory.trim() && activeProject?.path) {
       setDirectory(activeProject.path)
@@ -192,6 +265,25 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
     setAwsProfile(remembered.aws_profile)
     setBedrockModel(remembered.bedrock_model)
   }, [open])
+
+  useEffect(() => {
+    if (!open || !isCodex) return
+    let cancelled = false
+    fetchCodexLaunchOptions()
+      .then((options) => {
+        if (!cancelled) {
+          setCodexLaunchOptions(options)
+          setCodexLaunchOptionsError(null)
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setCodexLaunchOptions(null)
+          setCodexLaunchOptionsError(err instanceof Error ? err.message : 'Failed to load Codex options')
+        }
+      })
+    return () => { cancelled = true }
+  }, [open, isCodex])
 
   // Fetch sessions when switching to resume mode
   useEffect(() => {
@@ -227,7 +319,9 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
       setSkipPermissions(false)
       setPrompt('')
       setModel('')
+      setCustomModel(false)
       setProfile('')
+      setCustomProfile(false)
       setSandbox('')
       setApprovalPolicy('')
       setSearch(false)
@@ -238,6 +332,8 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
       setError(null)
       setSelectedSession(null)
       setRecentSessions([])
+      setCodexLaunchOptions(null)
+      setCodexLaunchOptionsError(null)
       setSubmitting(false)
     }
   }, [open, defaultProvider])
@@ -327,6 +423,10 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
                 setProvider(value as AgentProviderId)
                 setMode('plain')
                 setSelectedSession(null)
+                setModel('')
+                setCustomModel(false)
+                setProfile('')
+                setCustomProfile(false)
                 setError(null)
               }}
             >
@@ -531,12 +631,63 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
             <div className="grid grid-cols-2 gap-3">
               <div className="space-y-1.5">
                 <Label htmlFor="codex-model">Model</Label>
-                <Input id="codex-model" value={model} onChange={(e) => setModel(e.target.value)} placeholder="default" />
+                <Select value={modelSelectValue} onValueChange={handleModelSelect}>
+                  <SelectTrigger id="codex-model">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={DEFAULT_SELECT_VALUE}>{defaultModelLabel}</SelectItem>
+                    {modelOptions.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {formatModelOption(option)}
+                      </SelectItem>
+                    ))}
+                    <SelectItem value={CUSTOM_SELECT_VALUE}>Custom model</SelectItem>
+                  </SelectContent>
+                </Select>
+                {modelSelectValue === CUSTOM_SELECT_VALUE && (
+                  <Input
+                    id="codex-model-custom"
+                    value={model}
+                    onChange={(event) => setModel(event.target.value)}
+                    placeholder="model name"
+                    autoComplete="off"
+                    aria-label="Custom Codex model"
+                  />
+                )}
               </div>
               <div className="space-y-1.5">
                 <Label htmlFor="codex-profile">Profile</Label>
-                <Input id="codex-profile" value={profile} onChange={(e) => setProfile(e.target.value)} placeholder="default" />
+                <Select value={profileSelectValue} onValueChange={handleProfileSelect}>
+                  <SelectTrigger id="codex-profile">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={DEFAULT_SELECT_VALUE}>{defaultProfileLabel}</SelectItem>
+                    {profileOptions.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {formatProfileOption(option)}
+                      </SelectItem>
+                    ))}
+                    <SelectItem value={CUSTOM_SELECT_VALUE}>Custom profile</SelectItem>
+                  </SelectContent>
+                </Select>
+                {profileSelectValue === CUSTOM_SELECT_VALUE && (
+                  <Input
+                    id="codex-profile-custom"
+                    value={profile}
+                    onChange={(event) => setProfile(event.target.value)}
+                    placeholder="profile name"
+                    autoComplete="off"
+                    aria-label="Custom Codex profile"
+                  />
+                )}
               </div>
+              {codexLaunchOptionsError && (
+                <p className="col-span-2 text-xs text-destructive">
+                  Could not load Codex models and profiles. Custom values are still available.
+                </p>
+              )}
               <div className="space-y-1.5">
                 <Label>Sandbox</Label>
                 <Select value={sandbox || 'default'} onValueChange={(value) => setSandbox(value === 'default' ? '' : value)}>

--- a/frontend/src/features/cc-bridge/api.ts
+++ b/frontend/src/features/cc-bridge/api.ts
@@ -1,6 +1,14 @@
 import { apiClient, buildEndpoint } from '@/lib/api'
 import type { AgentProviderId } from '@/types/providers'
-import type { CCSessionsResponse, CCPreviewResponse, CCTokenResponse, SpawnSessionRequest, SpawnSessionResponse, KillSessionResponse } from './types'
+import type {
+  CCSessionsResponse,
+  CCPreviewResponse,
+  CCTokenResponse,
+  CodexLaunchOptionsResponse,
+  SpawnSessionRequest,
+  SpawnSessionResponse,
+  KillSessionResponse,
+} from './types'
 
 const BASE = 'agent-bridge'
 
@@ -27,6 +35,10 @@ export async function spawnSession(request: SpawnSessionRequest): Promise<SpawnS
     method: 'POST',
     body: JSON.stringify(request),
   })
+}
+
+export async function fetchCodexLaunchOptions(): Promise<CodexLaunchOptionsResponse> {
+  return apiClient<CodexLaunchOptionsResponse>('providers/codex-cli/launch-options')
 }
 
 export async function killSession(target: string, cleanupWorktree: boolean = false): Promise<KillSessionResponse> {

--- a/frontend/src/features/cc-bridge/types.ts
+++ b/frontend/src/features/cc-bridge/types.ts
@@ -63,3 +63,33 @@ export interface KillSessionResponse {
   killed: boolean
   error?: string
 }
+
+export interface CodexLaunchModelOption {
+  value: string
+  label: string
+  source: string
+  description?: string
+  priority?: number
+}
+
+export interface CodexLaunchProfileOption {
+  value: string
+  label: string
+  sources?: string[]
+  active?: boolean
+  parse_error?: string | null
+}
+
+export interface CodexLaunchOptionsResponse {
+  provider: 'codex-cli'
+  config_path: string
+  models_cache_path: string
+  config_exists: boolean
+  config_parse_error: string | null
+  models_cache_exists: boolean
+  models_cache_parse_error: string | null
+  default_model?: string | null
+  default_profile?: string | null
+  model_options: CodexLaunchModelOption[]
+  profile_options: CodexLaunchProfileOption[]
+}


### PR DESCRIPTION
## Summary

Closes #212.

Replaces the Codex `Model` and `Profile` free-text fields in New Agent Session with dropdown selectors while preserving explicit custom values.

## Changes

- Add `GET /providers/codex-cli/launch-options` for non-secret launch UI metadata.
- Source model options from `models_cache.json` using safe fields only: slug/value, display label, description, priority.
- Source profile options from existing Codex config/profile resolution across inline profiles, `*.config.toml`, active references, and missing references.
- Show Codex model/profile selectors in the New Agent Session dialog.
- Keep `Default` behavior as “send no model/profile override”.
- Keep custom model/profile support through an explicit `Custom model` / `Custom profile` choice.

## Verification

- `backend/venv/bin/pytest backend/tests -q` passes: 253 passed.
- `npm run build` passes.
- `npx eslint src/features/cc-bridge/NewSessionDialog.tsx src/features/cc-bridge/api.ts src/features/cc-bridge/types.ts` passes with the existing four React hook warnings in `NewSessionDialog.tsx`.
- `git diff --check` passes.
- Live local endpoint check returned Codex model options from `/home/joni/.codex/models_cache.json`.
