### PR TITLE
Expose Codex provider pages

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,16 +1,20 @@
-import { NavLink } from 'react-router-dom'
-import { cn } from '@/lib/utils'
-import { ProjectSwitcher } from '@/features/projects/ProjectSwitcher'
-import { useSidebar } from '@/contexts/SidebarContext'
-import { useProviderContext } from '@/contexts/ProviderContext'
+import { NavLink } from "react-router-dom";
+import { cn } from "@/lib/utils";
+import { ProjectSwitcher } from "@/features/projects/ProjectSwitcher";
+import { useSidebar } from "@/contexts/SidebarContext";
+import { useProviderContext } from "@/contexts/ProviderContext";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '@/components/ui/select'
-import type { AgentProviderCapabilities, AgentProviderId, AgentProviderStatus } from '@/types/providers'
+} from "@/components/ui/select";
+import type {
+  AgentProviderCapabilities,
+  AgentProviderId,
+  AgentProviderStatus,
+} from "@/types/providers";
 import {
   LayoutDashboard,
   Settings,
@@ -36,105 +40,179 @@ import {
   PanelLeftClose,
   PanelLeftOpen,
   type LucideIcon,
-} from 'lucide-react'
+} from "lucide-react";
 
 type NavItem = {
-  name: string
-  href: string
-  icon: LucideIcon
-  capability?: keyof AgentProviderCapabilities
-}
+  name: string;
+  href: string;
+  icon: LucideIcon;
+  capability?: keyof AgentProviderCapabilities;
+};
 
 type NavGroup = {
-  name: string
-  items: NavItem[]
-}
+  name: string;
+  items: NavItem[];
+};
 
 const commonNavigation: NavGroup[] = [
   {
-    name: 'Core',
+    name: "Core",
     items: [
-      { name: 'Dashboard', href: '/', icon: LayoutDashboard },
-      { name: 'Projects', href: '/projects', icon: FolderOpen },
-      { name: 'Agent Bridge', href: '/agent-bridge', icon: MonitorPlay, capability: 'sessions' },
+      { name: "Dashboard", href: "/", icon: LayoutDashboard },
+      { name: "Projects", href: "/projects", icon: FolderOpen },
+      {
+        name: "Agent Bridge",
+        href: "/agent-bridge",
+        icon: MonitorPlay,
+        capability: "sessions",
+      },
     ],
   },
   {
-    name: 'Operations',
+    name: "Operations",
     items: [
-      { name: 'Agent Mail', href: '/agent-mail', icon: Mail },
-      { name: 'Agent Teams', href: '/agent-teams', icon: UsersRound },
-      { name: 'Plans', href: '/plans', icon: ClipboardList, capability: 'plans' },
-      { name: 'Backup', href: '/backup', icon: Archive, capability: 'backup' },
+      { name: "Agent Mail", href: "/agent-mail", icon: Mail },
+      { name: "Agent Teams", href: "/agent-teams", icon: UsersRound },
+      {
+        name: "Plans",
+        href: "/plans",
+        icon: ClipboardList,
+        capability: "plans",
+      },
+      { name: "Backup", href: "/backup", icon: Archive, capability: "backup" },
     ],
   },
-]
+];
 
 const providerNavigation: Record<AgentProviderId, NavGroup[]> = {
-  'claude-code': [
+  "claude-code": [
     {
-      name: 'Claude Code',
+      name: "Claude Code",
       items: [
-        { name: 'Config', href: '/config', icon: Settings, capability: 'config' },
-        { name: 'Sessions', href: '/sessions', icon: MessageSquare, capability: 'sessions' },
-        { name: 'MCP Servers', href: '/mcp', icon: Server, capability: 'mcp' },
-        { name: 'Plugins', href: '/plugins', icon: Package, capability: 'plugins' },
-        { name: 'Permissions / Trust', href: '/permissions', icon: Shield, capability: 'permissions' },
+        {
+          name: "Config",
+          href: "/config",
+          icon: Settings,
+          capability: "config",
+        },
+        {
+          name: "Sessions",
+          href: "/sessions",
+          icon: MessageSquare,
+          capability: "sessions",
+        },
+        { name: "MCP Servers", href: "/mcp", icon: Server, capability: "mcp" },
+        {
+          name: "Plugins",
+          href: "/plugins",
+          icon: Package,
+          capability: "plugins",
+        },
+        {
+          name: "Permissions / Trust",
+          href: "/permissions",
+          icon: Shield,
+          capability: "permissions",
+        },
       ],
     },
     {
-      name: 'Claude Tools',
+      name: "Claude Tools",
       items: [
-        { name: 'Commands', href: '/commands', icon: Terminal, capability: 'commands' },
-        { name: 'Hooks', href: '/hooks', icon: Webhook, capability: 'hooks' },
-        { name: 'Agents', href: '/agents', icon: Bot, capability: 'agents' },
-        { name: 'Skills', href: '/skills', icon: Sparkles, capability: 'skills' },
-        { name: 'Memory', href: '/memory', icon: Brain, capability: 'memory' },
-        { name: 'Output Styles', href: '/output-styles', icon: Paintbrush, capability: 'output_styles' },
-        { name: 'Status Line', href: '/statusline', icon: Activity, capability: 'statusline' },
+        {
+          name: "Commands",
+          href: "/commands",
+          icon: Terminal,
+          capability: "commands",
+        },
+        { name: "Hooks", href: "/hooks", icon: Webhook, capability: "hooks" },
+        { name: "Agents", href: "/agents", icon: Bot, capability: "agents" },
+        {
+          name: "Skills",
+          href: "/skills",
+          icon: Sparkles,
+          capability: "skills",
+        },
+        { name: "Memory", href: "/memory", icon: Brain, capability: "memory" },
+        {
+          name: "Output Styles",
+          href: "/output-styles",
+          icon: Paintbrush,
+          capability: "output_styles",
+        },
+        {
+          name: "Status Line",
+          href: "/statusline",
+          icon: Activity,
+          capability: "statusline",
+        },
       ],
     },
     {
-      name: 'Claude Metrics',
+      name: "Claude Metrics",
       items: [
-        { name: 'Context', href: '/context', icon: Gauge, capability: 'context' },
-        { name: 'Usage', href: '/usage', icon: BarChart3, capability: 'usage' },
+        {
+          name: "Context",
+          href: "/context",
+          icon: Gauge,
+          capability: "context",
+        },
+        { name: "Usage", href: "/usage", icon: BarChart3, capability: "usage" },
       ],
     },
   ],
-  'codex-cli': [
+  "codex-cli": [
     {
-      name: 'Codex',
+      name: "Codex",
       items: [
-        { name: 'Config', href: '/config', icon: Settings, capability: 'config' },
+        {
+          name: "Config",
+          href: "/config",
+          icon: Settings,
+          capability: "config",
+        },
+        { name: "MCP Servers", href: "/mcp", icon: Server, capability: "mcp" },
+        {
+          name: "Plugins",
+          href: "/plugins",
+          icon: Package,
+          capability: "plugins",
+        },
       ],
     },
   ],
-}
+};
 
 function getNavigation(providerId: AgentProviderId): NavGroup[] {
-  return [
-    ...commonNavigation,
-    ...(providerNavigation[providerId] ?? []),
-  ]
+  return [...commonNavigation, ...(providerNavigation[providerId] ?? [])];
 }
 
-const visibleCapabilityStates = new Set(['supported', 'read_only', 'write_capable'])
+const visibleCapabilityStates = new Set([
+  "supported",
+  "read_only",
+  "write_capable",
+]);
 
 function supportsProvider(item: NavItem, provider: AgentProviderStatus | null) {
-  if (!item.capability || !provider) return true
-  const detail = provider.capability_matrix?.[item.capability]
-  if (detail) return visibleCapabilityStates.has(detail.state)
-  return Boolean(provider.capabilities?.[item.capability])
+  if (!item.capability || !provider) return true;
+  const detail = provider.capability_matrix?.[item.capability];
+  if (detail) return visibleCapabilityStates.has(detail.state);
+  return Boolean(provider.capabilities?.[item.capability]);
 }
 
-function NavGroupSection({ group, collapsed, selectedProvider }: {
-  group: NavGroup
-  collapsed: boolean
-  selectedProvider: AgentProviderStatus | null
+function NavGroupSection({
+  group,
+  collapsed,
+  selectedProvider,
+}: {
+  group: NavGroup;
+  collapsed: boolean;
+  selectedProvider: AgentProviderStatus | null;
 }) {
-  const visibleItems = group.items.filter((item) => supportsProvider(item, selectedProvider))
-  if (visibleItems.length === 0) return null
+  const visibleItems = group.items.filter((item) =>
+    supportsProvider(item, selectedProvider),
+  );
+  if (visibleItems.length === 0) return null;
 
   return (
     <div className="space-y-1">
@@ -147,15 +225,15 @@ function NavGroupSection({ group, collapsed, selectedProvider }: {
         <NavLink
           key={item.href}
           to={item.href}
-          end={item.href === '/'}
+          end={item.href === "/"}
           title={collapsed ? item.name : undefined}
           className={({ isActive }) =>
             cn(
-              'flex items-center rounded-md text-sm font-medium transition-colors',
-              collapsed ? 'justify-center p-2' : 'gap-2 px-3 py-2',
+              "flex items-center rounded-md text-sm font-medium transition-colors",
+              collapsed ? "justify-center p-2" : "gap-2 px-3 py-2",
               isActive
-                ? 'bg-primary text-primary-foreground'
-                : 'text-foreground hover:bg-accent hover:text-accent-foreground'
+                ? "bg-primary text-primary-foreground"
+                : "text-foreground hover:bg-accent hover:text-accent-foreground",
             )
           }
         >
@@ -164,32 +242,47 @@ function NavGroupSection({ group, collapsed, selectedProvider }: {
         </NavLink>
       ))}
     </div>
-  )
+  );
 }
 
 export function Sidebar() {
-  const { collapsed, setCollapsed } = useSidebar()
-  const { providers, selectedProviderId, selectedProvider, setSelectedProviderId } = useProviderContext()
-  const visibleGroups = getNavigation(selectedProviderId)
+  const { collapsed, setCollapsed } = useSidebar();
+  const {
+    providers,
+    selectedProviderId,
+    selectedProvider,
+    setSelectedProviderId,
+  } = useProviderContext();
+  const visibleGroups = getNavigation(selectedProviderId);
 
   return (
-    <aside className={cn(
-      'border-r bg-background transition-all duration-200 flex flex-col',
-      collapsed ? 'w-14' : 'w-64'
-    )}>
+    <aside
+      className={cn(
+        "border-r bg-background transition-all duration-200 flex flex-col",
+        collapsed ? "w-14" : "w-64",
+      )}
+    >
       {!collapsed && (
         <div className="py-4 border-b space-y-3">
           <ProjectSwitcher />
           <div className="px-4 space-y-1.5">
-            <p className="text-xs font-medium text-muted-foreground">Agent Provider</p>
-            <Select value={selectedProviderId} onValueChange={(value) => setSelectedProviderId(value as AgentProviderId)}>
+            <p className="text-xs font-medium text-muted-foreground">
+              Agent Provider
+            </p>
+            <Select
+              value={selectedProviderId}
+              onValueChange={(value) =>
+                setSelectedProviderId(value as AgentProviderId)
+              }
+            >
               <SelectTrigger className="h-9">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
                 {providers.map((provider) => (
                   <SelectItem key={provider.id} value={provider.id}>
-                    {provider.display_name}{!provider.installed ? ' (missing)' : ''}
+                    {provider.display_name}
+                    {!provider.installed ? " (missing)" : ""}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -197,10 +290,12 @@ export function Sidebar() {
           </div>
         </div>
       )}
-      <nav className={cn(
-        'flex flex-col flex-1 overflow-y-auto',
-        collapsed ? 'gap-1 p-2' : 'gap-4 p-4'
-      )}>
+      <nav
+        className={cn(
+          "flex flex-col flex-1 overflow-y-auto",
+          collapsed ? "gap-1 p-2" : "gap-4 p-4",
+        )}
+      >
         {visibleGroups.map((group) => (
           <NavGroupSection
             key={group.name}
@@ -213,10 +308,14 @@ export function Sidebar() {
       <button
         onClick={() => setCollapsed(!collapsed)}
         className="flex items-center justify-center p-3 border-t text-muted-foreground hover:text-foreground transition-colors"
-        title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+        title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
       >
-        {collapsed ? <PanelLeftOpen className="h-4 w-4" /> : <PanelLeftClose className="h-4 w-4" />}
+        {collapsed ? (
+          <PanelLeftOpen className="h-4 w-4" />
+        ) : (
+          <PanelLeftClose className="h-4 w-4" />
+        )}
       </button>
     </aside>
-  )
+  );
 }

--- a/frontend/src/features/config/CodexInventoryCard.tsx
+++ b/frontend/src/features/config/CodexInventoryCard.tsx
@@ -1,6 +1,6 @@
-import { useMemo, useState } from 'react'
-import { ChevronRight, Plus, RefreshCw, Trash2 } from 'lucide-react'
-import { toast } from 'sonner'
+import { useMemo, useState } from "react";
+import { ChevronRight, Plus, RefreshCw, Trash2 } from "lucide-react";
+import { toast } from "sonner";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -11,98 +11,124 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   AlertDialogTrigger,
-} from '@/components/ui/alert-dialog'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { Textarea } from '@/components/ui/textarea'
-import { addCodexMcpServer, installCodexPlugin, removeCodexMcpServer, removeCodexPlugin } from '@/hooks/useProviders'
-import { cn } from '@/lib/utils'
-import type { CodexMcpAddRequest, CodexMcpInventoryResponse, CodexPluginInventoryResponse } from '@/types/providers'
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  addCodexMcpServer,
+  installCodexPlugin,
+  removeCodexMcpServer,
+  removeCodexPlugin,
+} from "@/hooks/useProviders";
+import { cn } from "@/lib/utils";
+import type {
+  CodexMcpAddRequest,
+  CodexMcpInventoryResponse,
+  CodexPluginInventoryResponse,
+} from "@/types/providers";
 
 interface CodexInventoryCardProps {
-  mcp: CodexMcpInventoryResponse | null
-  plugins: CodexPluginInventoryResponse | null
-  mcpError: string | null
-  pluginError: string | null
-  loading: boolean
-  onRefresh: () => void | Promise<void>
+  mcp: CodexMcpInventoryResponse | null;
+  plugins: CodexPluginInventoryResponse | null;
+  mcpError: string | null;
+  pluginError: string | null;
+  loading: boolean;
+  onRefresh: () => void | Promise<void>;
+  sections?: CodexInventorySection[];
+  title?: string;
+  description?: string;
 }
 
-type McpMode = 'command' | 'url'
+type McpMode = "command" | "url";
+type CodexInventorySection = "mcp" | "plugins";
 
 interface McpServerRow {
-  name: string
-  details: unknown
+  name: string;
+  details: unknown;
 }
 
 function getMcpServerMap(servers: unknown): Record<string, unknown> | null {
-  if (!servers || typeof servers !== 'object' || Array.isArray(servers)) return null
-  const objectValue = servers as Record<string, unknown>
-  if (objectValue.servers && typeof objectValue.servers === 'object' && !Array.isArray(objectValue.servers)) {
-    return objectValue.servers as Record<string, unknown>
+  if (!servers || typeof servers !== "object" || Array.isArray(servers))
+    return null;
+  const objectValue = servers as Record<string, unknown>;
+  if (
+    objectValue.servers &&
+    typeof objectValue.servers === "object" &&
+    !Array.isArray(objectValue.servers)
+  ) {
+    return objectValue.servers as Record<string, unknown>;
   }
-  return objectValue
+  return objectValue;
 }
 
 function getMcpServerRows(servers: unknown): McpServerRow[] {
   if (Array.isArray(servers)) {
     return servers.flatMap((server, index) => {
-      if (!server || typeof server !== 'object') return []
-      const objectValue = server as Record<string, unknown>
-      const name = typeof objectValue.name === 'string' ? objectValue.name : `server-${index + 1}`
-      return [{ name, details: server }]
-    })
+      if (!server || typeof server !== "object") return [];
+      const objectValue = server as Record<string, unknown>;
+      const name =
+        typeof objectValue.name === "string"
+          ? objectValue.name
+          : `server-${index + 1}`;
+      return [{ name, details: server }];
+    });
   }
-  const map = getMcpServerMap(servers)
-  if (!map) return []
-  return Object.entries(map).map(([name, details]) => ({ name, details }))
+  const map = getMcpServerMap(servers);
+  if (!map) return [];
+  return Object.entries(map).map(([name, details]) => ({ name, details }));
 }
 
 function countMcpServers(servers: unknown): number | null {
-  if (!servers || typeof servers !== 'object') return null
-  if (Array.isArray(servers)) return servers.length
-  const map = getMcpServerMap(servers)
-  return map ? Object.keys(map).length : null
+  if (!servers || typeof servers !== "object") return null;
+  if (Array.isArray(servers)) return servers.length;
+  const map = getMcpServerMap(servers);
+  return map ? Object.keys(map).length : null;
 }
 
 function parseLines(value: string): string[] {
   return value
-    .split('\n')
+    .split("\n")
     .map((line) => line.trim())
-    .filter(Boolean)
+    .filter(Boolean);
 }
 
 function parseEnv(value: string): Record<string, string> {
-  const env: Record<string, string> = {}
+  const env: Record<string, string> = {};
   for (const line of parseLines(value)) {
-    const separatorIndex = line.indexOf('=')
+    const separatorIndex = line.indexOf("=");
     if (separatorIndex <= 0) {
-      throw new Error('Environment variables must use KEY=VALUE format')
+      throw new Error("Environment variables must use KEY=VALUE format");
     }
-    env[line.slice(0, separatorIndex).trim()] = line.slice(separatorIndex + 1)
+    env[line.slice(0, separatorIndex).trim()] = line.slice(separatorIndex + 1);
   }
-  return env
+  return env;
+}
+
+function isInstalledPluginStatus(status: string | undefined): boolean {
+  const normalized = status?.trim().toLowerCase();
+  return Boolean(normalized && normalized !== "not installed");
 }
 
 function InventoryError({ message }: { message: string | null }) {
-  if (!message) return null
+  if (!message) return null;
   return (
     <p className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
       {message}
     </p>
-  )
+  );
 }
 
 function InventoryMessage({ message }: { message: string | null }) {
-  if (!message) return null
+  if (!message) return null;
   return (
     <p className="rounded-md border border-primary/30 bg-primary/10 p-3 text-sm text-primary">
       {message}
     </p>
-  )
+  );
 }
 
 function RawDetails({ label, content }: { label: string; content: unknown }) {
@@ -113,10 +139,12 @@ function RawDetails({ label, content }: { label: string; content: unknown }) {
         {label}
       </summary>
       <pre className="max-h-72 overflow-auto border-t bg-muted p-3 text-xs">
-        {typeof content === 'string' ? content || '(empty)' : JSON.stringify(content, null, 2)}
+        {typeof content === "string"
+          ? content || "(empty)"
+          : JSON.stringify(content, null, 2)}
       </pre>
     </details>
-  )
+  );
 }
 
 export function CodexInventoryCard({
@@ -126,173 +154,238 @@ export function CodexInventoryCard({
   pluginError,
   loading,
   onRefresh,
+  sections = ["mcp", "plugins"],
+  title = "Codex Inventory",
+  description,
 }: CodexInventoryCardProps) {
-  const [mode, setMode] = useState<McpMode>('command')
-  const [name, setName] = useState('')
-  const [command, setCommand] = useState('')
-  const [argsText, setArgsText] = useState('')
-  const [envText, setEnvText] = useState('')
-  const [url, setUrl] = useState('')
-  const [bearerTokenEnvVar, setBearerTokenEnvVar] = useState('')
-  const [pluginName, setPluginName] = useState('')
-  const [pluginMarketplace, setPluginMarketplace] = useState('')
-  const [mutationError, setMutationError] = useState<string | null>(null)
-  const [mutationMessage, setMutationMessage] = useState<string | null>(null)
-  const [mutating, setMutating] = useState(false)
+  const showMcp = sections.includes("mcp");
+  const showPlugins = sections.includes("plugins");
+  const [mode, setMode] = useState<McpMode>("command");
+  const [name, setName] = useState("");
+  const [command, setCommand] = useState("");
+  const [argsText, setArgsText] = useState("");
+  const [envText, setEnvText] = useState("");
+  const [url, setUrl] = useState("");
+  const [bearerTokenEnvVar, setBearerTokenEnvVar] = useState("");
+  const [pluginName, setPluginName] = useState("");
+  const [pluginMarketplace, setPluginMarketplace] = useState("");
+  const [pluginSearch, setPluginSearch] = useState("");
+  const [mutationError, setMutationError] = useState<string | null>(null);
+  const [mutationMessage, setMutationMessage] = useState<string | null>(null);
+  const [mutating, setMutating] = useState(false);
 
-  const mcpRows = useMemo(() => getMcpServerRows(mcp?.servers), [mcp?.servers])
-  const mcpCount = countMcpServers(mcp?.servers)
-  const pluginCount = plugins?.plugins.length ?? null
-  const pluginCapabilities = plugins?.mutation_capabilities
-  const canInstallPlugins = pluginCapabilities?.install.state === 'supported'
-  const canRemovePlugins = pluginCapabilities?.remove.state === 'supported'
+  const mcpRows = useMemo(() => getMcpServerRows(mcp?.servers), [mcp?.servers]);
+  const mcpCount = countMcpServers(mcp?.servers);
+  const pluginCount = plugins?.plugins.length ?? null;
+  const installedPluginCount = useMemo(
+    () =>
+      plugins?.plugins.filter((plugin) =>
+        isInstalledPluginStatus(plugin.status),
+      ).length ?? null,
+    [plugins?.plugins],
+  );
+  const filteredPlugins = useMemo(() => {
+    const query = pluginSearch.trim().toLowerCase();
+    const rows = plugins?.plugins ?? [];
+    if (!query) return rows;
+    return rows.filter(
+      (plugin) =>
+        plugin.name.toLowerCase().includes(query) ||
+        plugin.status?.toLowerCase().includes(query) ||
+        plugin.version?.toLowerCase().includes(query) ||
+        plugin.path?.toLowerCase().includes(query),
+    );
+  }, [pluginSearch, plugins?.plugins]);
+  const pluginCapabilities = plugins?.mutation_capabilities;
+  const canInstallPlugins = pluginCapabilities?.install.state === "supported";
+  const canRemovePlugins = pluginCapabilities?.remove.state === "supported";
   const pluginToggleUnsupported = [
     pluginCapabilities?.enable.reason,
     pluginCapabilities?.disable.reason,
-  ].filter(Boolean).join(' ')
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   const resetForm = () => {
-    setName('')
-    setCommand('')
-    setArgsText('')
-    setEnvText('')
-    setUrl('')
-    setBearerTokenEnvVar('')
-  }
+    setName("");
+    setCommand("");
+    setArgsText("");
+    setEnvText("");
+    setUrl("");
+    setBearerTokenEnvVar("");
+  };
 
   const resetPluginForm = () => {
-    setPluginName('')
-    setPluginMarketplace('')
-  }
+    setPluginName("");
+    setPluginMarketplace("");
+  };
 
   const handleAddMcp = async () => {
-    setMutationError(null)
-    setMutationMessage(null)
+    setMutationError(null);
+    setMutationMessage(null);
     try {
-      const trimmedName = name.trim()
-      if (!trimmedName) throw new Error('Server name is required')
-      const request: CodexMcpAddRequest = mode === 'url'
-        ? {
-            name: trimmedName,
-            url: url.trim(),
-            ...(bearerTokenEnvVar.trim() && { bearer_token_env_var: bearerTokenEnvVar.trim() }),
-          }
-        : {
-            name: trimmedName,
-            command: command.trim(),
-            args: parseLines(argsText),
-            env: parseEnv(envText),
-          }
-      if (mode === 'url' && !request.url) throw new Error('URL is required')
-      if (mode === 'command' && !request.command) throw new Error('Command is required')
+      const trimmedName = name.trim();
+      if (!trimmedName) throw new Error("Server name is required");
+      const request: CodexMcpAddRequest =
+        mode === "url"
+          ? {
+              name: trimmedName,
+              url: url.trim(),
+              ...(bearerTokenEnvVar.trim() && {
+                bearer_token_env_var: bearerTokenEnvVar.trim(),
+              }),
+            }
+          : {
+              name: trimmedName,
+              command: command.trim(),
+              args: parseLines(argsText),
+              env: parseEnv(envText),
+            };
+      if (mode === "url" && !request.url) throw new Error("URL is required");
+      if (mode === "command" && !request.command)
+        throw new Error("Command is required");
 
-      setMutating(true)
-      const result = await addCodexMcpServer(request)
+      setMutating(true);
+      const result = await addCodexMcpServer(request);
       if (result.exit_code !== 0) {
-        throw new Error(result.stderr || result.stdout || `codex mcp add exited with ${result.exit_code}`)
+        throw new Error(
+          result.stderr ||
+            result.stdout ||
+            `codex mcp add exited with ${result.exit_code}`,
+        );
       }
-      const message = `MCP server "${trimmedName}" added`
-      setMutationMessage(message)
-      toast.success(message)
-      resetForm()
-      await onRefresh()
+      const message = `MCP server "${trimmedName}" added`;
+      setMutationMessage(message);
+      toast.success(message);
+      resetForm();
+      await onRefresh();
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to add MCP server'
-      setMutationError(message)
-      toast.error(message)
+      const message =
+        error instanceof Error ? error.message : "Failed to add MCP server";
+      setMutationError(message);
+      toast.error(message);
     } finally {
-      setMutating(false)
+      setMutating(false);
     }
-  }
+  };
 
   const handleRemoveMcp = async (serverName: string) => {
-    setMutationError(null)
-    setMutationMessage(null)
-    setMutating(true)
+    setMutationError(null);
+    setMutationMessage(null);
+    setMutating(true);
     try {
-      const result = await removeCodexMcpServer(serverName)
+      const result = await removeCodexMcpServer(serverName);
       if (result.exit_code !== 0) {
-        throw new Error(result.stderr || result.stdout || `codex mcp remove exited with ${result.exit_code}`)
+        throw new Error(
+          result.stderr ||
+            result.stdout ||
+            `codex mcp remove exited with ${result.exit_code}`,
+        );
       }
-      const message = `MCP server "${serverName}" removed`
-      setMutationMessage(message)
-      toast.success(message)
-      await onRefresh()
+      const message = `MCP server "${serverName}" removed`;
+      setMutationMessage(message);
+      toast.success(message);
+      await onRefresh();
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to remove MCP server'
-      setMutationError(message)
-      toast.error(message)
+      const message =
+        error instanceof Error ? error.message : "Failed to remove MCP server";
+      setMutationError(message);
+      toast.error(message);
     } finally {
-      setMutating(false)
+      setMutating(false);
     }
-  }
+  };
 
   const handleInstallPlugin = async () => {
-    setMutationError(null)
-    setMutationMessage(null)
+    setMutationError(null);
+    setMutationMessage(null);
     try {
-      const trimmedName = pluginName.trim()
-      const trimmedMarketplace = pluginMarketplace.trim()
-      if (!trimmedName) throw new Error('Plugin name is required')
+      const trimmedName = pluginName.trim();
+      const trimmedMarketplace = pluginMarketplace.trim();
+      if (!trimmedName) throw new Error("Plugin name is required");
       if (!canInstallPlugins) {
-        throw new Error(pluginCapabilities?.install.reason || 'Codex plugin install is not supported')
+        throw new Error(
+          pluginCapabilities?.install.reason ||
+            "Codex plugin install is not supported",
+        );
       }
 
-      setMutating(true)
+      setMutating(true);
       const result = await installCodexPlugin({
         name: trimmedName,
         ...(trimmedMarketplace && { marketplace: trimmedMarketplace }),
-      })
+      });
       if (result.exit_code !== 0) {
-        throw new Error(result.stderr || result.stdout || `codex plugin add exited with ${result.exit_code}`)
+        throw new Error(
+          result.stderr ||
+            result.stdout ||
+            `codex plugin add exited with ${result.exit_code}`,
+        );
       }
-      const message = `Plugin "${trimmedName}" installed`
-      setMutationMessage(message)
-      toast.success(message)
-      resetPluginForm()
-      await onRefresh()
+      const message = `Plugin "${trimmedName}" installed`;
+      setMutationMessage(message);
+      toast.success(message);
+      resetPluginForm();
+      await onRefresh();
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to install Codex plugin'
-      setMutationError(message)
-      toast.error(message)
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Failed to install Codex plugin";
+      setMutationError(message);
+      toast.error(message);
     } finally {
-      setMutating(false)
+      setMutating(false);
     }
-  }
+  };
 
   const handleRemovePlugin = async (nameToRemove: string) => {
-    setMutationError(null)
-    setMutationMessage(null)
+    setMutationError(null);
+    setMutationMessage(null);
     if (!canRemovePlugins) {
-      const message = pluginCapabilities?.remove.reason || 'Codex plugin remove is not supported'
-      setMutationError(message)
-      toast.error(message)
-      return
+      const message =
+        pluginCapabilities?.remove.reason ||
+        "Codex plugin remove is not supported";
+      setMutationError(message);
+      toast.error(message);
+      return;
     }
 
-    setMutating(true)
+    setMutating(true);
     try {
-      const result = await removeCodexPlugin(nameToRemove)
+      const result = await removeCodexPlugin(nameToRemove);
       if (result.exit_code !== 0) {
-        throw new Error(result.stderr || result.stdout || `codex plugin remove exited with ${result.exit_code}`)
+        throw new Error(
+          result.stderr ||
+            result.stdout ||
+            `codex plugin remove exited with ${result.exit_code}`,
+        );
       }
-      const message = `Plugin "${nameToRemove}" removed`
-      setMutationMessage(message)
-      toast.success(message)
-      await onRefresh()
+      const message = `Plugin "${nameToRemove}" removed`;
+      setMutationMessage(message);
+      toast.success(message);
+      await onRefresh();
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to remove Codex plugin'
-      setMutationError(message)
-      toast.error(message)
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Failed to remove Codex plugin";
+      setMutationError(message);
+      toast.error(message);
     } finally {
-      setMutating(false)
+      setMutating(false);
     }
-  }
+  };
 
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0">
-        <CardTitle>Codex Inventory</CardTitle>
+        <div>
+          <CardTitle>{title}</CardTitle>
+          {description && (
+            <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+          )}
+        </div>
         <Button
           variant="ghost"
           size="icon"
