### PR TITLE
Fix dashboard provider-specific stats

### DIFF
--- a/frontend/src/contexts/DashboardContext.tsx
+++ b/frontend/src/contexts/DashboardContext.tsx
@@ -26,28 +26,42 @@ import type { HookListResponse } from '@/types/hooks';
 import type { PermissionListResponse } from '@/types/permissions';
 import type { SlashCommandListResponse } from '@/types/commands';
 import type { ActiveSessionsResponse, ActiveSessionContext } from '@/types/context';
+import type {
+  AgentProviderId,
+  CodexConfigResponse,
+  CodexFeatureInventoryResponse,
+  CodexMcpInventoryResponse,
+  CodexPluginInventoryResponse,
+} from '@/types/providers';
 
 export interface DashboardStats {
+  providerId: AgentProviderId;
+  providerDisplayName: string;
   mcpServerCount: number;
-  commandCount: number;
-  agentCount: number;
-  skillCount: number;
-  hookCount: number;
-  pluginCount: number;
-  permissionCount: number;
-  outputStyleCount: number;
-  allowRules: number;
-  denyRules: number;
+  commandCount: number | null;
+  agentCount: number | null;
+  skillCount: number | null;
+  hookCount: number | null;
+  pluginCount: number | null;
+  permissionCount: number | null;
+  outputStyleCount: number | null;
+  allowRules: number | null;
+  denyRules: number | null;
   settingsKeys: number;
   sessionCount: number;
-  sessionsToday: number;
-  sessionsThisWeek: number;
+  sessionMetricKind: 'transcript' | 'live';
+  sessionsToday: number | null;
+  sessionsThisWeek: number | null;
   mostActiveProject?: string;
-  totalMessages: number;
-  contextHighestPct: number;
+  totalMessages: number | null;
+  contextHighestPct: number | null;
   contextHighestProject?: string;
-  contextActiveCount: number;
+  contextActiveCount: number | null;
   planCount: number;
+  featureFlagCount: number | null;
+  enabledFeatureFlagCount: number | null;
+  unsupportedFeatures: string[];
+  warnings: string[];
 }
 
 interface DashboardContextType {
@@ -60,9 +74,43 @@ interface DashboardContextType {
 
 const DashboardContext = createContext<DashboardContextType | undefined>(undefined);
 
+interface AgentBridgeSessionsResponse {
+  sessions: unknown[];
+  count: number;
+}
+
+function countCollection(value: unknown): number {
+  if (Array.isArray(value)) return value.length;
+  if (value && typeof value === 'object') return Object.keys(value).length;
+  return 0;
+}
+
+function countCodexConfigEntries(config: CodexConfigResponse): number {
+  return Object.entries(config.summary ?? {}).reduce((total, [, value]) => {
+    if (value == null) return total;
+    if (Array.isArray(value)) return total + value.length;
+    if (typeof value === 'object') return total + Object.keys(value).length;
+    return total + 1;
+  }, 0);
+}
+
+async function safeFetch<T>(
+  request: Promise<T>,
+  fallback: T,
+  warning: string,
+  warnings: string[],
+): Promise<T> {
+  try {
+    return await request;
+  } catch (err) {
+    warnings.push(err instanceof Error ? `${warning}: ${err.message}` : warning);
+    return fallback;
+  }
+}
+
 export function DashboardProvider({ children }: { children: ReactNode }) {
   const { activeProject } = useProjectContext();
-  const { selectedProviderId } = useProviderContext();
+  const { selectedProviderId, selectedProvider } = useProviderContext();
   const { getDashboardStats } = useSessionsApi();
   const { getActiveSessions } = useContextApi();
   const { getStats: getPlanStats } = usePlansApi();
@@ -80,7 +128,138 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
     setError(null);
     const currentFetchId = ++fetchId.current;
     try {
+      const providerId = selectedProviderId;
+      const providerDisplayName = selectedProvider?.display_name ?? (
+        providerId === 'codex-cli' ? 'Codex' : 'Claude Code'
+      );
       const params = { project_path: activeProject?.path };
+
+      if (providerId === 'codex-cli') {
+        const warnings: string[] = [];
+        const [
+          configData,
+          mcpData,
+          pluginsData,
+          featuresData,
+          bridgeSessionsData,
+          planStatsData,
+        ] = await Promise.all([
+          safeFetch(
+            apiClient<CodexConfigResponse>('codex-config'),
+            {
+              provider: 'codex-cli',
+              path: '',
+              exists: false,
+              parse_error: null,
+              summary: {
+                projects: {},
+                profiles: {},
+                features: {},
+              },
+              profile_resolution: null,
+            },
+            'Codex config unavailable',
+            warnings,
+          ),
+          safeFetch(
+            apiClient<CodexMcpInventoryResponse>('providers/codex-cli/mcp'),
+            {
+              provider: 'codex-cli',
+              provider_display_name: 'Codex',
+              exit_code: 1,
+              servers: null,
+              parse_error: null,
+              stderr: '',
+              raw_stdout: '',
+            },
+            'Codex MCP inventory unavailable',
+            warnings,
+          ),
+          safeFetch(
+            apiClient<CodexPluginInventoryResponse>('providers/codex-cli/plugins'),
+            {
+              provider: 'codex-cli',
+              provider_display_name: 'Codex',
+              exit_code: 1,
+              plugins: [],
+              mutation_capabilities: {
+                install: { state: 'unsupported', reason: 'Unavailable' },
+                remove: { state: 'unsupported', reason: 'Unavailable' },
+                enable: { state: 'unsupported', reason: 'Unavailable' },
+                disable: { state: 'unsupported', reason: 'Unavailable' },
+              },
+              stderr: '',
+              raw_stdout: '',
+            },
+            'Codex plugin inventory unavailable',
+            warnings,
+          ),
+          safeFetch(
+            apiClient<CodexFeatureInventoryResponse>('providers/codex-cli/features'),
+            {
+              provider: 'codex-cli',
+              provider_display_name: 'Codex',
+              exit_code: 1,
+              features: [],
+              stderr: '',
+              raw_stdout: '',
+            },
+            'Codex feature inventory unavailable',
+            warnings,
+          ),
+          safeFetch(
+            apiClient<AgentBridgeSessionsResponse>(
+              buildEndpoint('agent-bridge/sessions', { provider: providerId }),
+            ),
+            { sessions: [], count: 0 },
+            'Codex live sessions unavailable',
+            warnings,
+          ),
+          getPlanStats().catch(() => ({ total_plans: 0 })),
+        ]);
+
+        if (currentFetchId !== fetchId.current) return;
+
+        setStats({
+          providerId,
+          providerDisplayName,
+          mcpServerCount: countCollection(mcpData.servers),
+          commandCount: null,
+          agentCount: null,
+          skillCount: null,
+          hookCount: null,
+          pluginCount: pluginsData.plugins.length,
+          permissionCount: null,
+          outputStyleCount: null,
+          allowRules: null,
+          denyRules: null,
+          settingsKeys: countCodexConfigEntries(configData),
+          sessionCount: bridgeSessionsData.count ?? bridgeSessionsData.sessions.length,
+          sessionMetricKind: 'live',
+          sessionsToday: null,
+          sessionsThisWeek: null,
+          mostActiveProject: undefined,
+          totalMessages: null,
+          contextHighestPct: null,
+          contextHighestProject: undefined,
+          contextActiveCount: null,
+          planCount: planStatsData.total_plans,
+          featureFlagCount: featuresData.features.length,
+          enabledFeatureFlagCount: featuresData.features.filter((feature) => feature.enabled).length,
+          unsupportedFeatures: [
+            'Slash commands',
+            'Agents',
+            'Skills',
+            'Hooks',
+            'Permissions',
+            'Output styles',
+            'Transcript context',
+          ],
+          warnings,
+        });
+        setLastFetched(new Date());
+        return;
+      }
 
       const [
         configData,
@@ -123,6 +302,8 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
         : null;
 
       setStats({
+        providerId,
+        providerDisplayName,
         mcpServerCount: mcpData.servers.length,
         commandCount: commandsData.commands.length,
         agentCount: agentsData.agents.length,
@@ -135,6 +316,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
         denyRules,
         settingsKeys: Object.keys(configData.settings || {}).length,
         sessionCount: sessionStatsData.total_sessions,
+        sessionMetricKind: 'transcript',
         sessionsToday: sessionStatsData.sessions_today,
         sessionsThisWeek: sessionStatsData.sessions_this_week,
         mostActiveProject: sessionStatsData.most_active_project,
@@ -143,6 +325,10 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
         contextHighestProject: highestCtx?.project_name,
         contextActiveCount: activeSessions.length,
         planCount: planStatsData.total_plans,
+        featureFlagCount: null,
+        enabledFeatureFlagCount: null,
+        unsupportedFeatures: [],
+        warnings: [],
       });
       setLastFetched(new Date());
     } catch (err) {
@@ -156,7 +342,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
   // getDashboardStats and getActiveSessions have stable refs (empty deps).
   // getPlanStats changes with activeProject?.path and selectedProviderId; those are handled below.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeProject?.path, selectedProviderId]);
+  }, [activeProject?.path, selectedProvider?.display_name, selectedProviderId]);
 
   // Re-fetch when active project or provider changes (but not on initial mount)
   useEffect(() => {

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -13,9 +13,12 @@ import { getRelativeTime } from '@/features/usage/utils'
 export function DashboardPage() {
   const { stats, loading, error, lastFetched, refreshDashboard } = useDashboard({ autoFetch: true })
   const { projects } = useProjectContext()
-  const { providers, selectedProviderId, setSelectedProviderId } = useProviderContext()
+  const { providers, selectedProviderId, selectedProvider, setSelectedProviderId } = useProviderContext()
   const navigate = useNavigate()
   const installedProviderCount = providers.filter((provider) => provider.installed).length
+  const providerStats = stats?.providerId === selectedProviderId ? stats : null
+  const selectedProviderName = selectedProvider?.display_name ?? (selectedProviderId === 'codex-cli' ? 'Codex' : 'Claude Code')
+  const isCodex = selectedProviderId === 'codex-cli'
 
   return (
     <div className="space-y-6">
@@ -50,7 +53,7 @@ export function DashboardPage() {
         </Card>
       )}
 
-      {loading && !stats && (
+      {loading && !providerStats && (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           {[...Array(9)].map((_, i) => (
             <Card key={i}>
@@ -65,7 +68,25 @@ export function DashboardPage() {
         </div>
       )}
 
-      {stats && (
+      {providerStats && providerStats.warnings.length > 0 && (
+        <Card className="border-amber-500/60">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-amber-600 dark:text-amber-400">Partial {selectedProviderName} data</CardTitle>
+            <CardDescription>
+              Some provider-specific checks could not be loaded.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-1 text-xs text-muted-foreground">
+              {providerStats.warnings.map((warning) => (
+                <p key={warning}>{warning}</p>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {providerStats && (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           {/* Order matches sidebar navigation */}
 
@@ -143,23 +164,44 @@ export function DashboardPage() {
             </CardContent>
           </Card>
 
-          <Card>
-            <CardHeader className="pb-2">
-              <CardDescription>Projects</CardDescription>
-              <CardTitle className="text-3xl">{projects.length}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-xs text-muted-foreground">
-                Tracked projects
-              </p>
-            </CardContent>
-          </Card>
+          {isCodex ? (
+            <Card>
+              <CardHeader className="pb-2">
+                <CardDescription>Codex Config</CardDescription>
+                <CardTitle className="text-3xl">{providerStats.settingsKeys}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-xs text-muted-foreground">
+                  Safe config entries, profiles, projects, and feature settings
+                </p>
+                <Button
+                  variant="link"
+                  className="p-0 h-auto mt-2"
+                  onClick={() => navigate('/config')}
+                >
+                  View Codex config →
+                </Button>
+              </CardContent>
+            </Card>
+          ) : (
+            <Card>
+              <CardHeader className="pb-2">
+                <CardDescription>Projects</CardDescription>
+                <CardTitle className="text-3xl">{projects.length}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-xs text-muted-foreground">
+                  Tracked Claude Code projects
+                </p>
+              </CardContent>
+            </Card>
+          )}
 
           {/* Tier 2: Core Configuration */}
           <Card>
             <CardHeader className="pb-2">
-              <CardDescription>MCP Servers</CardDescription>
-              <CardTitle className="text-3xl">{stats.mcpServerCount}</CardTitle>
+              <CardDescription>{selectedProviderName} MCP Servers</CardDescription>
+              <CardTitle className="text-3xl">{providerStats.mcpServerCount}</CardTitle>
             </CardHeader>
             <CardContent>
               <p className="text-xs text-muted-foreground">
@@ -168,123 +210,153 @@ export function DashboardPage() {
             </CardContent>
           </Card>
 
+          {!isCodex && (
+            <Card>
+              <CardHeader className="pb-2">
+                <CardDescription>Claude Commands</CardDescription>
+                <CardTitle className="text-3xl">{providerStats.commandCount}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-xs text-muted-foreground">
+                  Claude slash commands available
+                </p>
+              </CardContent>
+            </Card>
+          )}
+
           <Card>
             <CardHeader className="pb-2">
-              <CardDescription>Claude Commands</CardDescription>
-              <CardTitle className="text-3xl">{stats.commandCount}</CardTitle>
+              <CardDescription>{selectedProviderName} Plugins</CardDescription>
+              <CardTitle className="text-3xl">{providerStats.pluginCount ?? 0}</CardTitle>
             </CardHeader>
             <CardContent>
               <p className="text-xs text-muted-foreground">
-                Claude slash commands available
+                Installed {selectedProviderName} plugins
               </p>
             </CardContent>
           </Card>
 
-          <Card>
-            <CardHeader className="pb-2">
-              <CardDescription>Claude Plugins</CardDescription>
-              <CardTitle className="text-3xl">{stats.pluginCount}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-xs text-muted-foreground">
-                Installed Claude plugins
-              </p>
-            </CardContent>
-          </Card>
+          {isCodex && (
+            <Card>
+              <CardHeader className="pb-2">
+                <CardDescription>Codex Feature Flags</CardDescription>
+                <CardTitle className="text-3xl">{providerStats.featureFlagCount ?? 0}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-xs text-muted-foreground">
+                  {providerStats.enabledFeatureFlagCount ?? 0} enabled
+                </p>
+              </CardContent>
+            </Card>
+          )}
 
-          <Card>
-            <CardHeader className="pb-2">
-              <CardDescription>Claude Hooks</CardDescription>
-              <CardTitle className="text-3xl">{stats.hookCount}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-xs text-muted-foreground">
-                Claude automation hooks configured
-              </p>
-            </CardContent>
-          </Card>
+          {!isCodex && (
+            <>
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardDescription>Claude Hooks</CardDescription>
+                  <CardTitle className="text-3xl">{providerStats.hookCount}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-xs text-muted-foreground">
+                    Claude automation hooks configured
+                  </p>
+                </CardContent>
+              </Card>
 
-          <Card>
-            <CardHeader className="pb-2">
-              <CardDescription>Claude Permissions</CardDescription>
-              <CardTitle className="text-3xl">{stats.permissionCount}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-xs text-muted-foreground">
-                Claude permission rules
-              </p>
-            </CardContent>
-          </Card>
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardDescription>Claude Permissions</CardDescription>
+                  <CardTitle className="text-3xl">{providerStats.permissionCount}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-xs text-muted-foreground">
+                    Claude permission rules
+                  </p>
+                </CardContent>
+              </Card>
 
-          <Card>
-            <CardHeader className="pb-2">
-              <CardDescription>Claude Agents</CardDescription>
-              <CardTitle className="text-3xl">{stats.agentCount}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-xs text-muted-foreground">
-                Custom agents (user, project, plugin)
-              </p>
-            </CardContent>
-          </Card>
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardDescription>Claude Agents</CardDescription>
+                  <CardTitle className="text-3xl">{providerStats.agentCount}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-xs text-muted-foreground">
+                    Custom agents (user, project, plugin)
+                  </p>
+                </CardContent>
+              </Card>
 
-          <Card>
-            <CardHeader className="pb-2">
-              <CardDescription>Claude Skills</CardDescription>
-              <CardTitle className="text-3xl">{stats.skillCount}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-xs text-muted-foreground">
-                Available skills
-              </p>
-            </CardContent>
-          </Card>
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardDescription>Claude Skills</CardDescription>
+                  <CardTitle className="text-3xl">{providerStats.skillCount}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-xs text-muted-foreground">
+                    Available skills
+                  </p>
+                </CardContent>
+              </Card>
+            </>
+          )}
 
           {/* Tier 3: Customization */}
-          <Card>
-            <CardHeader className="pb-2">
-              <CardDescription>Claude Output Styles</CardDescription>
-              <CardTitle className="text-3xl">{stats.outputStyleCount}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-xs text-muted-foreground">
-                Custom output formats
-              </p>
-            </CardContent>
-          </Card>
+          {!isCodex && (
+            <Card>
+              <CardHeader className="pb-2">
+                <CardDescription>Claude Output Styles</CardDescription>
+                <CardTitle className="text-3xl">{providerStats.outputStyleCount}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-xs text-muted-foreground">
+                  Custom output formats
+                </p>
+              </CardContent>
+            </Card>
+          )}
 
           {/* Tier 4: Monitoring */}
           <Card>
             <CardHeader className="pb-2">
-              <CardDescription>Claude Session History</CardDescription>
-              <CardTitle className="text-3xl">{stats.sessionCount}</CardTitle>
+              <CardDescription>
+                {providerStats.sessionMetricKind === 'live' ? `${selectedProviderName} Live Sessions` : 'Claude Session History'}
+              </CardDescription>
+              <CardTitle className="text-3xl">{providerStats.sessionCount}</CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="text-xs text-muted-foreground space-y-1">
-                <p>{stats.sessionsToday} today</p>
-                <p>{stats.sessionsThisWeek} this week</p>
-                {stats.mostActiveProject && (
-                  <p className="text-primary">Most active: {stats.mostActiveProject}</p>
-                )}
-              </div>
+              {providerStats.sessionMetricKind === 'live' ? (
+                <p className="text-xs text-muted-foreground">
+                  Sessions currently visible through Agent Bridge
+                </p>
+              ) : (
+                <div className="text-xs text-muted-foreground space-y-1">
+                  <p>{providerStats.sessionsToday} today</p>
+                  <p>{providerStats.sessionsThisWeek} this week</p>
+                  {providerStats.mostActiveProject && (
+                    <p className="text-primary">Most active: {providerStats.mostActiveProject}</p>
+                  )}
+                </div>
+              )}
               <Button
                 variant="link"
                 className="p-0 h-auto mt-2"
-                onClick={() => navigate('/sessions')}
+                onClick={() => navigate(providerStats.sessionMetricKind === 'live' ? '/agent-bridge' : '/sessions')}
               >
-                View all sessions →
+                {providerStats.sessionMetricKind === 'live' ? 'View live sessions →' : 'View all sessions →'}
               </Button>
             </CardContent>
           </Card>
 
           <Card>
             <CardHeader className="pb-2">
-              <CardDescription>{selectedProviderId === 'codex-cli' ? 'Plan Snapshots' : 'Plans'}</CardDescription>
-              <CardTitle className="text-3xl">{stats.planCount}</CardTitle>
+              <CardDescription>{isCodex ? 'Plan Snapshots' : 'Plans'}</CardDescription>
+              <CardTitle className="text-3xl">{providerStats.planCount}</CardTitle>
             </CardHeader>
             <CardContent>
               <p className="text-xs text-muted-foreground">
-                {selectedProviderId === 'codex-cli' ? 'Codex update_plan snapshots' : 'Execution plans'}
+                {isCodex ? 'Codex update_plan snapshots' : 'Execution plans'}
               </p>
               <Button
                 variant="link"
@@ -296,72 +368,126 @@ export function DashboardPage() {
             </CardContent>
           </Card>
 
-          <Card>
-            <CardHeader className="pb-2">
-              <CardDescription>Claude Context Window</CardDescription>
-              <CardTitle className="text-3xl">
-                {stats.contextActiveCount > 0 ? `${stats.contextHighestPct.toFixed(0)}%` : '--'}
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              {stats.contextActiveCount > 0 ? (
-                <div className="space-y-2">
-                  <Progress
-                    value={stats.contextHighestPct}
-                    className={`h-2 ${
-                      stats.contextHighestPct >= 95 ? '[&>div]:bg-red-500' :
-                      stats.contextHighestPct >= 80 ? '[&>div]:bg-orange-500' :
-                      stats.contextHighestPct >= 50 ? '[&>div]:bg-yellow-500' :
-                      '[&>div]:bg-green-500'
-                    }`}
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    {stats.contextActiveCount} active session{stats.contextActiveCount !== 1 ? 's' : ''}
-                    {stats.contextHighestProject && ` - ${stats.contextHighestProject}`}
-                  </p>
+          {!isCodex && (
+            <Card>
+              <CardHeader className="pb-2">
+                <CardDescription>Claude Context Window</CardDescription>
+                <CardTitle className="text-3xl">
+                  {providerStats.contextActiveCount && providerStats.contextActiveCount > 0
+                    ? `${(providerStats.contextHighestPct ?? 0).toFixed(0)}%`
+                    : '--'}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {providerStats.contextActiveCount && providerStats.contextActiveCount > 0 ? (
+                  <div className="space-y-2">
+                    <Progress
+                      value={providerStats.contextHighestPct ?? 0}
+                      className={`h-2 ${
+                        (providerStats.contextHighestPct ?? 0) >= 95 ? '[&>div]:bg-red-500' :
+                        (providerStats.contextHighestPct ?? 0) >= 80 ? '[&>div]:bg-orange-500' :
+                        (providerStats.contextHighestPct ?? 0) >= 50 ? '[&>div]:bg-yellow-500' :
+                        '[&>div]:bg-green-500'
+                      }`}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      {providerStats.contextActiveCount} active session{providerStats.contextActiveCount !== 1 ? 's' : ''}
+                      {providerStats.contextHighestProject && ` - ${providerStats.contextHighestProject}`}
+                    </p>
+                  </div>
+                ) : (
+                  <p className="text-xs text-muted-foreground">No active sessions</p>
+                )}
+                <Button
+                  variant="link"
+                  className="p-0 h-auto mt-2"
+                  onClick={() => navigate('/context')}
+                >
+                  View context →
+                </Button>
+              </CardContent>
+            </Card>
+          )}
+
+          {isCodex && providerStats.unsupportedFeatures.length > 0 && (
+            <Card>
+              <CardHeader className="pb-2">
+                <CardDescription>Not shown for Codex</CardDescription>
+                <CardTitle className="text-base">Claude Code-only surfaces</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="flex flex-wrap gap-1.5">
+                  {providerStats.unsupportedFeatures.map((feature) => (
+                    <Badge key={feature} variant="secondary">
+                      {feature}
+                    </Badge>
+                  ))}
                 </div>
-              ) : (
-                <p className="text-xs text-muted-foreground">No active sessions</p>
-              )}
-              <Button
-                variant="link"
-                className="p-0 h-auto mt-2"
-                onClick={() => navigate('/context')}
-              >
-                View context →
-              </Button>
-            </CardContent>
-          </Card>
+                <p className="mt-3 text-xs text-muted-foreground">
+                  These cards are hidden because Codex does not expose equivalent data through Claude Deck yet.
+                </p>
+              </CardContent>
+            </Card>
+          )}
         </div>
       )}
 
-      {stats && (
+      {providerStats && (
         <Card>
           <CardHeader>
             <CardTitle>Quick Status</CardTitle>
-            <CardDescription>Claude Code configuration health indicators</CardDescription>
+            <CardDescription>{selectedProviderName} configuration health indicators</CardDescription>
           </CardHeader>
           <CardContent>
-            <div className="space-y-2">
-              <div className="flex items-center justify-between text-sm">
-                <span>Settings keys:</span>
-                <span className="font-medium">
-                  {stats.settingsKeys} configured
-                </span>
+            {isCodex ? (
+              <div className="space-y-2">
+                <div className="flex items-center justify-between text-sm">
+                  <span>Config entries:</span>
+                  <span className="font-medium">
+                    {providerStats.settingsKeys}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between text-sm">
+                  <span>MCP servers:</span>
+                  <span className="font-medium">
+                    {providerStats.mcpServerCount}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between text-sm">
+                  <span>Plugins:</span>
+                  <span className="font-medium">
+                    {providerStats.pluginCount ?? 0}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between text-sm">
+                  <span>Enabled features:</span>
+                  <span className="font-medium">
+                    {providerStats.enabledFeatureFlagCount ?? 0}
+                  </span>
+                </div>
               </div>
-              <div className="flex items-center justify-between text-sm">
-                <span>Allow rules:</span>
-                <span className="font-medium text-success">
-                  {stats.allowRules}
-                </span>
+            ) : (
+              <div className="space-y-2">
+                <div className="flex items-center justify-between text-sm">
+                  <span>Settings keys:</span>
+                  <span className="font-medium">
+                    {providerStats.settingsKeys} configured
+                  </span>
+                </div>
+                <div className="flex items-center justify-between text-sm">
+                  <span>Allow rules:</span>
+                  <span className="font-medium text-success">
+                    {providerStats.allowRules}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between text-sm">
+                  <span>Deny rules:</span>
+                  <span className="font-medium text-destructive">
+                    {providerStats.denyRules}
+                  </span>
+                </div>
               </div>
-              <div className="flex items-center justify-between text-sm">
-                <span>Deny rules:</span>
-                <span className="font-medium text-destructive">
-                  {stats.denyRules}
-                </span>
-              </div>
-            </div>
+            )}
           </CardContent>
         </Card>
       )}


### PR DESCRIPTION
Closes #215.

## Summary

- make dashboard stats provider-aware instead of always loading Claude Code APIs
- render Codex-specific cards for config, MCP, plugins, features, live sessions, and plan snapshots
- hide Claude-only dashboard cards in Codex mode and show a clear unsupported-surfaces notice
- ignore stale stats when switching providers

## Verification

- npm run build
- npx eslint src/contexts/DashboardContext.tsx src/features/dashboard/DashboardPage.tsx
- browser smoke: Codex view shows Codex-specific cards and hides Claude-only cards
- browser smoke: Claude Code view keeps Claude-specific cards

Note: full `npm run lint` still fails on pre-existing unrelated repo-wide lint issues.