### PR TITLE
Fix Claude Code usage costs for current models

### DIFF
--- a/backend/app/services/pricing_service.py
+++ b/backend/app/services/pricing_service.py
@@ -10,12 +10,74 @@ from typing import Optional
 class PricingService:
     """Service for model pricing and cost calculation."""
 
+    # Bump when MODEL_PRICING changes so cached usage aggregates are recalculated.
+    PRICING_VERSION = "2026-06-20"
+
     # Default token threshold for tiered pricing (200k tokens)
     TIERED_THRESHOLD = 200_000
 
     # Model pricing data (costs per token)
     # Based on LiteLLM pricing data
     MODEL_PRICING = {
+        # Claude Fable 5 (June 2026)
+        "claude-fable-5": {
+            "input": 10.00 / 1_000_000,
+            "output": 50.00 / 1_000_000,
+            "cache_creation": 12.50 / 1_000_000,
+            "cache_read": 1.00 / 1_000_000,
+        },
+        # Claude Mythos 5 (June 2026, limited availability)
+        "claude-mythos-5": {
+            "input": 10.00 / 1_000_000,
+            "output": 50.00 / 1_000_000,
+            "cache_creation": 12.50 / 1_000_000,
+            "cache_read": 1.00 / 1_000_000,
+        },
+        # Claude Opus 4.x current aliases (2025-2026)
+        "claude-opus-4-8": {
+            "input": 5.00 / 1_000_000,
+            "output": 25.00 / 1_000_000,
+            "cache_creation": 6.25 / 1_000_000,
+            "cache_read": 0.50 / 1_000_000,
+        },
+        "claude-opus-4-7": {
+            "input": 5.00 / 1_000_000,
+            "output": 25.00 / 1_000_000,
+            "cache_creation": 6.25 / 1_000_000,
+            "cache_read": 0.50 / 1_000_000,
+        },
+        "claude-opus-4-6": {
+            "input": 5.00 / 1_000_000,
+            "output": 25.00 / 1_000_000,
+            "cache_creation": 6.25 / 1_000_000,
+            "cache_read": 0.50 / 1_000_000,
+        },
+        "claude-opus-4-5": {
+            "input": 5.00 / 1_000_000,
+            "output": 25.00 / 1_000_000,
+            "cache_creation": 6.25 / 1_000_000,
+            "cache_read": 0.50 / 1_000_000,
+        },
+        # Claude Sonnet 4.x current aliases (2025-2026)
+        "claude-sonnet-4-6": {
+            "input": 3.00 / 1_000_000,
+            "output": 15.00 / 1_000_000,
+            "cache_creation": 3.75 / 1_000_000,
+            "cache_read": 0.30 / 1_000_000,
+        },
+        "claude-sonnet-4-5": {
+            "input": 3.00 / 1_000_000,
+            "output": 15.00 / 1_000_000,
+            "cache_creation": 3.75 / 1_000_000,
+            "cache_read": 0.30 / 1_000_000,
+        },
+        # Claude Haiku 4.5 (October 2025)
+        "claude-haiku-4-5": {
+            "input": 1.00 / 1_000_000,
+            "output": 5.00 / 1_000_000,
+            "cache_creation": 1.25 / 1_000_000,
+            "cache_read": 0.10 / 1_000_000,
+        },
         # Claude Sonnet 4 (May 2025)
         "claude-sonnet-4-20250514": {
             "input": 3.00 / 1_000_000,
@@ -40,14 +102,10 @@ class PricingService:
         },
         # Claude Opus 4.5 (November 2025)
         "claude-opus-4-5-20251101": {
-            "input": 15.00 / 1_000_000,
-            "output": 75.00 / 1_000_000,
-            "cache_creation": 18.75 / 1_000_000,
-            "cache_read": 1.50 / 1_000_000,
-            "input_above_200k": 30.00 / 1_000_000,
-            "output_above_200k": 112.50 / 1_000_000,
-            "cache_creation_above_200k": 37.50 / 1_000_000,
-            "cache_read_above_200k": 3.00 / 1_000_000,
+            "input": 5.00 / 1_000_000,
+            "output": 25.00 / 1_000_000,
+            "cache_creation": 6.25 / 1_000_000,
+            "cache_read": 0.50 / 1_000_000,
         },
         # Claude 3.5 Sonnet (October 2024)
         "claude-3-5-sonnet-20241022": {
@@ -96,6 +154,7 @@ class PricingService:
     # Provider prefixes for model name matching
     PROVIDER_PREFIXES = [
         "anthropic/",
+        "anthropic.",
         "claude-",
         "claude-3-",
         "claude-3-5-",

--- a/backend/app/services/usage_service.py
+++ b/backend/app/services/usage_service.py
@@ -79,7 +79,7 @@ class UsageService:
         **params: Any,
     ) -> str:
         """Generate cache key for query."""
-        key_parts = [cache_type]
+        key_parts = [cache_type, f"pricing:{self.pricing.PRICING_VERSION}"]
         if project_path:
             key_parts.append(f"project:{project_path}")
         for k, v in sorted(params.items()):
@@ -284,7 +284,7 @@ class UsageService:
 
     def _calculate_entry_cost(self, entry: LoadedUsageEntry) -> float:
         """Calculate cost for a single entry."""
-        if entry.cost_usd is not None:
+        if entry.cost_usd is not None and entry.cost_usd > 0:
             return entry.cost_usd
         return self.pricing.calculate_cost(
             input_tokens=entry.input_tokens,

--- a/backend/tests/test_usage_service.py
+++ b/backend/tests/test_usage_service.py
@@ -87,11 +87,47 @@ class TestPricingService:
         # The fuzzy matching should find it
         assert pricing is not None or self.pricing.get_model_pricing("claude-sonnet-4-20250514") is not None
 
+    def test_current_claude_code_alias_pricing(self):
+        """Test current Claude Code model aliases have non-zero pricing."""
+        sonnet_cost = self.pricing.calculate_cost(
+            input_tokens=1000,
+            output_tokens=500,
+            model="claude-sonnet-4-6",
+        )
+        assert sonnet_cost == pytest.approx(0.0105, rel=1e-3)
+
+        opus_cost = self.pricing.calculate_cost(
+            input_tokens=1000,
+            output_tokens=500,
+            cache_creation_tokens=200,
+            cache_read_tokens=1000,
+            model="claude-opus-4-7",
+        )
+        assert opus_cost == pytest.approx(0.01925, rel=1e-3)
+
+        fable_cost = self.pricing.calculate_cost(
+            input_tokens=1000,
+            output_tokens=500,
+            cache_creation_tokens=200,
+            cache_read_tokens=1000,
+            model="claude-fable-5",
+        )
+        assert fable_cost == pytest.approx(0.0385, rel=1e-3)
+
+    def test_current_alias_matching_with_provider_style_name(self):
+        """Test provider-prefixed current aliases resolve."""
+        pricing = self.pricing.get_model_pricing("anthropic.claude-sonnet-4-6-v1:0")
+        assert pricing is not None
+        assert pricing["input"] == pytest.approx(3.00 / 1_000_000)
+
     def test_get_supported_models(self):
         """Test listing supported models."""
         models = self.pricing.get_supported_models()
         assert len(models) > 0
         assert "claude-sonnet-4-20250514" in models
+        assert "claude-sonnet-4-6" in models
+        assert "claude-opus-4-7" in models
+        assert "claude-fable-5" in models
 
     def test_calculate_tiered_cost_boundary(self):
         """Test tiered cost calculation at boundary."""
@@ -148,6 +184,38 @@ class TestUsageService:
         assert entry.input_tokens == 1000
         assert entry.output_tokens == 500
         assert entry.model == "claude-sonnet-4-20250514"
+
+    def test_zero_cost_usd_falls_back_to_pricing(self):
+        """Test zero costUSD does not suppress calculated cost for token usage."""
+        entry = LoadedUsageEntry(
+            timestamp=datetime.now(),
+            input_tokens=1000,
+            output_tokens=500,
+            cache_creation_tokens=0,
+            cache_read_tokens=0,
+            cost_usd=0.0,
+            model="claude-fable-5",
+            session_id="test-session",
+            version="1.0.0",
+            project_path="test-project",
+        )
+        assert self.service._calculate_entry_cost(entry) == pytest.approx(0.035, rel=1e-3)
+
+    def test_positive_cost_usd_is_trusted(self):
+        """Test positive costUSD remains authoritative when present."""
+        entry = LoadedUsageEntry(
+            timestamp=datetime.now(),
+            input_tokens=1000,
+            output_tokens=500,
+            cache_creation_tokens=0,
+            cache_read_tokens=0,
+            cost_usd=0.01,
+            model="claude-fable-5",
+            session_id="test-session",
+            version="1.0.0",
+            project_path="test-project",
+        )
+        assert self.service._calculate_entry_cost(entry) == 0.01
 
     @pytest.fixture
     def sample_entries(self):


### PR DESCRIPTION
Closes #219

## Summary
- Add pricing for current Claude Code model aliases used in local JSONL, including Sonnet 4.6, Opus 4.6/4.7/4.8, and Fable 5.
- Version usage cache keys by pricing table so stale zero-cost aggregates are bypassed after pricing changes.
- Recalculate when costUSD is zero with non-zero token usage while still trusting positive costUSD values.

## Verification
- `cd backend && ./venv/bin/pytest tests/test_usage_service.py -q`
- Direct UsageService over local JSONL: total_cost changed from 0.0 to 467.27, daily costs populated.
- Live API after cache invalidation returned total_cost 467.27225025 and non-zero daily costs.