@@ -301,201 +394,253 @@ export function CodexInventoryCard({
           disabled={loading || mutating}
           title="Refresh inventory"
         >
-          <RefreshCw className={cn('h-4 w-4', loading && 'animate-spin')} />
+          <RefreshCw className={cn("h-4 w-4", loading && "animate-spin")} />
         </Button>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="grid gap-3 md:grid-cols-2">
-          <div className="rounded-md border p-3">
-            <div className="flex items-center justify-between gap-2">
-              <p className="text-sm font-medium">MCP Servers</p>
-              <Badge variant={mcp?.exit_code === 0 ? 'default' : 'outline'}>
-                exit {mcp?.exit_code ?? 'n/a'}
-              </Badge>
-            </div>
-            <p className="mt-1 text-2xl font-semibold">{mcpCount ?? 'Unknown'}</p>
-            {mcp?.parse_error && (
-              <p className="mt-2 text-xs text-destructive">{mcp.parse_error}</p>
-            )}
-            {mcp?.stderr && (
-              <p className="mt-2 text-xs text-muted-foreground">{mcp.stderr}</p>
-            )}
-          </div>
-
-          <div className="rounded-md border p-3">
-            <div className="flex items-center justify-between gap-2">
-              <p className="text-sm font-medium">Plugins</p>
-              <Badge variant={plugins?.exit_code === 0 ? 'default' : 'outline'}>
-                exit {plugins?.exit_code ?? 'n/a'}
-              </Badge>
-            </div>
-            <p className="mt-1 text-2xl font-semibold">{pluginCount ?? 'Unknown'}</p>
-            {pluginCapabilities && (
-              <div className="mt-2 flex flex-wrap gap-1.5">
-                <Badge variant={canInstallPlugins ? 'default' : 'outline'}>install</Badge>
-                <Badge variant={canRemovePlugins ? 'default' : 'outline'}>remove</Badge>
-                <Badge variant="outline">enable unsupported</Badge>
-                <Badge variant="outline">disable unsupported</Badge>
+        <div
+          className={cn(
+            "grid gap-3",
+            showMcp && showPlugins && "md:grid-cols-2",
+          )}
+        >
+          {showMcp && (
+            <div className="rounded-md border p-3">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-sm font-medium">MCP Servers</p>
+                <Badge variant={mcp?.exit_code === 0 ? "default" : "outline"}>
+                  exit {mcp?.exit_code ?? "n/a"}
+                </Badge>
               </div>
-            )}
-            {plugins?.stderr && (
-              <p className="mt-2 text-xs text-muted-foreground">{plugins.stderr}</p>
-            )}
-          </div>
+              <p className="mt-1 text-2xl font-semibold">
+                {mcpCount ?? "Unknown"}
+              </p>
+              {mcp?.parse_error && (
+                <p className="mt-2 text-xs text-destructive">
+                  {mcp.parse_error}
+                </p>
+              )}
+              {mcp?.stderr && (
+                <p className="mt-2 text-xs text-muted-foreground">
+                  {mcp.stderr}
+                </p>
+              )}
+            </div>
+          )}
+
+          {showPlugins && (
+            <div className="rounded-md border p-3">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-sm font-medium">Plugins</p>
+                <Badge
+                  variant={plugins?.exit_code === 0 ? "default" : "outline"}
+                >
+                  exit {plugins?.exit_code ?? "n/a"}
+                </Badge>
+              </div>
+              <p className="mt-1 text-2xl font-semibold">
+                {pluginCount ?? "Unknown"}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {installedPluginCount ?? 0} installed; inventory includes
+                available plugins reported by Codex CLI.
+              </p>
+              {pluginCapabilities && (
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  <Badge variant={canInstallPlugins ? "default" : "outline"}>
+                    install
+                  </Badge>
+                  <Badge variant={canRemovePlugins ? "default" : "outline"}>
+                    remove
+                  </Badge>
+                  <Badge variant="outline">enable unsupported</Badge>
+                  <Badge variant="outline">disable unsupported</Badge>
+                </div>
+              )}
+              {plugins?.stderr && (
+                <p className="mt-2 text-xs text-muted-foreground">
+                  {plugins.stderr}
+                </p>
+              )}
+            </div>
+          )}
         </div>
 
-        <InventoryError message={mcpError} />
-        <InventoryError message={pluginError} />
+        {showMcp && <InventoryError message={mcpError} />}
+        {showPlugins && <InventoryError message={pluginError} />}
         <InventoryError message={mutationError} />
         <InventoryMessage message={mutationMessage} />
 
-        <div className="rounded-md border p-3">
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <p className="text-sm font-medium">Add MCP Server</p>
-            <div className="flex rounded-md border p-0.5">
-              <Button
-                type="button"
-                variant={mode === 'command' ? 'secondary' : 'ghost'}
-                size="sm"
-                className="h-7"
-                onClick={() => setMode('command')}
-              >
-                Command
-              </Button>
-              <Button
-                type="button"
-                variant={mode === 'url' ? 'secondary' : 'ghost'}
-                size="sm"
-                className="h-7"
-                onClick={() => setMode('url')}
-              >
-                URL
-              </Button>
+        {showMcp && (
+          <div className="rounded-md border p-3">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <p className="text-sm font-medium">Add MCP Server</p>
+              <div className="flex rounded-md border p-0.5">
+                <Button
+                  type="button"
+                  variant={mode === "command" ? "secondary" : "ghost"}
+                  size="sm"
+                  className="h-7"
+                  onClick={() => setMode("command")}
+                >
+                  Command
+                </Button>
+                <Button
+                  type="button"
+                  variant={mode === "url" ? "secondary" : "ghost"}
+                  size="sm"
+                  className="h-7"
+                  onClick={() => setMode("url")}
+                >
+                  URL
+                </Button>
+              </div>
             </div>
-          </div>
-          <div className="mt-3 grid gap-3 md:grid-cols-2">
-            <div className="space-y-1.5">
-              <Label htmlFor="codex-mcp-name">Name</Label>
-              <Input
-                id="codex-mcp-name"
-                value={name}
-                onChange={(event) => setName(event.target.value)}
-                placeholder="linear"
-                disabled={mutating}
-              />
-            </div>
-            {mode === 'url' ? (
-              <>
-                <div className="space-y-1.5">
-                  <Label htmlFor="codex-mcp-url">URL</Label>
-                  <Input
-                    id="codex-mcp-url"
-                    value={url}
-                    onChange={(event) => setUrl(event.target.value)}
-                    placeholder="https://example.com/mcp"
-                    disabled={mutating}
-                  />
-                </div>
-                <div className="space-y-1.5 md:col-span-2">
-                  <Label htmlFor="codex-mcp-bearer-env">Bearer Token Env Var</Label>
-                  <Input
-                    id="codex-mcp-bearer-env"
-                    value={bearerTokenEnvVar}
-                    onChange={(event) => setBearerTokenEnvVar(event.target.value)}
-                    placeholder="MCP_TOKEN"
-                    disabled={mutating}
-                  />
-                </div>
-              </>
-            ) : (
-              <>
-                <div className="space-y-1.5">
-                  <Label htmlFor="codex-mcp-command">Command</Label>
-                  <Input
-                    id="codex-mcp-command"
-                    value={command}
-                    onChange={(event) => setCommand(event.target.value)}
-                    placeholder="npx"
-                    disabled={mutating}
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="codex-mcp-args">Arguments</Label>
-                  <Textarea
-                    id="codex-mcp-args"
-                    value={argsText}
-                    onChange={(event) => setArgsText(event.target.value)}
-                    placeholder={'-y\n@linear/mcp'}
-                    disabled={mutating}
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="codex-mcp-env">Environment</Label>
-                  <Textarea
-                    id="codex-mcp-env"
-                    value={envText}
-                    onChange={(event) => setEnvText(event.target.value)}
-                    placeholder="LINEAR_API_KEY=value"
-                    disabled={mutating}
-                  />
-                </div>
-              </>
-            )}
-          </div>
-          <div className="mt-3 flex justify-end">
-            <Button onClick={handleAddMcp} disabled={mutating} className="gap-2">
-              <Plus className="h-4 w-4" />
-              Add Server
-            </Button>
-          </div>
-        </div>
-
-        <div className="rounded-md border p-3">
-          <div className="flex flex-wrap items-start justify-between gap-2">
-            <div>
-              <p className="text-sm font-medium">Install Plugin</p>
-              {pluginToggleUnsupported && (
-                <p className="mt-1 text-xs text-muted-foreground">{pluginToggleUnsupported}</p>
+            <div className="mt-3 grid gap-3 md:grid-cols-2">
+              <div className="space-y-1.5">
+                <Label htmlFor="codex-mcp-name">Name</Label>
+                <Input
+                  id="codex-mcp-name"
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                  placeholder="linear"
+                  disabled={mutating}
+                />
+              </div>
+              {mode === "url" ? (
+                <>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="codex-mcp-url">URL</Label>
+                    <Input
+                      id="codex-mcp-url"
+                      value={url}
+                      onChange={(event) => setUrl(event.target.value)}
+                      placeholder="https://example.com/mcp"
+                      disabled={mutating}
+                    />
+                  </div>
+                  <div className="space-y-1.5 md:col-span-2">
+                    <Label htmlFor="codex-mcp-bearer-env">
+                      Bearer Token Env Var
+                    </Label>
+                    <Input
+                      id="codex-mcp-bearer-env"
+                      value={bearerTokenEnvVar}
+                      onChange={(event) =>
+                        setBearerTokenEnvVar(event.target.value)
+                      }
+                      placeholder="MCP_TOKEN"
+                      disabled={mutating}
+                    />
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="codex-mcp-command">Command</Label>
+                    <Input
+                      id="codex-mcp-command"
+                      value={command}
+                      onChange={(event) => setCommand(event.target.value)}
+                      placeholder="npx"
+                      disabled={mutating}
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="codex-mcp-args">Arguments</Label>
+                    <Textarea
+                      id="codex-mcp-args"
+                      value={argsText}
+                      onChange={(event) => setArgsText(event.target.value)}
+                      placeholder={"-y\n@linear/mcp"}
+                      disabled={mutating}
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="codex-mcp-env">Environment</Label>
+                    <Textarea
+                      id="codex-mcp-env"
+                      value={envText}
+                      onChange={(event) => setEnvText(event.target.value)}
+                      placeholder="LINEAR_API_KEY=value"
+                      disabled={mutating}
+                    />
+                  </div>
+                </>
               )}
             </div>
-            {pluginCapabilities?.install.command && (
-              <Badge variant="outline">{pluginCapabilities.install.command}</Badge>
-            )}
-          </div>
-          <div className="mt-3 grid gap-3 md:grid-cols-2">
-            <div className="space-y-1.5">
-              <Label htmlFor="codex-plugin-name">Plugin</Label>
-              <Input
-                id="codex-plugin-name"
-                value={pluginName}
-                onChange={(event) => setPluginName(event.target.value)}
-                placeholder="linear or linear@openai-curated"
-                disabled={mutating || !canInstallPlugins}
-              />
-            </div>
-            <div className="space-y-1.5">
-              <Label htmlFor="codex-plugin-marketplace">Marketplace</Label>
-              <Input
-                id="codex-plugin-marketplace"
-                value={pluginMarketplace}
-                onChange={(event) => setPluginMarketplace(event.target.value)}
-                placeholder="openai-curated"
-                disabled={mutating || !canInstallPlugins}
-              />
+            <div className="mt-3 flex justify-end">
+              <Button
+                onClick={handleAddMcp}
+                disabled={mutating}
+                className="gap-2"
+              >
+                <Plus className="h-4 w-4" />
+                Add Server
+              </Button>
             </div>
           </div>
-          <div className="mt-3 flex justify-end">
-            <Button onClick={handleInstallPlugin} disabled={mutating || !canInstallPlugins} className="gap-2">
-              <Plus className="h-4 w-4" />
-              Install Plugin
-            </Button>
-          </div>
-        </div>
+        )}
 
-        {mcpRows.length > 0 && (
+        {showPlugins && (
+          <div className="rounded-md border p-3">
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div>
+                <p className="text-sm font-medium">Install Plugin</p>
+                {pluginToggleUnsupported && (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {pluginToggleUnsupported}
+                  </p>
+                )}
+              </div>
+              {pluginCapabilities?.install.command && (
+                <Badge variant="outline">
+                  {pluginCapabilities.install.command}
+                </Badge>
+              )}
+            </div>
+            <div className="mt-3 grid gap-3 md:grid-cols-2">
+              <div className="space-y-1.5">
+                <Label htmlFor="codex-plugin-name">Plugin</Label>
+                <Input
+                  id="codex-plugin-name"
+                  value={pluginName}
+                  onChange={(event) => setPluginName(event.target.value)}
+                  placeholder="linear or linear@openai-curated"
+                  disabled={mutating || !canInstallPlugins}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="codex-plugin-marketplace">Marketplace</Label>
+                <Input
+                  id="codex-plugin-marketplace"
+                  value={pluginMarketplace}
+                  onChange={(event) => setPluginMarketplace(event.target.value)}
+                  placeholder="openai-curated"
+                  disabled={mutating || !canInstallPlugins}
+                />
+              </div>
+            </div>
+            <div className="mt-3 flex justify-end">
+              <Button
+                onClick={handleInstallPlugin}
+                disabled={mutating || !canInstallPlugins}
+                className="gap-2"
+              >
+                <Plus className="h-4 w-4" />
+                Install Plugin
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {showMcp && mcpRows.length > 0 && (
           <div className="rounded-md border">
             {mcpRows.map((server) => (
-              <div key={server.name} className="flex items-start justify-between gap-3 border-b p-3 last:border-b-0">
+              <div
+                key={server.name}
+                className="flex items-start justify-between gap-3 border-b p-3 last:border-b-0"
+              >
                 <div className="min-w-0">
                   <p className="truncate text-sm font-medium">{server.name}</p>
                   <code className="mt-1 block max-w-full truncate rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
@@ -518,7 +663,9 @@ export function CodexInventoryCard({
                     <AlertDialogHeader>
                       <AlertDialogTitle>Remove MCP Server</AlertDialogTitle>
                       <AlertDialogDescription>
-                        Remove "{server.name}" from Codex MCP configuration? This uses codex mcp remove and cannot be undone from this screen.
+                        Remove "{server.name}" from Codex MCP configuration?
+                        This uses codex mcp remove and cannot be undone from
+                        this screen.
                       </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>
@@ -537,70 +684,106 @@ export function CodexInventoryCard({
           </div>
         )}
 
-        {plugins?.plugins && plugins.plugins.length > 0 && (
-          <div className="rounded-md border">
-            {plugins.plugins.map((plugin) => (
-              <div key={`${plugin.status ?? 'unknown'}:${plugin.name}`} className="border-b p-3 last:border-b-0">
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-2">
-                      <p className="truncate text-sm font-medium">{plugin.name}</p>
-                      {plugin.status && <Badge variant="outline">{plugin.status}</Badge>}
-                    </div>
-                    {(plugin.version || plugin.path) && (
-                      <div className="mt-1 flex min-w-0 flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                        {plugin.version && <span>v{plugin.version}</span>}
-                        {plugin.path && (
-                          <code className="max-w-full truncate rounded bg-muted px-1.5 py-0.5 font-mono">
-                            {plugin.path}
-                          </code>
+        {showPlugins && plugins?.plugins && plugins.plugins.length > 0 && (
+          <div className="space-y-3">
+            <Input
+              value={pluginSearch}
+              onChange={(event) => setPluginSearch(event.target.value)}
+              placeholder="Search plugins by name, status, version, or path"
+            />
+            <div className="rounded-md border">
+              {filteredPlugins.length === 0 ? (
+                <p className="p-3 text-sm text-muted-foreground">
+                  No plugins match the current search.
+                </p>
+              ) : (
+                filteredPlugins.map((plugin) => (
+                  <div
+                    key={`${plugin.status ?? "unknown"}:${plugin.name}`}
+                    className="border-b p-3 last:border-b-0"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <p className="truncate text-sm font-medium">
+                            {plugin.name}
+                          </p>
+                          {plugin.status && (
+                            <Badge variant="outline">{plugin.status}</Badge>
+                          )}
+                        </div>
+                        {(plugin.version || plugin.path) && (
+                          <div className="mt-1 flex min-w-0 flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                            {plugin.version && <span>v{plugin.version}</span>}
+                            {plugin.path && (
+                              <code className="max-w-full truncate rounded bg-muted px-1.5 py-0.5 font-mono">
+                                {plugin.path}
+                              </code>
+                            )}
+                          </div>
                         )}
                       </div>
-                    )}
+                      {isInstalledPluginStatus(plugin.status) && (
+                        <AlertDialog>
+                          <AlertDialogTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8 shrink-0 text-destructive hover:text-destructive"
+                              disabled={mutating || !canRemovePlugins}
+                              title={`Remove ${plugin.name}`}
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </AlertDialogTrigger>
+                          <AlertDialogContent>
+                            <AlertDialogHeader>
+                              <AlertDialogTitle>
+                                Remove Codex Plugin
+                              </AlertDialogTitle>
+                              <AlertDialogDescription>
+                                Remove "{plugin.name}" using codex plugin
+                                remove? This updates Codex local plugin config
+                                and cache.
+                              </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                              <AlertDialogCancel>Cancel</AlertDialogCancel>
+                              <AlertDialogAction
+                                onClick={() => handleRemovePlugin(plugin.name)}
+                                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                              >
+                                Remove
+                              </AlertDialogAction>
+                            </AlertDialogFooter>
+                          </AlertDialogContent>
+                        </AlertDialog>
+                      )}
+                    </div>
                   </div>
-                  {plugin.status === 'installed' && (
-                    <AlertDialog>
-                      <AlertDialogTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-8 w-8 shrink-0 text-destructive hover:text-destructive"
-                          disabled={mutating || !canRemovePlugins}
-                          title={`Remove ${plugin.name}`}
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </AlertDialogTrigger>
-                      <AlertDialogContent>
-                        <AlertDialogHeader>
-                          <AlertDialogTitle>Remove Codex Plugin</AlertDialogTitle>
-                          <AlertDialogDescription>
-                            Remove "{plugin.name}" using codex plugin remove? This updates Codex local plugin config and cache.
-                          </AlertDialogDescription>
-                        </AlertDialogHeader>
-                        <AlertDialogFooter>
-                          <AlertDialogCancel>Cancel</AlertDialogCancel>
-                          <AlertDialogAction
-                            onClick={() => handleRemovePlugin(plugin.name)}
-                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                          >
-                            Remove
-                          </AlertDialogAction>
-                        </AlertDialogFooter>
-                      </AlertDialogContent>
-                    </AlertDialog>
-                  )}
-                </div>
-              </div>
-            ))}
+                ))
+              )}
+            </div>
           </div>
         )}
 
-        <div className="grid gap-3 lg:grid-cols-2">
-          <RawDetails label="MCP JSON" content={mcp?.servers ?? null} />
-          <RawDetails label="Plugin output" content={plugins?.raw_stdout ?? ''} />
+        <div
+          className={cn(
+            "grid gap-3",
+            showMcp && showPlugins && "lg:grid-cols-2",
+          )}
+        >
+          {showMcp && (
+            <RawDetails label="MCP JSON" content={mcp?.servers ?? null} />
+          )}
+          {showPlugins && (
+            <RawDetails
+              label="Plugin output"
+              content={plugins?.raw_stdout ?? ""}
+            />
+          )}
         </div>
       </CardContent>
     </Card>
-  )
+  );
 }

--- a/frontend/src/features/config/CodexSettingsEditor.tsx
+++ b/frontend/src/features/config/CodexSettingsEditor.tsx
@@ -1,140 +1,172 @@
-import { useMemo, useState } from 'react'
-import type { ReactNode } from 'react'
-import { HelpCircle, Plus, RotateCcw, Save } from 'lucide-react'
-import { toast } from 'sonner'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { useEffect, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+import { HelpCircle, Plus, RotateCcw, Save } from "lucide-react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '@/components/ui/select'
-import { Switch } from '@/components/ui/switch'
-import { updateCodexConfig } from '@/hooks/useProviders'
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { updateCodexConfig } from "@/hooks/useProviders";
 import type {
   CodexConfigResponse,
   CodexConfigUpdateRequest,
   CodexFeatureInventoryResponse,
   CodexFeatureInventoryRow,
-} from '@/types/providers'
+} from "@/types/providers";
 
 interface CodexSettingsEditorProps {
-  config: CodexConfigResponse | null
-  featureInventory: CodexFeatureInventoryResponse | null
-  featureInventoryError: string | null
-  onSaved: () => Promise<void> | void
+  config: CodexConfigResponse | null;
+  featureInventory: CodexFeatureInventoryResponse | null;
+  featureInventoryError: string | null;
+  onSaved: () => Promise<void> | void;
 }
 
-const FEATURE_NAME_PATTERN = /^[A-Za-z0-9_-]+$/
-const DEFAULT_SELECT_VALUE = '__default__'
+const FEATURE_NAME_PATTERN = /^[A-Za-z0-9_-]+$/;
+const DEFAULT_SELECT_VALUE = "__default__";
 const REASONING_EFFORT_OPTIONS = [
-  { value: 'low', label: 'Low' },
-  { value: 'medium', label: 'Medium' },
-  { value: 'high', label: 'High' },
-  { value: 'xhigh', label: 'Extra High' },
-]
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+  { value: "xhigh", label: "Extra High" },
+];
 const SANDBOX_MODE_OPTIONS = [
-  { value: 'read-only', label: 'Read Only' },
-  { value: 'workspace-write', label: 'Workspace Write' },
-  { value: 'danger-full-access', label: 'Danger Full Access' },
-]
+  { value: "read-only", label: "Read Only" },
+  { value: "workspace-write", label: "Workspace Write" },
+  { value: "danger-full-access", label: "Danger Full Access" },
+];
 const APPROVAL_POLICY_OPTIONS = [
-  { value: 'untrusted', label: 'Untrusted' },
-  { value: 'on-request', label: 'On Request' },
-  { value: 'never', label: 'Never' },
-  { value: 'on-failure', label: 'On Failure (deprecated)' },
-]
+  { value: "untrusted", label: "Untrusted" },
+  { value: "on-request", label: "On Request" },
+  { value: "never", label: "Never" },
+  { value: "on-failure", label: "On Failure (deprecated)" },
+];
 const SETTING_HELP = {
-  model: 'Model the agent should use. This is open-ended; enter any Codex-supported model id.',
-  reasoning: 'Controls reasoning depth for models that support it.',
-  profile: 'Layers a named Codex profile config on top of the base user config.',
-  sandboxMode: 'Sandbox policy for filesystem and network access during command execution.',
-  approvalPolicy: 'Controls when Codex requires human approval before executing a command.',
-  search: 'Enables live web search. Codex can use the native web search tool without per-call approval.',
-  strictConfig: 'Errors out when config.toml contains fields this Codex version does not recognize.',
-  noAltScreen: 'Runs the TUI inline instead of in an alternate screen, preserving terminal scrollback history.',
-} satisfies Record<string, string>
+  model:
+    "Model the agent should use. This is open-ended; enter any Codex-supported model id.",
+  reasoning: "Controls reasoning depth for models that support it.",
+  profile:
+    "Layers a named Codex profile config on top of the base user config.",
+  sandboxMode:
+    "Sandbox policy for filesystem and network access during command execution.",
+  approvalPolicy:
+    "Controls when Codex requires human approval before executing a command.",
+  search:
+    "Enables live web search. Codex can use the native web search tool without per-call approval.",
+  strictConfig:
+    "Errors out when config.toml contains fields this Codex version does not recognize.",
+  noAltScreen:
+    "Runs the TUI inline instead of in an alternate screen, preserving terminal scrollback history.",
+} satisfies Record<string, string>;
 const FEATURE_HELP: Record<string, string> = {
-  apps: 'Enable ChatGPT Apps/connectors support.',
-  enable_request_compression: 'Compress streaming request bodies with zstd when supported.',
-  fast_mode: 'Enable model-catalog service tier selection in the TUI, including Fast-tier commands when the active model advertises them.',
-  goals: 'Enable persistent objectives that keep a Codex thread working toward a defined outcome across turns.',
-  hooks: 'Enable lifecycle hooks loaded from hooks.json or inline hooks config.',
-  memories: 'Enable Codex Memories.',
-  multi_agent: 'Enable multi-agent collaboration tools such as spawn_agent, send_input, resume_agent, wait_agent, and close_agent.',
-  network_proxy: 'Enable sandboxed networking. Table-form config can set network policy options such as allowed domains.',
-  personality: 'Enable personality selection controls.',
-  prevent_idle_sleep: 'Prevent the machine from sleeping while a turn is actively running.',
-  shell_snapshot: 'Snapshot the shell environment to speed up repeated commands.',
-  shell_tool: 'Enable the default shell tool for running commands.',
-  skill_mcp_dependency_install: 'Allow prompting and installing missing MCP dependencies for skills.',
-  undo: 'Enable undo support.',
-  unified_exec: 'Use the unified PTY-backed exec tool.',
-}
+  apps: "Enable ChatGPT Apps/connectors support.",
+  enable_request_compression:
+    "Compress streaming request bodies with zstd when supported.",
+  fast_mode:
+    "Enable model-catalog service tier selection in the TUI, including Fast-tier commands when the active model advertises them.",
+  goals:
+    "Enable persistent objectives that keep a Codex thread working toward a defined outcome across turns.",
+  hooks:
+    "Enable lifecycle hooks loaded from hooks.json or inline hooks config.",
+  memories: "Enable Codex Memories.",
+  multi_agent:
+    "Enable multi-agent collaboration tools such as spawn_agent, send_input, resume_agent, wait_agent, and close_agent.",
+  network_proxy:
+    "Enable sandboxed networking. Table-form config can set network policy options such as allowed domains.",
+  personality: "Enable personality selection controls.",
+  prevent_idle_sleep:
+    "Prevent the machine from sleeping while a turn is actively running.",
+  shell_snapshot:
+    "Snapshot the shell environment to speed up repeated commands.",
+  shell_tool: "Enable the default shell tool for running commands.",
+  skill_mcp_dependency_install:
+    "Allow prompting and installing missing MCP dependencies for skills.",
+  undo: "Enable undo support.",
+  unified_exec: "Use the unified PTY-backed exec tool.",
+};
 const FEATURE_ORDER = [
-  'goals',
-  'memories',
-  'hooks',
-  'multi_agent',
-  'fast_mode',
-  'undo',
-  'prevent_idle_sleep',
-  'network_proxy',
-  'shell_tool',
-  'shell_snapshot',
-  'personality',
-  'unified_exec',
-]
+  "goals",
+  "memories",
+  "hooks",
+  "multi_agent",
+  "fast_mode",
+  "undo",
+  "prevent_idle_sleep",
+  "network_proxy",
+  "shell_tool",
+  "shell_snapshot",
+  "personality",
+  "unified_exec",
+];
 
 function optionalString(value: string): string | null {
-  const trimmed = value.trim()
-  return trimmed.length > 0 ? trimmed : null
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
-function optionalBoolean(current: boolean, original: boolean | undefined): boolean | null {
-  if (original !== undefined || current === true) return current
-  return null
+function optionalBoolean(
+  current: boolean,
+  original: boolean | undefined,
+): boolean | null {
+  if (original !== undefined || current === true) return current;
+  return null;
 }
 
-function booleanFeatureOverrides(features: Record<string, unknown> | undefined): Record<string, boolean> {
-  if (!features) return {}
+function booleanFeatureOverrides(
+  features: Record<string, unknown> | undefined,
+): Record<string, boolean> {
+  if (!features) return {};
   return Object.fromEntries(
-    Object.entries(features).filter((entry): entry is [string, boolean] => typeof entry[1] === 'boolean'),
-  )
+    Object.entries(features).filter(
+      (entry): entry is [string, boolean] => typeof entry[1] === "boolean",
+    ),
+  );
 }
 
 function uniqueStrings(values: Array<string | null | undefined>): string[] {
-  return Array.from(new Set(values.map((value) => value?.trim()).filter((value): value is string => Boolean(value))))
+  return Array.from(
+    new Set(
+      values
+        .map((value) => value?.trim())
+        .filter((value): value is string => Boolean(value)),
+    ),
+  );
 }
 
 function stringValue(value: unknown): string | undefined {
-  return typeof value === 'string' && value.trim().length > 0 ? value : undefined
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
 }
 
 function withCurrentOption(
   options: { value: string; label: string }[],
   current: string,
 ): { value: string; label: string }[] {
-  if (!current || options.some((option) => option.value === current)) return options
-  return [...options, { value: current, label: `${current} (custom)` }]
+  if (!current || options.some((option) => option.value === current))
+    return options;
+  return [...options, { value: current, label: `${current} (custom)` }];
 }
 
 function formatKnownValues(values: string[], emptyMessage: string): string {
-  if (values.length === 0) return emptyMessage
-  return `Known in this config: ${values.join(', ')}.`
+  if (values.length === 0) return emptyMessage;
+  return `Known in this config: ${values.join(", ")}.`;
 }
 
 function featureHelp(feature: CodexFeatureInventoryRow): string {
-  return FEATURE_HELP[feature.name]
-    ?? (
-      `No official description found. Codex reports this flag as ${feature.stage || 'unknown stage'} `
-      + `and currently ${feature.enabled ? 'enabled' : 'disabled'}.`
-    )
+  return (
+    FEATURE_HELP[feature.name] ??
+    `No official description found. Codex reports this flag as ${feature.stage || "unknown stage"} ` +
+      `and currently ${feature.enabled ? "enabled" : "disabled"}.`
+  );
 }
 
 function HelpIcon({ text }: { text: string }) {
@@ -147,7 +179,7 @@ function HelpIcon({ text }: { text: string }) {
     >
       <HelpCircle className="h-3.5 w-3.5" />
     </span>
-  )
+  );
 }
 
 function LabelWithHelp({
@@ -156,10 +188,10 @@ function LabelWithHelp({
   help,
   className,
 }: {
-  htmlFor?: string
-  children: ReactNode
-  help?: string
-  className?: string
+  htmlFor?: string;
+  children: ReactNode;
+  help?: string;
+  className?: string;
 }) {
   return (
     <div className="flex min-w-0 items-center gap-1.5">
@@ -168,7 +200,7 @@ function LabelWithHelp({
       </Label>
       {help && <HelpIcon text={help} />}
     </div>
-  )
+  );
 }
 
 function Field({
@@ -180,13 +212,13 @@ function Field({
   description,
   help,
 }: {
-  id: string
-  label: string
-  value: string
-  placeholder?: string
-  onChange: (value: string) => void
-  description?: string
-  help?: string
+  id: string;
+  label: string;
+  value: string;
+  placeholder?: string;
+  onChange: (value: string) => void;
+  description?: string;
+  help?: string;
 }) {
   return (
     <div className="space-y-1.5">
@@ -199,9 +231,11 @@ function Field({
         placeholder={placeholder}
         onChange={(event) => onChange(event.target.value)}
       />
-      {description && <p className="text-xs text-muted-foreground">{description}</p>}
+      {description && (
+        <p className="text-xs text-muted-foreground">{description}</p>
+      )}
     </div>
-  )
+  );
 }
 
 function SelectField({
@@ -212,12 +246,12 @@ function SelectField({
   onChange,
   help,
 }: {
-  id: string
-  label: string
-  value: string
-  options: { value: string; label: string }[]
-  onChange: (value: string) => void
-  help?: string
+  id: string;
+  label: string;
+  value: string;
+  options: { value: string; label: string }[];
+  onChange: (value: string) => void;
+  help?: string;
 }) {
   return (
     <div className="space-y-1.5">
@@ -226,7 +260,9 @@ function SelectField({
       </LabelWithHelp>
       <Select
         value={value || DEFAULT_SELECT_VALUE}
-        onValueChange={(nextValue) => onChange(nextValue === DEFAULT_SELECT_VALUE ? '' : nextValue)}
+        onValueChange={(nextValue) =>
+          onChange(nextValue === DEFAULT_SELECT_VALUE ? "" : nextValue)
+        }
       >
         <SelectTrigger id={id}>
           <SelectValue />
@@ -241,7 +277,7 @@ function SelectField({
         </SelectContent>
       </Select>
     </div>
-  )
+  );
 }
 
 function ToggleRow({
@@ -252,12 +288,12 @@ function ToggleRow({
   trailing,
   help,
 }: {
-  id: string
-  label: string
-  checked: boolean
-  onChange: (checked: boolean) => void
-  trailing?: ReactNode
-  help?: string
+  id: string;
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  trailing?: ReactNode;
+  help?: string;
 }) {
   return (
     <div className="flex items-center justify-between gap-3 rounded-md border px-3 py-2">
@@ -269,7 +305,7 @@ function ToggleRow({
         <Switch id={id} checked={checked} onCheckedChange={onChange} />
       </div>
     </div>
-  )
+  );
 }
 
 function FeatureToggleRow({
@@ -280,22 +316,26 @@ function FeatureToggleRow({
   onReset,
   help,
 }: {
-  feature: CodexFeatureInventoryRow
-  checked: boolean
-  explicit: boolean
-  onChange: (checked: boolean) => void
-  onReset: () => void
-  help: string
+  feature: CodexFeatureInventoryRow;
+  checked: boolean;
+  explicit: boolean;
+  onChange: (checked: boolean) => void;
+  onReset: () => void;
+  help: string;
 }) {
   return (
     <div className="flex items-center justify-between gap-3 rounded-md border px-3 py-2">
       <div className="min-w-0">
-        <LabelWithHelp htmlFor={`codex-feature-${feature.name}`} help={help} className="block truncate text-sm font-medium">
+        <LabelWithHelp
+          htmlFor={`codex-feature-${feature.name}`}
+          help={help}
+          className="block truncate text-sm font-medium"
+        >
           {feature.name}
         </LabelWithHelp>
         <div className="mt-1 flex flex-wrap gap-1.5">
           <Badge variant="outline" className="text-xs">
-            {feature.stage || 'unknown'}
+            {feature.stage || "unknown"}
           </Badge>
           {explicit && (
             <Badge variant="secondary" className="text-xs">
@@ -306,28 +346,55 @@ function FeatureToggleRow({
       </div>
       <div className="flex shrink-0 items-center gap-2">
         {explicit && (
-          <Button type="button" variant="ghost" size="icon" onClick={onReset} title="Use Codex default">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={onReset}
+            title="Use Codex default"
+          >
             <RotateCcw className="h-4 w-4" />
           </Button>
         )}
-        <Switch id={`codex-feature-${feature.name}`} checked={checked} onCheckedChange={onChange} />
+        <Switch
+          id={`codex-feature-${feature.name}`}
+          checked={checked}
+          onCheckedChange={onChange}
+        />
       </div>
     </div>
-  )
+  );
 }
 
-function sortFeatures(features: CodexFeatureInventoryRow[]): CodexFeatureInventoryRow[] {
-  const rank = new Map(FEATURE_ORDER.map((name, index) => [name, index]))
+function sortFeatures(
+  features: CodexFeatureInventoryRow[],
+): CodexFeatureInventoryRow[] {
+  const rank = new Map(FEATURE_ORDER.map((name, index) => [name, index]));
   return [...features].sort((a, b) => {
-    const aRank = rank.get(a.name) ?? Number.MAX_SAFE_INTEGER
-    const bRank = rank.get(b.name) ?? Number.MAX_SAFE_INTEGER
-    if (aRank !== bRank) return aRank - bRank
-    return a.name.localeCompare(b.name)
-  })
+    const aRank = rank.get(a.name) ?? Number.MAX_SAFE_INTEGER;
+    const bRank = rank.get(b.name) ?? Number.MAX_SAFE_INTEGER;
+    if (aRank !== bRank) return aRank - bRank;
+    return a.name.localeCompare(b.name);
+  });
 }
 
 function isVisibleKnownFeature(feature: CodexFeatureInventoryRow): boolean {
-  return !['removed', 'deprecated'].includes(feature.stage)
+  return !["removed", "deprecated"].includes(feature.stage);
+}
+
+function findScrollableParent(element: HTMLElement): HTMLElement | null {
+  let parent = element.parentElement;
+  while (parent) {
+    const overflowY = window.getComputedStyle(parent).overflowY;
+    if (
+      (overflowY === "auto" || overflowY === "scroll") &&
+      parent.scrollHeight > parent.clientHeight
+    ) {
+      return parent;
+    }
+    parent = parent.parentElement;
+  }
+  return null;
 }
 
 export function CodexSettingsEditor({
@@ -336,96 +403,145 @@ export function CodexSettingsEditor({
   featureInventoryError,
   onSaved,
 }: CodexSettingsEditorProps) {
-  const summary = config?.summary
-  const initialFeatures = useMemo(() => booleanFeatureOverrides(summary?.features), [summary?.features])
+  const summary = config?.summary;
+  const initialFeatures = useMemo(
+    () => booleanFeatureOverrides(summary?.features),
+    [summary?.features],
+  );
   const knownFeatures = useMemo(
-    () => sortFeatures((featureInventory?.features ?? []).filter(isVisibleKnownFeature)),
+    () =>
+      sortFeatures(
+        (featureInventory?.features ?? []).filter(isVisibleKnownFeature),
+      ),
     [featureInventory?.features],
-  )
+  );
   const knownFeatureNames = useMemo(
     () => new Set(knownFeatures.map((feature) => feature.name)),
     [knownFeatures],
-  )
-  const [model, setModel] = useState(summary?.model ?? '')
-  const [reasoning, setReasoning] = useState(summary?.model_reasoning_effort ?? '')
-  const [profile, setProfile] = useState(summary?.profile ?? '')
-  const [sandboxMode, setSandboxMode] = useState(summary?.sandbox_mode ?? '')
-  const [approvalPolicy, setApprovalPolicy] = useState(summary?.approval_policy ?? '')
-  const [search, setSearch] = useState(summary?.search ?? false)
-  const [strictConfig, setStrictConfig] = useState(summary?.strict_config ?? false)
-  const [noAltScreen, setNoAltScreen] = useState(summary?.no_alt_screen ?? false)
-  const [features, setFeatures] = useState<Record<string, boolean>>(initialFeatures)
-  const [deletedFeatures, setDeletedFeatures] = useState<Set<string>>(() => new Set())
-  const [newFeature, setNewFeature] = useState('')
-  const [submitting, setSubmitting] = useState(false)
+  );
+  const [model, setModel] = useState(summary?.model ?? "");
+  const [reasoning, setReasoning] = useState(
+    summary?.model_reasoning_effort ?? "",
+  );
+  const [profile, setProfile] = useState(summary?.profile ?? "");
+  const [sandboxMode, setSandboxMode] = useState(summary?.sandbox_mode ?? "");
+  const [approvalPolicy, setApprovalPolicy] = useState(
+    summary?.approval_policy ?? "",
+  );
+  const [search, setSearch] = useState(summary?.search ?? false);
+  const [strictConfig, setStrictConfig] = useState(
+    summary?.strict_config ?? false,
+  );
+  const [noAltScreen, setNoAltScreen] = useState(
+    summary?.no_alt_screen ?? false,
+  );
+  const [features, setFeatures] =
+    useState<Record<string, boolean>>(initialFeatures);
+  const [deletedFeatures, setDeletedFeatures] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [newFeature, setNewFeature] = useState("");
+  const [submitting, setSubmitting] = useState(false);
 
   const knownModels = uniqueStrings([
     summary?.model,
     stringValue(config?.profile_resolution?.base_summary.model),
     stringValue(config?.profile_resolution?.effective_summary.model),
-    ...(config?.profile_resolution?.profiles ?? []).map((profile) => stringValue(profile.summary.model)),
-  ])
+    ...(config?.profile_resolution?.profiles ?? []).map((profile) =>
+      stringValue(profile.summary.model),
+    ),
+  ]);
   const knownProfiles = uniqueStrings([
     summary?.profile,
     summary?.profile_v2,
     ...Object.keys(summary?.profiles ?? {}),
-    ...(config?.profile_resolution?.profiles ?? []).map((profile) => profile.name),
-  ])
-  const featureEntries = Object.entries(features).sort(([a], [b]) => a.localeCompare(b))
-  const unknownFeatureEntries = featureEntries.filter(([name]) => !knownFeatureNames.has(name))
-  const canAddFeature = FEATURE_NAME_PATTERN.test(newFeature.trim()) && !(newFeature.trim() in features)
+    ...(config?.profile_resolution?.profiles ?? []).map(
+      (profile) => profile.name,
+    ),
+  ]);
+  const featureEntries = Object.entries(features).sort(([a], [b]) =>
+    a.localeCompare(b),
+  );
+  const unknownFeatureEntries = featureEntries.filter(
+    ([name]) => !knownFeatureNames.has(name),
+  );
+  const canAddFeature =
+    FEATURE_NAME_PATTERN.test(newFeature.trim()) &&
+    !(newFeature.trim() in features);
+
+  useEffect(() => {
+    if (window.location.hash !== "#codex-features") return;
+    const timer = window.setTimeout(() => {
+      const target = document.getElementById("codex-features");
+      if (!target) return;
+
+      const scrollParent = findScrollableParent(target);
+      if (scrollParent) {
+        const parentRect = scrollParent.getBoundingClientRect();
+        const targetRect = target.getBoundingClientRect();
+        scrollParent.scrollTop += targetRect.top - parentRect.top - 16;
+        return;
+      }
+
+      target.scrollIntoView({ block: "start" });
+    }, 100);
+
+    return () => window.clearTimeout(timer);
+  }, [knownFeatures.length, unknownFeatureEntries.length]);
 
   function setFeature(name: string, value: boolean) {
-    setFeatures((current) => ({ ...current, [name]: value }))
+    setFeatures((current) => ({ ...current, [name]: value }));
     setDeletedFeatures((current) => {
-      if (!current.has(name)) return current
-      const next = new Set(current)
-      next.delete(name)
-      return next
-    })
+      if (!current.has(name)) return current;
+      const next = new Set(current);
+      next.delete(name);
+      return next;
+    });
   }
 
   function resetFeature(name: string) {
     setFeatures((current) => {
-      const next = { ...current }
-      delete next[name]
-      return next
-    })
+      const next = { ...current };
+      delete next[name];
+      return next;
+    });
     setDeletedFeatures((current) => {
-      if (!(name in initialFeatures)) return current
-      const next = new Set(current)
-      next.add(name)
-      return next
-    })
+      if (!(name in initialFeatures)) return current;
+      const next = new Set(current);
+      next.add(name);
+      return next;
+    });
   }
 
   function addFeature() {
-    const name = newFeature.trim()
+    const name = newFeature.trim();
     if (!FEATURE_NAME_PATTERN.test(name)) {
-      toast.error('Feature names can only contain letters, numbers, underscores, and hyphens')
-      return
+      toast.error(
+        "Feature names can only contain letters, numbers, underscores, and hyphens",
+      );
+      return;
     }
     if (name in features) {
-      toast.error(`Feature "${name}" already exists`)
-      return
+      toast.error(`Feature "${name}" already exists`);
+      return;
     }
-    setFeatures((current) => ({ ...current, [name]: true }))
+    setFeatures((current) => ({ ...current, [name]: true }));
     setDeletedFeatures((current) => {
-      if (!current.has(name)) return current
-      const next = new Set(current)
-      next.delete(name)
-      return next
-    })
-    setNewFeature('')
+      if (!current.has(name)) return current;
+      const next = new Set(current);
+      next.delete(name);
+      return next;
+    });
+    setNewFeature("");
   }
 
   async function handleSave() {
-    setSubmitting(true)
+    setSubmitting(true);
     try {
-      const featureUpdates: Record<string, boolean | null> = { ...features }
+      const featureUpdates: Record<string, boolean | null> = { ...features };
       deletedFeatures.forEach((name) => {
-        featureUpdates[name] = null
-      })
+        featureUpdates[name] = null;
+      });
       const request: CodexConfigUpdateRequest = {
         settings: {
           model: optionalString(model),
@@ -438,14 +554,16 @@ export function CodexSettingsEditor({
           no_alt_screen: optionalBoolean(noAltScreen, summary?.no_alt_screen),
         },
         features: featureUpdates,
-      }
-      await updateCodexConfig(request)
-      toast.success('Codex config saved')
-      await onSaved()
+      };
+      await updateCodexConfig(request);
+      toast.success("Codex config saved");
+      await onSaved();
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to save Codex config')
+      toast.error(
+        error instanceof Error ? error.message : "Failed to save Codex config",
+      );
     } finally {
-      setSubmitting(false)
+      setSubmitting(false);
     }
   }
 
@@ -472,7 +590,7 @@ export function CodexSettingsEditor({
               placeholder="default"
               onChange={setModel}
               help={SETTING_HELP.model}
-              description={`${formatKnownValues(knownModels, 'No model ids detected in this config.')} You can enter any Codex-supported model id.`}
+              description={`${formatKnownValues(knownModels, "No model ids detected in this config.")} You can enter any Codex-supported model id.`}
             />
             <SelectField
               id="codex-reasoning"
@@ -489,7 +607,7 @@ export function CodexSettingsEditor({
               placeholder="default"
               onChange={setProfile}
               help={SETTING_HELP.profile}
-              description={`${formatKnownValues(knownProfiles, 'No named profiles detected in this config.')} You can enter any Codex profile name.`}
+              description={`${formatKnownValues(knownProfiles, "No named profiles detected in this config.")} You can enter any Codex profile name.`}
             />
           </CardContent>
         </Card>
@@ -539,9 +657,9 @@ export function CodexSettingsEditor({
           </CardContent>
         </Card>
 
-        <Card>
+        <Card id="codex-features">
           <CardHeader>
-            <CardTitle>Features</CardTitle>
+            <CardTitle>Feature Flags</CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
             {featureInventoryError && (
@@ -555,19 +673,25 @@ export function CodexSettingsEditor({
                 placeholder="feature_name"
                 onChange={(event) => setNewFeature(event.target.value)}
                 onKeyDown={(event) => {
-                  if (event.key === 'Enter') {
-                    event.preventDefault()
-                    addFeature()
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    addFeature();
                   }
                 }}
               />
-              <Button type="button" variant="outline" size="icon" onClick={addFeature} disabled={!canAddFeature}>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={addFeature}
+                disabled={!canAddFeature}
+              >
                 <Plus className="h-4 w-4" />
               </Button>
             </div>
             <div className="max-h-72 space-y-2 overflow-auto pr-1">
               {knownFeatures.map((feature) => {
-                const explicit = feature.name in features
+                const explicit = feature.name in features;
                 return (
                   <FeatureToggleRow
                     key={feature.name}
@@ -578,10 +702,13 @@ export function CodexSettingsEditor({
                     onReset={() => resetFeature(feature.name)}
                     help={featureHelp(feature)}
                   />
-                )
+                );
               })}
-              {unknownFeatureEntries.length === 0 && knownFeatures.length === 0 ? (
-                <p className="rounded-md border p-3 text-sm text-muted-foreground">No feature flags configured.</p>
+              {unknownFeatureEntries.length === 0 &&
+              knownFeatures.length === 0 ? (
+                <p className="rounded-md border p-3 text-sm text-muted-foreground">
+                  No feature flags configured.
+                </p>
               ) : (
                 unknownFeatureEntries.map(([name, enabled]) => (
                   <ToggleRow
@@ -592,7 +719,13 @@ export function CodexSettingsEditor({
                     onChange={(checked) => setFeature(name, checked)}
                     help="This feature flag is configured in config.toml but is not present in the active Codex feature inventory."
                     trailing={
-                      <Button type="button" variant="ghost" size="icon" onClick={() => resetFeature(name)} title="Use Codex default">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => resetFeature(name)}
+                        title="Use Codex default"
+                      >
                         <RotateCcw className="h-4 w-4" />
                       </Button>
                     }
@@ -605,11 +738,15 @@ export function CodexSettingsEditor({
       </div>
 
       <div className="flex justify-end">
-        <Button onClick={handleSave} disabled={submitting || Boolean(config?.parse_error)} className="gap-2">
+        <Button
+          onClick={handleSave}
+          disabled={submitting || Boolean(config?.parse_error)}
+          className="gap-2"
+        >
           <Save className="h-4 w-4" />
-          {submitting ? 'Saving...' : 'Save Codex Config'}
+          {submitting ? "Saving..." : "Save Codex Config"}
         </Button>
       </div>
     </div>
-  )
+  );
 }

--- a/frontend/src/features/config/ConfigViewerPage.tsx
+++ b/frontend/src/features/config/ConfigViewerPage.tsx
@@ -1,161 +1,233 @@
-import { useState, useEffect, useCallback } from 'react'
-import { Settings, Eye, Edit, Shield } from 'lucide-react'
-import type { ConfigFileListResponse, ConfigValue } from '@/types/config'
-import { RefreshButton } from '@/components/shared/RefreshButton'
-import { ConfigFileList } from './ConfigFileList'
-import { ConfigFileViewer } from './ConfigFileViewer'
-import { CodexDiagnosticsCard } from './CodexDiagnosticsCard'
-import { CodexInventoryCard } from './CodexInventoryCard'
-import { CodexProfileResolverCard } from './CodexProfileResolverCard'
-import { CodexSettingsEditor } from './CodexSettingsEditor'
-import { SettingsEditor } from './settings'
-import { ScopeResolver } from './ScopeResolver'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { apiClient, buildEndpoint } from '@/lib/api'
-import { useProjectContext } from '@/contexts/ProjectContext'
-import { useProviderContext } from '@/contexts/ProviderContext'
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useLocation } from "react-router-dom";
+import { Settings, Eye, Edit, Shield } from "lucide-react";
+import type { ConfigFileListResponse, ConfigValue } from "@/types/config";
+import { RefreshButton } from "@/components/shared/RefreshButton";
+import { ConfigFileList } from "./ConfigFileList";
+import { ConfigFileViewer } from "./ConfigFileViewer";
+import { CodexDiagnosticsCard } from "./CodexDiagnosticsCard";
+import { CodexInventoryCard } from "./CodexInventoryCard";
+import { CodexProfileResolverCard } from "./CodexProfileResolverCard";
+import { CodexSettingsEditor } from "./CodexSettingsEditor";
+import { SettingsEditor } from "./settings";
+import { ScopeResolver } from "./ScopeResolver";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { apiClient, buildEndpoint } from "@/lib/api";
+import { useProjectContext } from "@/contexts/ProjectContext";
+import { useProviderContext } from "@/contexts/ProviderContext";
 import {
   fetchCodexFeatureInventory,
   fetchCodexMcpInventory,
   fetchCodexPluginInventory,
   fetchProviderDoctor,
-} from '@/hooks/useProviders'
+} from "@/hooks/useProviders";
 import type {
   CodexConfigResponse,
   CodexFeatureInventoryResponse,
   CodexMcpInventoryResponse,
   CodexPluginInventoryResponse,
   ProviderDoctorResponse,
-} from '@/types/providers'
-import { toast } from 'sonner'
+} from "@/types/providers";
+import { toast } from "sonner";
 
 export function ConfigViewerPage() {
-  const { activeProject } = useProjectContext()
-  const { selectedProviderId, selectedProvider } = useProviderContext()
-  const [data, setData] = useState<ConfigFileListResponse | null>(null)
-  const [codexConfig, setCodexConfig] = useState<CodexConfigResponse | null>(null)
-  const [codexDoctor, setCodexDoctor] = useState<ProviderDoctorResponse | null>(null)
-  const [codexDoctorError, setCodexDoctorError] = useState<string | null>(null)
-  const [codexFeatureInventory, setCodexFeatureInventory] = useState<CodexFeatureInventoryResponse | null>(null)
-  const [codexFeatureError, setCodexFeatureError] = useState<string | null>(null)
-  const [codexMcpInventory, setCodexMcpInventory] = useState<CodexMcpInventoryResponse | null>(null)
-  const [codexPluginInventory, setCodexPluginInventory] = useState<CodexPluginInventoryResponse | null>(null)
-  const [codexMcpError, setCodexMcpError] = useState<string | null>(null)
-  const [codexPluginError, setCodexPluginError] = useState<string | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [selectedFile, setSelectedFile] = useState<string | null>(null)
-  const [activeTab, setActiveTab] = useState<'editor' | 'scopes' | 'viewer'>('editor')
+  const { activeProject } = useProjectContext();
+  const activeProjectPath = activeProject?.path;
+  const { selectedProviderId, selectedProvider } = useProviderContext();
+  const location = useLocation();
+  const [data, setData] = useState<ConfigFileListResponse | null>(null);
+  const [codexConfig, setCodexConfig] = useState<CodexConfigResponse | null>(
+    null,
+  );
+  const [codexDoctor, setCodexDoctor] = useState<ProviderDoctorResponse | null>(
+    null,
+  );
+  const [codexDoctorError, setCodexDoctorError] = useState<string | null>(null);
+  const [codexFeatureInventory, setCodexFeatureInventory] =
+    useState<CodexFeatureInventoryResponse | null>(null);
+  const [codexFeatureError, setCodexFeatureError] = useState<string | null>(
+    null,
+  );
+  const [codexMcpInventory, setCodexMcpInventory] =
+    useState<CodexMcpInventoryResponse | null>(null);
+  const [codexPluginInventory, setCodexPluginInventory] =
+    useState<CodexPluginInventoryResponse | null>(null);
+  const [codexMcpError, setCodexMcpError] = useState<string | null>(null);
+  const [codexPluginError, setCodexPluginError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedFile, setSelectedFile] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<"editor" | "scopes" | "viewer">(
+    "editor",
+  );
+  const editorScrollRef = useRef<HTMLDivElement | null>(null);
 
   const fetchData = useCallback(async () => {
-    setLoading(true)
-    setError(null)
+    setLoading(true);
+    setError(null);
     try {
-      if (selectedProviderId === 'codex-cli') {
-        const filesPromise = apiClient<ConfigFileListResponse>('codex-config/files')
-        const configPromise = apiClient<CodexConfigResponse>('codex-config')
-        const doctorPromise = fetchProviderDoctor('codex-cli')
+      if (selectedProviderId === "codex-cli") {
+        const filesPromise =
+          apiClient<ConfigFileListResponse>("codex-config/files");
+        const configPromise = apiClient<CodexConfigResponse>("codex-config");
+        const doctorPromise = fetchProviderDoctor("codex-cli")
           .then((doctor) => ({ doctor, error: null }))
           .catch((err) => ({
             doctor: null,
-            error: err instanceof Error ? err.message : 'Failed to load Codex diagnostics',
-          }))
+            error:
+              err instanceof Error
+                ? err.message
+                : "Failed to load Codex diagnostics",
+          }));
         const featuresPromise = fetchCodexFeatureInventory()
           .then((inventory) => ({ inventory, error: null }))
           .catch((err) => ({
             inventory: null,
-            error: err instanceof Error ? err.message : 'Failed to load Codex feature inventory',
-          }))
+            error:
+              err instanceof Error
+                ? err.message
+                : "Failed to load Codex feature inventory",
+          }));
         const mcpPromise = fetchCodexMcpInventory()
           .then((inventory) => ({ inventory, error: null }))
           .catch((err) => ({
             inventory: null,
-            error: err instanceof Error ? err.message : 'Failed to load Codex MCP inventory',
-          }))
+            error:
+              err instanceof Error
+                ? err.message
+                : "Failed to load Codex MCP inventory",
+          }));
         const pluginsPromise = fetchCodexPluginInventory()
           .then((inventory) => ({ inventory, error: null }))
           .catch((err) => ({
             inventory: null,
-            error: err instanceof Error ? err.message : 'Failed to load Codex plugin inventory',
-          }))
+            error:
+              err instanceof Error
+                ? err.message
+                : "Failed to load Codex plugin inventory",
+          }));
 
-        const [files, config, doctorResult, featuresResult, mcpResult, pluginResult] = await Promise.all([
+        const [
+          files,
+          config,
+          doctorResult,
+          featuresResult,
+          mcpResult,
+          pluginResult,
+        ] = await Promise.all([
           filesPromise,
           configPromise,
           doctorPromise,
           featuresPromise,
           mcpPromise,
           pluginsPromise,
-        ])
-        setData(files)
-        setCodexConfig(config)
-        setCodexDoctor(doctorResult.doctor)
-        setCodexDoctorError(doctorResult.error)
-        setCodexFeatureInventory(featuresResult.inventory)
-        setCodexFeatureError(featuresResult.error)
-        setCodexMcpInventory(mcpResult.inventory)
-        setCodexMcpError(mcpResult.error)
-        setCodexPluginInventory(pluginResult.inventory)
-        setCodexPluginError(pluginResult.error)
-        if (activeTab === 'scopes') setActiveTab('editor')
+        ]);
+        setData(files);
+        setCodexConfig(config);
+        setCodexDoctor(doctorResult.doctor);
+        setCodexDoctorError(doctorResult.error);
+        setCodexFeatureInventory(featuresResult.inventory);
+        setCodexFeatureError(featuresResult.error);
+        setCodexMcpInventory(mcpResult.inventory);
+        setCodexMcpError(mcpResult.error);
+        setCodexPluginInventory(pluginResult.inventory);
+        setCodexPluginError(pluginResult.error);
+        if (activeTab === "scopes") setActiveTab("editor");
       } else {
-        const endpoint = buildEndpoint('config/files', { project_path: activeProject?.path })
-        const response = await apiClient<ConfigFileListResponse>(endpoint)
-        setData(response)
-        setCodexConfig(null)
-        setCodexDoctor(null)
-        setCodexDoctorError(null)
-        setCodexFeatureInventory(null)
-        setCodexFeatureError(null)
-        setCodexMcpInventory(null)
-        setCodexPluginInventory(null)
-        setCodexMcpError(null)
-        setCodexPluginError(null)
+        const endpoint = buildEndpoint("config/files", {
+          project_path: activeProjectPath,
+        });
+        const response = await apiClient<ConfigFileListResponse>(endpoint);
+        setData(response);
+        setCodexConfig(null);
+        setCodexDoctor(null);
+        setCodexDoctorError(null);
+        setCodexFeatureInventory(null);
+        setCodexFeatureError(null);
+        setCodexMcpInventory(null);
+        setCodexPluginInventory(null);
+        setCodexMcpError(null);
+        setCodexPluginError(null);
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to load config files'
-      setError(message)
-      toast.error(message)
+      const message =
+        err instanceof Error ? err.message : "Failed to load config files";
+      setError(message);
+      toast.error(message);
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }, [activeProject?.path, selectedProviderId, activeTab])
+  }, [activeProjectPath, selectedProviderId, activeTab]);
 
   useEffect(() => {
-    fetchData()
-  }, [fetchData])
+    fetchData();
+  }, [fetchData]);
 
   useEffect(() => {
-    setSelectedFile(null)
-  }, [selectedProviderId])
+    setSelectedFile(null);
+  }, [selectedProviderId]);
+
+  useEffect(() => {
+    if (
+      selectedProviderId !== "codex-cli" ||
+      location.hash !== "#codex-features" ||
+      loading
+    )
+      return;
+    if (activeTab !== "editor") {
+      setActiveTab("editor");
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      const target = document.getElementById("codex-features");
+      if (!target) return;
+
+      const scrollContainer = editorScrollRef.current;
+      if (scrollContainer) {
+        const containerRect = scrollContainer.getBoundingClientRect();
+        const targetRect = target.getBoundingClientRect();
+        scrollContainer.scrollTop += targetRect.top - containerRect.top - 16;
+        return;
+      }
+
+      target.scrollIntoView({ block: "start" });
+    }, 50);
+    return () => window.clearTimeout(timer);
+  }, [
+    selectedProviderId,
+    location.hash,
+    loading,
+    codexFeatureInventory,
+    activeTab,
+  ]);
 
   const handleOverrideInLocal = async (key: string, value: ConfigValue) => {
-    const parts = key.split('.')
-    const settings: Record<string, ConfigValue> = {}
-    let current: Record<string, ConfigValue> = settings
+    const parts = key.split(".");
+    const settings: Record<string, ConfigValue> = {};
+    let current: Record<string, ConfigValue> = settings;
     for (let i = 0; i < parts.length - 1; i++) {
-      const nested: Record<string, ConfigValue> = {}
-      current[parts[i]] = nested
-      current = nested
+      const nested: Record<string, ConfigValue> = {};
+      current[parts[i]] = nested;
+      current = nested;
     }
-    current[parts[parts.length - 1]] = value
+    current[parts[parts.length - 1]] = value;
 
     try {
-      await apiClient('config/settings', {
-        method: 'PUT',
+      await apiClient("config/settings", {
+        method: "PUT",
         body: JSON.stringify({
-          scope: 'local',
+          scope: "local",
           settings,
-          project_path: activeProject?.path
-        })
-      })
-      toast.success(`Setting "${key}" copied to local scope`)
-      fetchData()
+          project_path: activeProjectPath,
+        }),
+      });
+      toast.success(`Setting "${key}" copied to local scope`);
+      fetchData();
     } catch {
-      toast.error('Failed to copy setting to local scope')
+      toast.error("Failed to copy setting to local scope");
     }
-  }
+  };
 
   return (
     <div className="space-y-6 h-full flex flex-col">
@@ -166,19 +238,25 @@ export function ConfigViewerPage() {
             Configuration
           </h1>
           <p className="text-muted-foreground">
-            View {selectedProvider?.display_name ?? 'agent'} configuration
+            View {selectedProvider?.display_name ?? "agent"} configuration
           </p>
         </div>
         <RefreshButton onClick={fetchData} loading={loading} />
       </div>
 
-      <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as typeof activeTab)} className="flex-1 flex flex-col overflow-hidden">
+      <Tabs
+        value={activeTab}
+        onValueChange={(v) => setActiveTab(v as typeof activeTab)}
+        className="flex-1 flex flex-col overflow-hidden"
+      >
         <TabsList className="w-fit">
           <TabsTrigger value="editor" className="flex items-center gap-2">
             <Edit className="h-4 w-4" />
-            {selectedProviderId === 'codex-cli' ? 'Overview' : 'Settings Editor'}
+            {selectedProviderId === "codex-cli"
+              ? "Overview"
+              : "Settings Editor"}
           </TabsTrigger>
-          {selectedProviderId === 'claude-code' && (
+          {selectedProviderId === "claude-code" && (
             <TabsTrigger value="scopes" className="flex items-center gap-2">
               <Shield className="h-4 w-4" />
               Scope Resolver
@@ -190,13 +268,19 @@ export function ConfigViewerPage() {
           </TabsTrigger>
         </TabsList>
 
-        <TabsContent value="editor" className="flex-1 overflow-auto mt-4">
-          {selectedProviderId === 'codex-cli' ? (
+        <TabsContent
+          value="editor"
+          ref={editorScrollRef}
+          className="flex-1 overflow-auto mt-4"
+        >
+          {selectedProviderId === "codex-cli" ? (
             <div className="space-y-4">
               {!codexConfig?.exists && (
                 <Card>
                   <CardContent className="pt-6">
-                    <p className="text-sm text-muted-foreground">No ~/.codex/config.toml file found. Saving will create it.</p>
+                    <p className="text-sm text-muted-foreground">
+                      No ~/.codex/config.toml file found. Saving will create it.
+                    </p>
                   </CardContent>
                 </Card>
               )}
@@ -207,7 +291,9 @@ export function ConfigViewerPage() {
                 featureInventoryError={codexFeatureError}
                 onSaved={fetchData}
               />
-              <CodexProfileResolverCard resolution={codexConfig?.profile_resolution} />
+              <CodexProfileResolverCard
+                resolution={codexConfig?.profile_resolution}
+              />
               <CodexDiagnosticsCard
                 doctor={codexDoctor}
                 loading={loading}
@@ -229,7 +315,9 @@ export function ConfigViewerPage() {
         </TabsContent>
 
         <TabsContent value="scopes" className="flex-1 overflow-auto mt-4">
-          <ScopeResolver onOverride={activeProject ? handleOverrideInLocal : undefined} />
+          <ScopeResolver
+            onOverride={activeProject ? handleOverrideInLocal : undefined}
+          />
         </TabsContent>
 
         <TabsContent value="viewer" className="flex-1 overflow-hidden mt-4">
@@ -252,7 +340,9 @@ export function ConfigViewerPage() {
                 </CardHeader>
                 <CardContent>
                   {loading && !data && (
-                    <p className="text-sm text-muted-foreground">Loading files...</p>
+                    <p className="text-sm text-muted-foreground">
+                      Loading files...
+                    </p>
                   )}
                   {data && (
                     <ConfigFileList
@@ -268,12 +358,16 @@ export function ConfigViewerPage() {
             <div className="col-span-8 overflow-y-auto">
               <ConfigFileViewer
                 filePath={selectedFile}
-                rawEndpoint={selectedProviderId === 'codex-cli' ? 'codex-config/file' : 'config/raw'}
+                rawEndpoint={
+                  selectedProviderId === "codex-cli"
+                    ? "codex-config/file"
+                    : "config/raw"
+                }
               />
             </div>
           </div>
         </TabsContent>
       </Tabs>
     </div>
-  )
+  );
 }

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -1,24 +1,47 @@
-import { AlertCircle, Bot, CheckCircle2, LayoutDashboard, Terminal } from 'lucide-react'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-import { RefreshButton } from '@/components/shared/RefreshButton'
-import { useNavigate } from 'react-router-dom'
-import { Progress } from '@/components/ui/progress'
-import { Badge } from '@/components/ui/badge'
-import { useDashboard } from '@/contexts/DashboardContext'
-import { useProjectContext } from '@/contexts/ProjectContext'
-import { useProviderContext } from '@/contexts/ProviderContext'
-import { getRelativeTime } from '@/features/usage/utils'
+import {
+  AlertCircle,
+  Bot,
+  CheckCircle2,
+  LayoutDashboard,
+  Terminal,
+} from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { RefreshButton } from "@/components/shared/RefreshButton";
+import { useNavigate } from "react-router-dom";
+import { Progress } from "@/components/ui/progress";
+import { Badge } from "@/components/ui/badge";
+import { useDashboard } from "@/contexts/DashboardContext";
+import { useProjectContext } from "@/contexts/ProjectContext";
+import { useProviderContext } from "@/contexts/ProviderContext";
+import { getRelativeTime } from "@/features/usage/utils";
 
 export function DashboardPage() {
-  const { stats, loading, error, lastFetched, refreshDashboard } = useDashboard({ autoFetch: true })
-  const { projects } = useProjectContext()
-  const { providers, selectedProviderId, selectedProvider, setSelectedProviderId } = useProviderContext()
-  const navigate = useNavigate()
-  const installedProviderCount = providers.filter((provider) => provider.installed).length
-  const providerStats = stats?.providerId === selectedProviderId ? stats : null
-  const selectedProviderName = selectedProvider?.display_name ?? (selectedProviderId === 'codex-cli' ? 'Codex' : 'Claude Code')
-  const isCodex = selectedProviderId === 'codex-cli'
+  const { stats, loading, error, lastFetched, refreshDashboard } = useDashboard(
+    { autoFetch: true },
+  );
+  const { projects } = useProjectContext();
+  const {
+    providers,
+    selectedProviderId,
+    selectedProvider,
+    setSelectedProviderId,
+  } = useProviderContext();
+  const navigate = useNavigate();
+  const installedProviderCount = providers.filter(
+    (provider) => provider.installed,
+  ).length;
+  const providerStats = stats?.providerId === selectedProviderId ? stats : null;
+  const selectedProviderName =
+    selectedProvider?.display_name ??
+    (selectedProviderId === "codex-cli" ? "Codex" : "Claude Code");
+  const isCodex = selectedProviderId === "codex-cli";
 
   return (
     <div className="space-y-6">
@@ -71,7 +94,9 @@ export function DashboardPage() {
       {providerStats && providerStats.warnings.length > 0 && (
         <Card className="border-amber-500/60">
           <CardHeader className="pb-2">
-            <CardTitle className="text-amber-600 dark:text-amber-400">Partial {selectedProviderName} data</CardTitle>
+            <CardTitle className="text-amber-600 dark:text-amber-400">
+              Partial {selectedProviderName} data
+            </CardTitle>
             <CardDescription>
               Some provider-specific checks could not be loaded.
             </CardDescription>
@@ -111,37 +136,53 @@ export function DashboardPage() {
             <CardContent>
               <div className="grid gap-3 md:grid-cols-2">
                 {providers.map((provider) => {
-                  const isSelected = provider.id === selectedProviderId
+                  const isSelected = provider.id === selectedProviderId;
                   return (
                     <button
                       key={provider.id}
                       type="button"
                       onClick={() => setSelectedProviderId(provider.id)}
                       className={`rounded-md border p-4 text-left transition-colors hover:bg-accent ${
-                        isSelected ? 'border-primary bg-primary/5' : 'border-border'
+                        isSelected
+                          ? "border-primary bg-primary/5"
+                          : "border-border"
                       }`}
                     >
                       <div className="flex items-start justify-between gap-3">
                         <div className="min-w-0">
                           <div className="flex items-center gap-2">
                             <Terminal className="h-4 w-4 shrink-0" />
-                            <p className="font-medium">{provider.display_name}</p>
-                            {isSelected && <Badge variant="secondary">Selected</Badge>}
+                            <p className="font-medium">
+                              {provider.display_name}
+                            </p>
+                            {isSelected && (
+                              <Badge variant="secondary">Selected</Badge>
+                            )}
                           </div>
                           <p className="mt-1 text-xs text-muted-foreground">
-                            {provider.binary_path ?? provider.config_paths.home ?? 'Binary not found'}
+                            {provider.binary_path ??
+                              provider.config_paths.home ??
+                              "Binary not found"}
                           </p>
                         </div>
                         <Badge
-                          variant={provider.installed ? 'outline' : 'destructive'}
-                          className={provider.installed ? 'text-green-600 dark:text-green-400' : undefined}
+                          variant={
+                            provider.installed ? "outline" : "destructive"
+                          }
+                          className={
+                            provider.installed
+                              ? "text-green-600 dark:text-green-400"
+                              : undefined
+                          }
                         >
                           {provider.installed ? (
                             <CheckCircle2 className="mr-1 h-3 w-3" />
                           ) : (
                             <AlertCircle className="mr-1 h-3 w-3" />
                           )}
-                          {provider.installed ? provider.version ?? 'Installed' : 'Missing'}
+                          {provider.installed
+                            ? (provider.version ?? "Installed")
+                            : "Missing"}
                         </Badge>
                       </div>
                       <div className="mt-3 flex flex-wrap gap-1.5">
@@ -158,7 +199,7 @@ export function DashboardPage() {
                           ))}
                       </div>
                     </button>
-                  )
+                  );
                 })}
               </div>
             </CardContent>
@@ -168,7 +209,9 @@ export function DashboardPage() {
             <Card>
               <CardHeader className="pb-2">
                 <CardDescription>Codex Config</CardDescription>
-                <CardTitle className="text-3xl">{providerStats.settingsKeys}</CardTitle>
+                <CardTitle className="text-3xl">
+                  {providerStats.settingsKeys}
+                </CardTitle>
               </CardHeader>
               <CardContent>
                 <p className="text-xs text-muted-foreground">
@@ -177,7 +220,7 @@ export function DashboardPage() {
                 <Button
                   variant="link"
                   className="p-0 h-auto mt-2"
-                  onClick={() => navigate('/config')}
+                  onClick={() => navigate("/config")}
                 >
                   View Codex config →
                 </Button>
@@ -200,13 +243,24 @@ export function DashboardPage() {
           {/* Tier 2: Core Configuration */}
           <Card>
             <CardHeader className="pb-2">
-              <CardDescription>{selectedProviderName} MCP Servers</CardDescription>
-              <CardTitle className="text-3xl">{providerStats.mcpServerCount}</CardTitle>
+              <CardDescription>
+                {selectedProviderName} MCP Servers
+              </CardDescription>
+              <CardTitle className="text-3xl">
+                {providerStats.mcpServerCount}
+              </CardTitle>
             </CardHeader>
             <CardContent>
               <p className="text-xs text-muted-foreground">
                 Configured MCP servers
               </p>
+              <Button
+                variant="link"
+                className="p-0 h-auto mt-2"
+                onClick={() => navigate("/mcp")}
+              >
+                Manage MCP servers →
+              </Button>
             </CardContent>
           </Card>
 
@@ -214,7 +268,9 @@ export function DashboardPage() {
             <Card>
               <CardHeader className="pb-2">
                 <CardDescription>Claude Commands</CardDescription>
-                <CardTitle className="text-3xl">{providerStats.commandCount}</CardTitle>
+                <CardTitle className="text-3xl">
+                  {providerStats.commandCount}
+                </CardTitle>
               </CardHeader>
               <CardContent>
                 <p className="text-xs text-muted-foreground">
@@ -227,12 +283,23 @@ export function DashboardPage() {
           <Card>
             <CardHeader className="pb-2">
               <CardDescription>{selectedProviderName} Plugins</CardDescription>
-              <CardTitle className="text-3xl">{providerStats.pluginCount ?? 0}</CardTitle>
+              <CardTitle className="text-3xl">
+                {providerStats.pluginCount ?? 0}
+              </CardTitle>
             </CardHeader>
             <CardContent>
               <p className="text-xs text-muted-foreground">
-                Installed {selectedProviderName} plugins
+                {isCodex
+                  ? "Codex CLI plugin inventory rows"
+                  : `Installed ${selectedProviderName} plugins`}
               </p>
+              <Button
+                variant="link"
+                className="p-0 h-auto mt-2"
+                onClick={() => navigate("/plugins")}
+              >
+                {isCodex ? "Open Codex plugins →" : "View plugins →"}
+              </Button>
             </CardContent>
           </Card>
 
@@ -240,12 +307,21 @@ export function DashboardPage() {
             <Card>
               <CardHeader className="pb-2">
                 <CardDescription>Codex Feature Flags</CardDescription>
-                <CardTitle className="text-3xl">{providerStats.featureFlagCount ?? 0}</CardTitle>
+                <CardTitle className="text-3xl">
+                  {providerStats.featureFlagCount ?? 0}
+                </CardTitle>
               </CardHeader>
               <CardContent>
                 <p className="text-xs text-muted-foreground">
                   {providerStats.enabledFeatureFlagCount ?? 0} enabled
                 </p>
+                <Button
+                  variant="link"
+                  className="p-0 h-auto mt-2"
+                  onClick={() => navigate("/config#codex-features")}
+                >
+                  Manage feature flags →
+                </Button>
               </CardContent>
             </Card>
           )}
@@ -255,7 +331,9 @@ export function DashboardPage() {
               <Card>
                 <CardHeader className="pb-2">
                   <CardDescription>Claude Hooks</CardDescription>
-                  <CardTitle className="text-3xl">{providerStats.hookCount}</CardTitle>
+                  <CardTitle className="text-3xl">
+                    {providerStats.hookCount}
+                  </CardTitle>
                 </CardHeader>
                 <CardContent>
                   <p className="text-xs text-muted-foreground">
@@ -267,7 +345,9 @@ export function DashboardPage() {
               <Card>
                 <CardHeader className="pb-2">
                   <CardDescription>Claude Permissions</CardDescription>
-                  <CardTitle className="text-3xl">{providerStats.permissionCount}</CardTitle>
+                  <CardTitle className="text-3xl">
+                    {providerStats.permissionCount}
+                  </CardTitle>
                 </CardHeader>
                 <CardContent>
                   <p className="text-xs text-muted-foreground">
@@ -279,7 +359,9 @@ export function DashboardPage() {
               <Card>
                 <CardHeader className="pb-2">
                   <CardDescription>Claude Agents</CardDescription>
-                  <CardTitle className="text-3xl">{providerStats.agentCount}</CardTitle>
+                  <CardTitle className="text-3xl">
+                    {providerStats.agentCount}
+                  </CardTitle>
                 </CardHeader>
                 <CardContent>
                   <p className="text-xs text-muted-foreground">
@@ -291,7 +373,9 @@ export function DashboardPage() {
               <Card>
                 <CardHeader className="pb-2">
                   <CardDescription>Claude Skills</CardDescription>
-                  <CardTitle className="text-3xl">{providerStats.skillCount}</CardTitle>
+                  <CardTitle className="text-3xl">
+                    {providerStats.skillCount}
+                  </CardTitle>
                 </CardHeader>
                 <CardContent>
                   <p className="text-xs text-muted-foreground">
@@ -307,7 +391,9 @@ export function DashboardPage() {
             <Card>
               <CardHeader className="pb-2">
                 <CardDescription>Claude Output Styles</CardDescription>
-                <CardTitle className="text-3xl">{providerStats.outputStyleCount}</CardTitle>
+                <CardTitle className="text-3xl">
+                  {providerStats.outputStyleCount}
+                </CardTitle>
               </CardHeader>
               <CardContent>
                 <p className="text-xs text-muted-foreground">
@@ -321,12 +407,16 @@ export function DashboardPage() {
           <Card>
             <CardHeader className="pb-2">
               <CardDescription>
-                {providerStats.sessionMetricKind === 'live' ? `${selectedProviderName} Live Sessions` : 'Claude Session History'}
+                {providerStats.sessionMetricKind === "live"
+                  ? `${selectedProviderName} Live Sessions`
+                  : "Claude Session History"}
               </CardDescription>
-              <CardTitle className="text-3xl">{providerStats.sessionCount}</CardTitle>
+              <CardTitle className="text-3xl">
+                {providerStats.sessionCount}
+              </CardTitle>
             </CardHeader>
             <CardContent>
-              {providerStats.sessionMetricKind === 'live' ? (
+              {providerStats.sessionMetricKind === "live" ? (
                 <p className="text-xs text-muted-foreground">
                   Sessions currently visible through Agent Bridge
                 </p>
@@ -335,33 +425,47 @@ export function DashboardPage() {
                   <p>{providerStats.sessionsToday} today</p>
                   <p>{providerStats.sessionsThisWeek} this week</p>
                   {providerStats.mostActiveProject && (
-                    <p className="text-primary">Most active: {providerStats.mostActiveProject}</p>
+                    <p className="text-primary">
+                      Most active: {providerStats.mostActiveProject}
+                    </p>
                   )}
                 </div>
               )}
               <Button
                 variant="link"
                 className="p-0 h-auto mt-2"
-                onClick={() => navigate(providerStats.sessionMetricKind === 'live' ? '/agent-bridge' : '/sessions')}
+                onClick={() =>
+                  navigate(
+                    providerStats.sessionMetricKind === "live"
+                      ? "/agent-bridge"
+                      : "/sessions",
+                  )
+                }
               >
-                {providerStats.sessionMetricKind === 'live' ? 'View live sessions →' : 'View all sessions →'}
+                {providerStats.sessionMetricKind === "live"
+                  ? "View live sessions →"
+                  : "View all sessions →"}
               </Button>
             </CardContent>
           </Card>
 
           <Card>
             <CardHeader className="pb-2">
-              <CardDescription>{isCodex ? 'Plan Snapshots' : 'Plans'}</CardDescription>
-              <CardTitle className="text-3xl">{providerStats.planCount}</CardTitle>
+              <CardDescription>
+                {isCodex ? "Plan Snapshots" : "Plans"}
+              </CardDescription>
+              <CardTitle className="text-3xl">
+                {providerStats.planCount}
+              </CardTitle>
             </CardHeader>
             <CardContent>
               <p className="text-xs text-muted-foreground">
-                {isCodex ? 'Codex update_plan snapshots' : 'Execution plans'}
+                {isCodex ? "Codex update_plan snapshots" : "Execution plans"}
               </p>
               <Button
                 variant="link"
                 className="p-0 h-auto mt-2"
-                onClick={() => navigate('/plans')}
+                onClick={() => navigate("/plans")}
               >
                 View all plans →
               </Button>
@@ -373,35 +477,44 @@ export function DashboardPage() {
               <CardHeader className="pb-2">
                 <CardDescription>Claude Context Window</CardDescription>
                 <CardTitle className="text-3xl">
-                  {providerStats.contextActiveCount && providerStats.contextActiveCount > 0
+                  {providerStats.contextActiveCount &&
+                  providerStats.contextActiveCount > 0
                     ? `${(providerStats.contextHighestPct ?? 0).toFixed(0)}%`
-                    : '--'}
+                    : "--"}
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                {providerStats.contextActiveCount && providerStats.contextActiveCount > 0 ? (
+                {providerStats.contextActiveCount &&
+                providerStats.contextActiveCount > 0 ? (
                   <div className="space-y-2">
                     <Progress
                       value={providerStats.contextHighestPct ?? 0}
                       className={`h-2 ${
-                        (providerStats.contextHighestPct ?? 0) >= 95 ? '[&>div]:bg-red-500' :
-                        (providerStats.contextHighestPct ?? 0) >= 80 ? '[&>div]:bg-orange-500' :
-                        (providerStats.contextHighestPct ?? 0) >= 50 ? '[&>div]:bg-yellow-500' :
-                        '[&>div]:bg-green-500'
+                        (providerStats.contextHighestPct ?? 0) >= 95
+                          ? "[&>div]:bg-red-500"
+                          : (providerStats.contextHighestPct ?? 0) >= 80
+                            ? "[&>div]:bg-orange-500"
+                            : (providerStats.contextHighestPct ?? 0) >= 50
+                              ? "[&>div]:bg-yellow-500"
+                              : "[&>div]:bg-green-500"
                       }`}
                     />
                     <p className="text-xs text-muted-foreground">
-                      {providerStats.contextActiveCount} active session{providerStats.contextActiveCount !== 1 ? 's' : ''}
-                      {providerStats.contextHighestProject && ` - ${providerStats.contextHighestProject}`}
+                      {providerStats.contextActiveCount} active session
+                      {providerStats.contextActiveCount !== 1 ? "s" : ""}
+                      {providerStats.contextHighestProject &&
+                        ` - ${providerStats.contextHighestProject}`}
                     </p>
                   </div>
                 ) : (
-                  <p className="text-xs text-muted-foreground">No active sessions</p>
+                  <p className="text-xs text-muted-foreground">
+                    No active sessions
+                  </p>
                 )}
                 <Button
                   variant="link"
                   className="p-0 h-auto mt-2"
-                  onClick={() => navigate('/context')}
+                  onClick={() => navigate("/context")}
                 >
                   View context →
                 </Button>
@@ -413,7 +526,9 @@ export function DashboardPage() {
             <Card>
               <CardHeader className="pb-2">
                 <CardDescription>Not shown for Codex</CardDescription>
-                <CardTitle className="text-base">Claude Code-only surfaces</CardTitle>
+                <CardTitle className="text-base">
+                  Claude Code-only surfaces
+                </CardTitle>
               </CardHeader>
               <CardContent>
                 <div className="flex flex-wrap gap-1.5">
@@ -424,7 +539,8 @@ export function DashboardPage() {
                   ))}
                 </div>
                 <p className="mt-3 text-xs text-muted-foreground">
-                  These cards are hidden because Codex does not expose equivalent data through Claude Deck yet.
+                  These cards are hidden because Codex does not expose
+                  equivalent data through Claude Deck yet.
                 </p>
               </CardContent>
             </Card>
@@ -436,7 +552,9 @@ export function DashboardPage() {
         <Card>
           <CardHeader>
             <CardTitle>Quick Status</CardTitle>
-            <CardDescription>{selectedProviderName} configuration health indicators</CardDescription>
+            <CardDescription>
+              {selectedProviderName} configuration health indicators
+            </CardDescription>
           </CardHeader>
           <CardContent>
             {isCodex ? (
@@ -492,5 +610,5 @@ export function DashboardPage() {
         </Card>
       )}
     </div>
-  )
+  );
 }

--- a/frontend/src/features/mcp/MCPServersPage.tsx
+++ b/frontend/src/features/mcp/MCPServersPage.tsx
@@ -1,6 +1,12 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { Plus, Server, Shield, Info, PlayCircle } from "lucide-react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
@@ -40,6 +46,7 @@ import { MCPServerForm } from "./MCPServerForm";
 import { MCPServerDetailDialog } from "./MCPServerDetailDialog";
 import { MCPRegistryBrowser } from "./MCPRegistryBrowser";
 import { RefreshButton } from "@/components/shared/RefreshButton";
+import { CodexInventoryCard } from "@/features/config/CodexInventoryCard";
 import type {
   MCPServer,
   MCPServerCreate,
@@ -50,17 +57,84 @@ import type {
 } from "@/types/mcp";
 import { apiClient, buildEndpoint } from "@/lib/api";
 import { useProjectContext } from "@/contexts/ProjectContext";
+import { useProviderContext } from "@/contexts/ProviderContext";
+import { fetchCodexMcpInventory } from "@/hooks/useProviders";
+import type { CodexMcpInventoryResponse } from "@/types/providers";
 import { toast } from "sonner";
 
 export function MCPServersPage() {
+  const { selectedProviderId } = useProviderContext();
+  if (selectedProviderId === "codex-cli") return <CodexMCPServersPage />;
+  return <ClaudeMCPServersPage />;
+}
+
+function CodexMCPServersPage() {
+  const [inventory, setInventory] = useState<CodexMcpInventoryResponse | null>(
+    null,
+  );
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchInventory = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setInventory(await fetchCodexMcpInventory());
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to load Codex MCP servers";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchInventory();
+  }, [fetchInventory]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold flex items-center gap-2">
+            <Server className="h-8 w-8" />
+            Codex MCP Servers
+          </h1>
+          <p className="text-muted-foreground mt-1">
+            Manage MCP servers through the Codex CLI command surface
+          </p>
+        </div>
+        <RefreshButton onClick={fetchInventory} loading={loading} />
+      </div>
+
+      <CodexInventoryCard
+        mcp={inventory}
+        plugins={null}
+        mcpError={error}
+        pluginError={null}
+        loading={loading}
+        onRefresh={fetchInventory}
+        sections={["mcp"]}
+        title="Codex MCP Inventory"
+        description="List, add, and remove MCP servers using codex mcp. Claude Code approval settings and registry installs are not part of the Codex CLI MCP surface."
+      />
+    </div>
+  );
+}
+
+function ClaudeMCPServersPage() {
   const { activeProject } = useProjectContext();
+  const activeProjectPath = activeProject?.path;
   const [servers, setServers] = useState<MCPServer[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showWizard, setShowWizard] = useState(false);
   const [editingServer, setEditingServer] = useState<MCPServer | null>(null);
   const [approvalSettingsOpen, setApprovalSettingsOpen] = useState(false);
-  const [approvalSettings, setApprovalSettings] = useState<MCPServerApprovalSettings | null>(null);
+  const [approvalSettings, setApprovalSettings] =
+    useState<MCPServerApprovalSettings | null>(null);
 
   // Detail dialog state
   const [detailServer, setDetailServer] = useState<MCPServer | null>(null);
@@ -74,8 +148,8 @@ export function MCPServersPage() {
   const [showTestAllConfirm, setShowTestAllConfirm] = useState(false);
 
   // Separate managed servers from editable ones
-  const managedServers = servers.filter(s => s.scope === "managed");
-  const editableServers = servers.filter(s => s.scope !== "managed");
+  const managedServers = servers.filter((s) => s.scope === "managed");
+  const editableServers = servers.filter((s) => s.scope !== "managed");
 
   // Build approval overrides lookup map
   const approvalOverrides = useMemo(() => {
@@ -91,21 +165,26 @@ export function MCPServersPage() {
     setLoading(true);
     setError(null);
     try {
-      const endpoint = buildEndpoint("mcp/servers", { project_path: activeProject?.path });
+      const endpoint = buildEndpoint("mcp/servers", {
+        project_path: activeProjectPath,
+      });
       const response = await apiClient<MCPServerListResponse>(endpoint);
       setServers(response.servers);
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to load MCP servers";
+      const message =
+        err instanceof Error ? err.message : "Failed to load MCP servers";
       setError(message);
       toast.error(message);
     } finally {
       setLoading(false);
     }
-  }, [activeProject?.path]);
+  }, [activeProjectPath]);
 
   const fetchApprovalSettings = useCallback(async () => {
     try {
-      const response = await apiClient<MCPServerApprovalSettings>("mcp/approval-settings");
+      const response = await apiClient<MCPServerApprovalSettings>(
+        "mcp/approval-settings",
+      );
       setApprovalSettings(response);
     } catch {
       // Silently fail - approval settings are optional
@@ -119,13 +198,16 @@ export function MCPServersPage() {
 
   const handleApprovalSettingsChange = async (defaultMode: string) => {
     try {
-      const updated = await apiClient<MCPServerApprovalSettings>("mcp/approval-settings", {
-        method: "PUT",
-        body: JSON.stringify({
-          default_mode: defaultMode,
-          server_overrides: approvalSettings?.server_overrides || [],
-        }),
-      });
+      const updated = await apiClient<MCPServerApprovalSettings>(
+        "mcp/approval-settings",
+        {
+          method: "PUT",
+          body: JSON.stringify({
+            default_mode: defaultMode,
+            server_overrides: approvalSettings?.server_overrides || [],
+          }),
+        },
+      );
       setApprovalSettings(updated);
       toast.success("Approval settings updated");
     } catch {
@@ -133,24 +215,33 @@ export function MCPServersPage() {
     }
   };
 
-  const handleServerApprovalChange = async (serverName: string, mode: string | null) => {
+  const handleServerApprovalChange = async (
+    serverName: string,
+    mode: string | null,
+  ) => {
     if (!approvalSettings) return;
     try {
       // Build new overrides: remove existing entry for this server, add new one if mode is not null
       const newOverrides = approvalSettings.server_overrides.filter(
-        o => o.server_name !== serverName
+        (o) => o.server_name !== serverName,
       );
       if (mode) {
-        newOverrides.push({ server_name: serverName, mode: mode as MCPServerApprovalSettings["default_mode"] });
+        newOverrides.push({
+          server_name: serverName,
+          mode: mode as MCPServerApprovalSettings["default_mode"],
+        });
       }
 
-      const updated = await apiClient<MCPServerApprovalSettings>("mcp/approval-settings", {
-        method: "PUT",
-        body: JSON.stringify({
-          default_mode: approvalSettings.default_mode,
-          server_overrides: newOverrides,
-        }),
-      });
+      const updated = await apiClient<MCPServerApprovalSettings>(
+        "mcp/approval-settings",
+        {
+          method: "PUT",
+          body: JSON.stringify({
+            default_mode: approvalSettings.default_mode,
+            server_overrides: newOverrides,
+          }),
+        },
+      );
       setApprovalSettings(updated);
       toast.success("Server approval override updated");
     } catch {
@@ -160,7 +251,9 @@ export function MCPServersPage() {
 
   const handleAddServer = async (server: MCPServerCreate) => {
     try {
-      const endpoint = buildEndpoint("mcp/servers", { project_path: activeProject?.path });
+      const endpoint = buildEndpoint("mcp/servers", {
+        project_path: activeProjectPath,
+      });
       await apiClient<MCPServer>(endpoint, {
         method: "POST",
         body: JSON.stringify(server),
@@ -170,17 +263,22 @@ export function MCPServersPage() {
       setShowWizard(false);
       await fetchServers();
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to add server";
+      const message =
+        err instanceof Error ? err.message : "Failed to add server";
       toast.error(message);
       throw err;
     }
   };
 
-  const handleUpdateServer = async (name: string, scope: string, updates: MCPServerUpdate) => {
+  const handleUpdateServer = async (
+    name: string,
+    scope: string,
+    updates: MCPServerUpdate,
+  ) => {
     try {
       const endpoint = buildEndpoint(`mcp/servers/${name}`, {
         scope,
-        project_path: activeProject?.path,
+        project_path: activeProjectPath,
       });
       await apiClient<MCPServer>(endpoint, {
         method: "PUT",
@@ -191,7 +289,8 @@ export function MCPServersPage() {
       setEditingServer(null);
       await fetchServers();
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to update server";
+      const message =
+        err instanceof Error ? err.message : "Failed to update server";
       toast.error(message);
       throw err;
     }
@@ -201,7 +300,7 @@ export function MCPServersPage() {
     try {
       const endpoint = buildEndpoint(`mcp/servers/${name}`, {
         scope,
-        project_path: activeProject?.path,
+        project_path: activeProjectPath,
       });
       await apiClient(endpoint, {
         method: "DELETE",
@@ -210,24 +309,25 @@ export function MCPServersPage() {
       toast.success(`MCP server "${name}" removed successfully`);
       await fetchServers();
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to remove server";
+      const message =
+        err instanceof Error ? err.message : "Failed to remove server";
       toast.error(message);
     }
   };
 
   const handleToggle = async (server: MCPServer, enabled: boolean) => {
     try {
-      await apiClient(
-        `mcp/servers/${encodeURIComponent(server.name)}/toggle`,
-        {
-          method: "POST",
-          body: JSON.stringify({ disabled: !enabled }),
-        }
+      await apiClient(`mcp/servers/${encodeURIComponent(server.name)}/toggle`, {
+        method: "POST",
+        body: JSON.stringify({ disabled: !enabled }),
+      });
+      toast.success(
+        `Server "${server.name}" ${enabled ? "enabled" : "disabled"}`,
       );
-      toast.success(`Server "${server.name}" ${enabled ? "enabled" : "disabled"}`);
       await fetchServers();
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to toggle server";
+      const message =
+        err instanceof Error ? err.message : "Failed to toggle server";
       toast.error(message);
     }
   };
@@ -241,14 +341,19 @@ export function MCPServersPage() {
     setShowTestAllConfirm(false);
     setTestingAll(true);
     try {
-      const endpoint = buildEndpoint("mcp/servers/test-all", { project_path: activeProject?.path });
-      const response = await apiClient<MCPTestAllResponse>(endpoint, { method: "POST" });
-      const connected = response.results.filter(r => r.success).length;
-      const failed = response.results.filter(r => !r.success).length;
+      const endpoint = buildEndpoint("mcp/servers/test-all", {
+        project_path: activeProjectPath,
+      });
+      const response = await apiClient<MCPTestAllResponse>(endpoint, {
+        method: "POST",
+      });
+      const connected = response.results.filter((r) => r.success).length;
+      const failed = response.results.filter((r) => !r.success).length;
       toast.success(`${connected} connected, ${failed} failed`);
       await fetchServers();
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to test servers";
+      const message =
+        err instanceof Error ? err.message : "Failed to test servers";
       toast.error(message);
     } finally {
       setTestingAll(false);
@@ -323,12 +428,16 @@ export function MCPServersPage() {
                 <div className="flex items-center gap-2">
                   <Shield className="h-5 w-5 text-amber-600" />
                   <CardTitle className="text-lg">Managed Servers</CardTitle>
-                  <Badge variant="outline" className="text-amber-600 border-amber-600">
+                  <Badge
+                    variant="outline"
+                    className="text-amber-600 border-amber-600"
+                  >
                     Enterprise
                   </Badge>
                 </div>
                 <CardDescription>
-                  These servers are configured by your organization and cannot be modified.
+                  These servers are configured by your organization and cannot
+                  be modified.
                 </CardDescription>
               </CardHeader>
               <CardContent>
@@ -348,18 +457,26 @@ export function MCPServersPage() {
           )}
 
           {/* Approval Settings Panel */}
-          <Collapsible open={approvalSettingsOpen} onOpenChange={setApprovalSettingsOpen}>
+          <Collapsible
+            open={approvalSettingsOpen}
+            onOpenChange={setApprovalSettingsOpen}
+          >
             <Card>
               <CollapsibleTrigger asChild>
                 <CardHeader className="cursor-pointer hover:bg-muted/50 transition-colors">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
                       <Info className="h-5 w-5" />
-                      <CardTitle className="text-lg">Server Approval Settings</CardTitle>
+                      <CardTitle className="text-lg">
+                        Server Approval Settings
+                      </CardTitle>
                     </div>
                     <Badge variant="outline">
-                      {approvalSettings?.default_mode === "always-allow" ? "Auto-approve" :
-                       approvalSettings?.default_mode === "always-deny" ? "Always deny" : "Ask each time"}
+                      {approvalSettings?.default_mode === "always-allow"
+                        ? "Auto-approve"
+                        : approvalSettings?.default_mode === "always-deny"
+                          ? "Always deny"
+                          : "Ask each time"}
                     </Badge>
                   </div>
                   <CardDescription>
@@ -371,23 +488,34 @@ export function MCPServersPage() {
                 <CardContent className="pt-0">
                   <div className="space-y-4">
                     <div>
-                      <Label htmlFor="default-approval">Default Approval Mode</Label>
+                      <Label htmlFor="default-approval">
+                        Default Approval Mode
+                      </Label>
                       <Select
-                        value={approvalSettings?.default_mode || "ask-every-time"}
+                        value={
+                          approvalSettings?.default_mode || "ask-every-time"
+                        }
                         onValueChange={handleApprovalSettingsChange}
                       >
                         <SelectTrigger id="default-approval" className="mt-2">
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="ask-every-time">Ask every time</SelectItem>
-                          <SelectItem value="always-allow">Always allow (trust all servers)</SelectItem>
-                          <SelectItem value="always-deny">Always deny</SelectItem>
+                          <SelectItem value="ask-every-time">
+                            Ask every time
+                          </SelectItem>
+                          <SelectItem value="always-allow">
+                            Always allow (trust all servers)
+                          </SelectItem>
+                          <SelectItem value="always-deny">
+                            Always deny
+                          </SelectItem>
                         </SelectContent>
                       </Select>
                       <p className="text-xs text-muted-foreground mt-2">
-                        This controls whether Claude Code asks for permission before using MCP tools.
-                        Per-server overrides can be set in each server's detail view.
+                        This controls whether Claude Code asks for permission
+                        before using MCP tools. Per-server overrides can be set
+                        in each server's detail view.
                       </p>
                     </div>
                   </div>
@@ -434,17 +562,24 @@ export function MCPServersPage() {
         onTestComplete={fetchServers}
         approvalSettings={approvalSettings}
         onApprovalChange={handleServerApprovalChange}
-        readOnly={detailServer?.scope === "plugin" || detailServer?.scope === "managed"}
+        readOnly={
+          detailServer?.scope === "plugin" || detailServer?.scope === "managed"
+        }
       />
 
       {/* Test All Confirmation Dialog */}
-      <AlertDialog open={showTestAllConfirm} onOpenChange={setShowTestAllConfirm}>
+      <AlertDialog
+        open={showTestAllConfirm}
+        onOpenChange={setShowTestAllConfirm}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Test All Servers?</AlertDialogTitle>
             <AlertDialogDescription>
-              This will test {serverCount} {serverCount === 1 ? "server" : "servers"} sequentially.
-              Estimated time: ~{estimatedTime}s. Each test spawns a subprocess and may take up to 30s for npx-based servers.
+              This will test {serverCount}{" "}
+              {serverCount === 1 ? "server" : "servers"} sequentially. Estimated
+              time: ~{estimatedTime}s. Each test spawns a subprocess and may
+              take up to 30s for npx-based servers.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -473,7 +608,10 @@ export function MCPServersPage() {
       </Dialog>
 
       {/* Edit Server Dialog */}
-      <Dialog open={!!editingServer} onOpenChange={(open) => !open && setEditingServer(null)}>
+      <Dialog
+        open={!!editingServer}
+        onOpenChange={(open) => !open && setEditingServer(null)}
+      >
         <DialogContent className="max-w-2xl">
           <DialogHeader>
             <DialogTitle>Edit MCP Server</DialogTitle>

--- a/frontend/src/features/plugins/PluginsPage.tsx
+++ b/frontend/src/features/plugins/PluginsPage.tsx
@@ -9,19 +9,97 @@ import type {
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { RefreshCw, Package, Store, Settings, Globe, ArrowUpCircle } from "lucide-react";
+import {
+  RefreshCw,
+  Package,
+  Store,
+  Settings,
+  Globe,
+  ArrowUpCircle,
+} from "lucide-react";
 import { InstalledPlugins } from "./InstalledPlugins";
 import { PluginDetails } from "./PluginDetails";
 import { MarketplaceBrowser } from "./MarketplaceBrowser";
 import { PluginInstallWizard } from "./PluginInstallWizard";
 import { MarketplaceManager } from "./MarketplaceManager";
 import { AllAvailablePlugins } from "./AllAvailablePlugins";
+import { CodexInventoryCard } from "@/features/config/CodexInventoryCard";
 import { apiClient, buildEndpoint } from "@/lib/api";
 import { useProjectContext } from "@/contexts/ProjectContext";
+import { useProviderContext } from "@/contexts/ProviderContext";
+import { fetchCodexPluginInventory } from "@/hooks/useProviders";
+import type { CodexPluginInventoryResponse } from "@/types/providers";
 import { toast } from "sonner";
 
 export function PluginsPage() {
+  const { selectedProviderId } = useProviderContext();
+  if (selectedProviderId === "codex-cli") return <CodexPluginsPage />;
+  return <ClaudePluginsPage />;
+}
+
+function CodexPluginsPage() {
+  const [inventory, setInventory] =
+    useState<CodexPluginInventoryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchInventory = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setInventory(await fetchCodexPluginInventory());
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to load Codex plugins";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchInventory();
+  }, [fetchInventory]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold flex items-center gap-2">
+            <Package className="h-8 w-8" />
+            Codex Plugins
+          </h1>
+          <p className="text-muted-foreground mt-2">
+            View Codex plugin inventory and use supported install/remove actions
+          </p>
+        </div>
+        <Button onClick={fetchInventory} variant="outline" disabled={loading}>
+          <RefreshCw
+            className={`h-4 w-4 mr-2 ${loading ? "animate-spin" : ""}`}
+          />
+          Refresh
+        </Button>
+      </div>
+
+      <CodexInventoryCard
+        mcp={null}
+        plugins={inventory}
+        mcpError={null}
+        pluginError={error}
+        loading={loading}
+        onRefresh={fetchInventory}
+        sections={["plugins"]}
+        title="Codex Plugin Inventory"
+        description="Codex CLI reports installed and available plugin rows together. Enable/disable actions are shown as unsupported when the installed CLI does not expose them."
+      />
+    </div>
+  );
+}
+
+function ClaudePluginsPage() {
   const { activeProject } = useProjectContext();
+  const activeProjectPath = activeProject?.path;
   const [activeTab, setActiveTab] = useState<PluginTab>("installed");
   const [plugins, setPlugins] = useState<Plugin[]>([]);
   const [marketplaces, setMarketplaces] = useState<MarketplaceResponse[]>([]);
@@ -29,7 +107,9 @@ export function PluginsPage() {
   const [error, setError] = useState<string | null>(null);
 
   // Update tracking
-  const [updateInfo, setUpdateInfo] = useState<Map<string, PluginUpdateInfo>>(new Map());
+  const [updateInfo, setUpdateInfo] = useState<Map<string, PluginUpdateInfo>>(
+    new Map(),
+  );
   const [checkingUpdates, setCheckingUpdates] = useState(false);
 
   // Search state (shared across tabs)
@@ -40,8 +120,11 @@ export function PluginsPage() {
   const [detailsOpen, setDetailsOpen] = useState(false);
 
   // Install wizard
-  const [pluginToInstall, setPluginToInstall] = useState<MarketplacePlugin | null>(null);
-  const [installMarketplaceName, setInstallMarketplaceName] = useState<string | null>(null);
+  const [pluginToInstall, setPluginToInstall] =
+    useState<MarketplacePlugin | null>(null);
+  const [installMarketplaceName, setInstallMarketplaceName] = useState<
+    string | null
+  >(null);
   const [installWizardOpen, setInstallWizardOpen] = useState(false);
 
   // Show marketplace manager
@@ -58,23 +141,29 @@ export function PluginsPage() {
 
   const fetchPlugins = useCallback(async () => {
     try {
-      const endpoint = buildEndpoint("plugins", { project_path: activeProject?.path });
+      const endpoint = buildEndpoint("plugins", {
+        project_path: activeProjectPath,
+      });
       const data = await apiClient<{ plugins: Plugin[] }>(endpoint);
       setPlugins(data.plugins || []);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load plugins");
     }
-  }, [activeProject?.path]);
+  }, [activeProjectPath]);
 
   const fetchMarketplaces = useCallback(async () => {
     try {
-      const endpoint = buildEndpoint("plugins/marketplaces", { project_path: activeProject?.path });
-      const data = await apiClient<{ marketplaces: MarketplaceResponse[] }>(endpoint);
+      const endpoint = buildEndpoint("plugins/marketplaces", {
+        project_path: activeProjectPath,
+      });
+      const data = await apiClient<{ marketplaces: MarketplaceResponse[] }>(
+        endpoint,
+      );
       setMarketplaces(data.marketplaces || []);
     } catch (err) {
       console.error("Failed to load marketplaces:", err);
     }
-  }, [activeProject?.path]);
+  }, [activeProjectPath]);
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -90,9 +179,10 @@ export function PluginsPage() {
   const handleCheckUpdates = useCallback(async () => {
     setCheckingUpdates(true);
     try {
-      const data = await apiClient<{ plugins: PluginUpdateInfo[]; outdated_count: number }>(
-        "plugins/updates"
-      );
+      const data = await apiClient<{
+        plugins: PluginUpdateInfo[];
+        outdated_count: number;
+      }>("plugins/updates");
       const newUpdateInfo = new Map<string, PluginUpdateInfo>();
       data.plugins.forEach((info) => {
         newUpdateInfo.set(info.name, info);
@@ -110,28 +200,31 @@ export function PluginsPage() {
     }
   }, []);
 
-  const handleUpdatePlugin = useCallback(async (name: string) => {
-    try {
-      const data = await apiClient<{ success: boolean; message: string }>(
-        `/api/v1/plugins/${name}/update`,
-        { method: "POST" }
-      );
-      if (data.success) {
-        toast.success(`Plugin "${name}" updated successfully`);
-        // Refresh plugins and clear update info for this plugin
-        fetchPlugins();
-        setUpdateInfo((prev) => {
-          const newMap = new Map(prev);
-          newMap.delete(name);
-          return newMap;
-        });
-      } else {
-        toast.error(data.message);
+  const handleUpdatePlugin = useCallback(
+    async (name: string) => {
+      try {
+        const data = await apiClient<{ success: boolean; message: string }>(
+          `/api/v1/plugins/${name}/update`,
+          { method: "POST" },
+        );
+        if (data.success) {
+          toast.success(`Plugin "${name}" updated successfully`);
+          // Refresh plugins and clear update info for this plugin
+          fetchPlugins();
+          setUpdateInfo((prev) => {
+            const newMap = new Map(prev);
+            newMap.delete(name);
+            return newMap;
+          });
+        } else {
+          toast.error(data.message);
+        }
+      } catch {
+        toast.error(`Failed to update plugin "${name}"`);
       }
-    } catch {
-      toast.error(`Failed to update plugin "${name}"`);
-    }
-  }, [fetchPlugins]);
+    },
+    [fetchPlugins],
+  );
 
   const handleUpdateAll = useCallback(async () => {
     try {
@@ -140,15 +233,15 @@ export function PluginsPage() {
         message: string;
         updated_count: number;
         failed_count: number;
-}>("plugins/update-all", { method: "POST" });
-      
+      }>("plugins/update-all", { method: "POST" });
+
       if (data.updated_count > 0) {
         toast.success(`Updated ${data.updated_count} plugin(s)`);
       }
       if (data.failed_count > 0) {
         toast.error(`${data.failed_count} plugin(s) failed to update`);
       }
-      
+
       // Refresh plugins and clear update info
       fetchPlugins();
       setUpdateInfo(new Map());
@@ -160,7 +253,11 @@ export function PluginsPage() {
   const handleEnableAll = useCallback(async () => {
     let successCount = 0;
     for (const plugin of plugins) {
-      if (plugin.enabled === false && plugin.source !== "local" && plugin.source !== "local-project") {
+      if (
+        plugin.enabled === false &&
+        plugin.source !== "local" &&
+        plugin.source !== "local-project"
+      ) {
         try {
           await apiClient(`/api/v1/plugins/${plugin.name}/toggle`, {
             method: "POST",
@@ -181,7 +278,11 @@ export function PluginsPage() {
   const handleDisableAll = useCallback(async () => {
     let successCount = 0;
     for (const plugin of plugins) {
-      if (plugin.enabled !== false && plugin.source !== "local" && plugin.source !== "local-project") {
+      if (
+        plugin.enabled !== false &&
+        plugin.source !== "local" &&
+        plugin.source !== "local-project"
+      ) {
         try {
           await apiClient(`/api/v1/plugins/${plugin.name}/toggle`, {
             method: "POST",
@@ -206,17 +307,24 @@ export function PluginsPage() {
 
   const handleUninstall = async (name: string) => {
     try {
-      const endpoint = buildEndpoint(`plugins/${name}`, { project_path: activeProject?.path });
+      const endpoint = buildEndpoint(`plugins/${name}`, {
+        project_path: activeProjectPath,
+      });
       await apiClient(endpoint, { method: "DELETE" });
 
       toast.success(`Plugin "${name}" uninstalled successfully`);
       fetchPlugins();
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to uninstall plugin");
+      toast.error(
+        error instanceof Error ? error.message : "Failed to uninstall plugin",
+      );
     }
   };
 
-  const handleInstall = (plugin: MarketplacePlugin, marketplaceName: string) => {
+  const handleInstall = (
+    plugin: MarketplacePlugin,
+    marketplaceName: string,
+  ) => {
     setPluginToInstall(plugin);
     setInstallMarketplaceName(marketplaceName);
     setInstallWizardOpen(true);
@@ -228,7 +336,9 @@ export function PluginsPage() {
 
   const handleToggle = async (plugin: Plugin, enabled: boolean) => {
     try {
-      const endpoint = buildEndpoint(`plugins/${plugin.name}/toggle`, { project_path: activeProject?.path });
+      const endpoint = buildEndpoint(`plugins/${plugin.name}/toggle`, {
+        project_path: activeProjectPath,
+      });
       const data = await apiClient<{ message: string }>(endpoint, {
         method: "POST",
         body: JSON.stringify({
@@ -240,7 +350,9 @@ export function PluginsPage() {
       toast.success(data.message);
       fetchPlugins();
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to toggle plugin");
+      toast.error(
+        error instanceof Error ? error.message : "Failed to toggle plugin",
+      );
     }
   };
 
@@ -258,7 +370,11 @@ export function PluginsPage() {
           </p>
         </div>
         {updatesCount > 0 && (
-          <Button variant="default" onClick={handleUpdateAll} className="bg-orange-500 hover:bg-orange-600">
+          <Button
+            variant="default"
+            onClick={handleUpdateAll}
+            className="bg-orange-500 hover:bg-orange-600"
+          >
             <ArrowUpCircle className="h-4 w-4 mr-2" />
             Update All ({updatesCount})
           </Button>
@@ -277,7 +393,9 @@ export function PluginsPage() {
       {/* Actions */}
       <div className="flex gap-2">
         <Button onClick={fetchData} variant="outline" disabled={loading}>
-          <RefreshCw className={`h-4 w-4 mr-2 ${loading ? "animate-spin" : ""}`} />
+          <RefreshCw
+            className={`h-4 w-4 mr-2 ${loading ? "animate-spin" : ""}`}
+          />
           Refresh
         </Button>
         <Button
@@ -291,11 +409,17 @@ export function PluginsPage() {
 
       {/* Marketplace Manager */}
       {showMarketplaceManager && (
-        <MarketplaceManager marketplaces={marketplaces} onRefresh={fetchMarketplaces} />
+        <MarketplaceManager
+          marketplaces={marketplaces}
+          onRefresh={fetchMarketplaces}
+        />
       )}
 
       {/* Tabs */}
-      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as PluginTab)}>
+      <Tabs
+        value={activeTab}
+        onValueChange={(value) => setActiveTab(value as PluginTab)}
+      >
         <TabsList>
           <TabsTrigger value="installed" className="flex items-center gap-2">
             <Package className="h-4 w-4" />


### PR DESCRIPTION
Closes #217

## Summary
- Add Codex MCP Servers and Plugins to provider-aware sidebar navigation.
- Make Codex dashboard MCP/plugin/feature cards actionable and correct the plugin inventory wording.
- Reuse the Codex inventory panel for focused `/mcp` and `/plugins` pages with Codex-specific add/remove/install/search controls.
- Add a stable Codex feature flag target from the dashboard and scroll the config editor panel to it.

## Verification
- `npm --prefix frontend run build`
- `cd frontend && npx eslint src/components/layout/Sidebar.tsx src/features/dashboard/DashboardPage.tsx src/features/config/CodexSettingsEditor.tsx src/features/config/ConfigViewerPage.tsx src/features/config/CodexInventoryCard.tsx src/features/mcp/MCPServersPage.tsx src/features/plugins/PluginsPage.tsx` (0 errors; existing set-state-in-effect warnings remain)
- Headless Chrome smoke over DevTools: Codex dashboard links, `/mcp`, `/plugins`, plugin search, and `/config#codex-features` visibility
