### PR TITLE
Prepare v2.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-06-20
+
+### Added
+- **Claude Code Config**: Added coverage for current Claude Code settings such as advisor model, fallback model chains, Remote Control startup, push notifications, notification channel, theme, auto-compact, file checkpointing, and newer safety/privacy toggles.
+- **Config editor helpers**: Added validated JSON editing for complex settings objects/arrays and a boolean map editor for plugin enablement.
+
+### Changed
+- **Dashboard**: Dashboard cards and navigation are now provider-aware so Codex selection does not show inaccessible Claude Code-only cards as if they were Codex pages.
+- **Codex provider pages**: Codex MCP servers, plugins, feature flags, and configuration inventory now route to provider-appropriate pages instead of dead-end dashboard stats.
+- **Claude Code settings**: Plugin marketplace settings, worktree symlink directories, sandbox Mach lookup settings, and managed marketplace policy values now use the JSON shapes documented by Claude Code.
+- **Docs**: Refreshed release, Config, and Dashboard docs to describe the 2.0.1 stabilization fixes.
+
+### Fixed
+- **Usage costs**: Claude Code usage dashboards now calculate costs for current Claude model aliases such as Opus 4.6/4.7/4.8, Sonnet 4.6, Haiku 4.5, and Fable 5 instead of showing `$0.00` with non-zero token usage.
+- **Usage cache**: Usage cache keys now include the pricing table version, avoiding stale zero-cost aggregates after pricing support changes.
+- **Config defaults**: Corrected stale UI defaults/descriptions for auto-updates, sandbox auto-allow, thinking summaries, plan auto-mode, and turn duration.
+
 ## [2.0.0] - 2026-06-19
 
 ### Added
@@ -141,7 +158,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RESTful API at `/api/v1/`
 - CORS configured for local development
 
-[Unreleased]: https://github.com/adrirubio/claude-deck/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/adrirubio/claude-deck/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/adrirubio/claude-deck/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/adrirubio/claude-deck/compare/v1.3.1...v2.0.0
 [1.3.1]: https://github.com/adrirubio/claude-deck/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/adrirubio/claude-deck/compare/v1.2.0...v1.3.0

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ If you only use Claude Code casually with mostly default config, Claude Deck may
 - **Backup & Restore** — Create and manage Claude Code backups with selective restore, plus redacted export-only Codex backups
 - **Projects** — Discover and manage project directories
 
+## What's New in 2.0.1
+
+Claude Deck 2.0.1 is a stabilization release for the 2.x coordination work:
+
+- Claude Code usage dashboards now calculate costs for current Claude model aliases instead of showing `$0.00` when token usage is present.
+- Dashboard cards and links are provider-aware, including Codex configuration, MCP, plugin, feature flag, live session, and plan surfaces.
+- Claude Code Config now exposes more current settings, including advisor model, fallback model chains, Remote Control, notification, checkpointing, theme, and safety/privacy controls.
+- Plugin marketplace, worktree, and sandbox settings now write the JSON shapes expected by current Claude Code.
+
 ## What's New in 2.0.0
 
 Claude Deck 2.0.0 shifts the product from single-agent management toward local agent coordination:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -13,7 +13,7 @@ class Settings(BaseSettings):
 
     # Application settings
     app_name: str = "Claude Deck"
-    app_version: str = "0.1.0"
+    app_version: str = "2.0.1"
     debug: bool = False
 
     # API settings

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-code-registry-backend"
-version = "2.0.0"
+version = "2.0.1"
 description = "Backend API for Claude Deck"
 requires-python = ">=3.11"
 dependencies = [

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,30 @@
 
 All notable changes to Claude Deck are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 2.0.1 — 2026-06-20
+
+### Added
+
+- Claude Code Config now covers current high-impact settings:
+  - advisor model
+  - fallback model chains
+  - Remote Control startup
+  - push notifications and terminal notification channel
+  - theme, auto-compact, file checkpointing, and newer safety/privacy toggles
+- The settings editor now includes validated JSON editing for complex settings objects and arrays, plus a boolean map editor for plugin enablement.
+
+### Changed
+
+- Dashboard cards and links are provider-aware, so Codex selection no longer shows Claude Code-only data or inaccessible links as if they were Codex surfaces.
+- Codex dashboard inventory for MCP servers, plugins, feature flags, and config now routes to provider-appropriate pages.
+- Claude Code plugin marketplace settings, worktree symlink directories, sandbox Mach lookup settings, and managed marketplace policy values now use documented JSON shapes.
+
+### Fixed
+
+- Claude Code usage dashboards now calculate costs for current model aliases such as Opus 4.6/4.7/4.8, Sonnet 4.6, Haiku 4.5, and Fable 5 instead of showing `$0.00` with non-zero token usage.
+- Usage cache keys now include the pricing table version, preventing stale zero-cost aggregates after pricing support changes.
+- Several settings defaults and descriptions were corrected to match current Claude Code behavior.
+
 ## 2.0.0 — 2026-06-19
 
 ### Added

--- a/docs/features/config.md
+++ b/docs/features/config.md
@@ -18,12 +18,17 @@ The Settings Editor tab provides form controls for common Claude Code settings:
 
 | Setting | Type | Description |
 |---------|------|-------------|
-| Model | Dropdown | Claude model selection (Opus 4.6, Sonnet 4.6, Haiku 4.5, etc.) |
+| Model | Dropdown | Claude model selection, including current Opus, Sonnet, Haiku, and Fable aliases |
+| Advisor Model | Text input | Optional model alias or full model ID for Claude Code's advisor tool |
+| Fallback Models | List | Ordered model chain to try when the primary model is overloaded or unavailable |
 | Permission Mode | Dropdown | default, acceptEdits, dontAsk, plan, bypassPermissions, delegate |
 | Update Channel | Dropdown | stable or latest |
 | Teammate Mode | Dropdown | auto, in-process, or tmux |
-| Read-only Files | Toggle | Always allow reading files without permission prompts |
-| Timeouts & Limits | Number inputs | Various timeout and limit settings |
+| Remote Control & Notifications | Toggles/dropdowns | Remote Control startup, mobile push notifications, and terminal notification channel |
+| Safety & Privacy | Toggles | Artifact publishing, Claude.ai connectors, bundled skills, WebFetch preflight, hooks, and workflow behavior |
+| Plugins | Map/JSON editors | Plugin enablement and marketplace settings using Claude Code's documented JSON shapes |
+| Worktrees & Sandbox | Lists/toggles | Worktree base refs, symlink directories, sparse paths, sandbox filesystem/network controls, and macOS service allowlists |
+| Timeouts & Limits | Number inputs | Cleanup, feedback survey, file suggestion, and sandbox proxy settings |
 
 The editor also includes a **Permission Rules** section where you can add allow/ask/deny patterns using glob syntax.
 
@@ -78,9 +83,9 @@ The Codex editor keeps open-ended fields editable and uses dropdowns where Codex
 
 | Setting | Control | Notes |
 |---------|---------|-------|
-| Model | Text input | Shows model ids already found in the loaded config/profile data, but allows any Codex-supported model id. |
+| Model | Dropdown with custom fallback | Shows model ids already found in the loaded config/profile data, while still allowing any Codex-supported model id. |
 | Reasoning Effort | Dropdown | Default, low, medium, high, or extra high. Existing custom values remain selectable. |
-| Profile | Text input | Shows profile names found in config/profile diagnostics, but allows any Codex profile name. |
+| Profile | Dropdown with custom fallback | Shows profile names found in config/profile diagnostics, while still allowing any Codex profile name. |
 | Sandbox Mode | Dropdown | Default, read-only, workspace-write, or danger-full-access. |
 | Approval Policy | Dropdown | Default, untrusted, on-request, never, or deprecated on-failure. |
 | Search | Toggle | Enables live web search for Codex. |

--- a/docs/features/dashboard.md
+++ b/docs/features/dashboard.md
@@ -1,10 +1,10 @@
 # Dashboard
 
-The dashboard provides an at-a-glance overview of your entire Claude Code configuration with 12 information cards organized in a responsive grid.
+The dashboard provides an at-a-glance overview of the selected provider and active project. Claude Code has the richest metrics; Codex focuses on configuration, provider inventory, and live-session state that can be read without exposing prompt history or provider-owned cache data.
 
 ## Overview
 
-When you open Claude Deck, the dashboard aggregates data from 12 API endpoints in parallel and displays:
+When Claude Code is selected, the dashboard aggregates data from the Claude Code configuration and session APIs and displays:
 
 - **Projects** — number of tracked project directories
 - **MCP Servers** — configured server count
@@ -21,15 +21,26 @@ When you open Claude Deck, the dashboard aggregates data from 12 API endpoints i
 
 A **Quick Status** card at the bottom shows settings key count and allow/deny rule breakdown.
 
+When Codex CLI is selected, the dashboard switches to Codex-specific cards such as:
+
+- **Codex Config** — safe config entries, profiles, projects, and feature settings
+- **Codex MCP Servers** — configured MCP server inventory
+- **Codex Plugins** — installed plugin inventory
+- **Codex Feature Flags** — available and enabled feature flags
+- **Codex Live Sessions** — sessions currently visible through Agent Bridge
+- **Plan Snapshots** — Codex `update_plan` snapshots
+
+Cards link to provider-appropriate pages. Claude Code-only surfaces such as usage costs, context windows, transcript browsing, memory, hooks, and permission pages are not shown as Codex data.
+
 ## How to Use
 
 ### Viewing Data
 
-All cards update together. The dashboard shows project-scoped data for the currently selected project — switch projects using the sidebar selector.
+All cards update together. The dashboard shows data for the currently selected provider and active project — switch providers and projects using the sidebar selectors.
 
 ### Context Window Indicator
 
-The context window card shows the highest context usage percentage across all active Claude Code sessions:
+For Claude Code, the context window card shows the highest context usage percentage across all active Claude Code sessions:
 
 | Color | Range | Meaning |
 |-------|-------|---------|
@@ -53,10 +64,10 @@ Several cards include links to jump to their full page:
 
 ## Configuration
 
-The dashboard has no dedicated configuration. It reads data from all other features. The active project (set via sidebar) determines the scope for MCP servers, commands, hooks, and permissions.
+The dashboard has no dedicated configuration. It reads data from all other features. The selected provider controls which cards are shown, and the active project determines the scope for project-aware cards.
 
 ## Tips
 
 - **Data is cached** — switching pages doesn't trigger a re-fetch. Click refresh for fresh data.
-- **Project switching** automatically re-fetches dashboard data for the new project.
+- **Provider and project switching** automatically re-fetch dashboard data for the new selection.
 - **First visit** shows a loading skeleton while data loads. Subsequent visits show cached data.

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,8 +40,10 @@ features:
     details: Discover project directories from local agent state or add them with the directory browser.
 ---
 
-## Release Focus: 2.0 Team Coordination
+## Release Focus: 2.x Team Coordination
 
 Claude Deck 2.0.0 makes Agent Mail and Agent Teams the main coordination layer for local coding agents. Agents can keep durable per-repository or per-team-slot identities, ask each other for context, hand work across repositories, and keep an inspectable mailbox without turning Claude Deck into a general chat product.
+
+Claude Deck 2.0.1 stabilizes that release with provider-aware dashboard fixes, current Claude Code usage-cost calculations, and broader coverage for recent Claude Code configuration settings.
 
 Presence has been removed. Agent Bridge, Agent Mail, and Agent Teams are now the supported surfaces for live session visibility, communication, and reusable rosters. Codex support still keeps provider boundaries explicit: usage metrics, context charts, and transcript browsing are not shown as if they were Claude Code data, and Codex backups remain redacted exports.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Bump frontend/backend release metadata to 2.0.1.
- Add 2.0.1 entries to the root and docs changelogs.
- Refresh README, docs home, Config docs, and Dashboard docs for the post-2.0 stabilization fixes.
- Update backend exposed app version to 2.0.1.

## Release notes
2.0.1 stabilizes the 2.x coordination release with provider-aware dashboard fixes, current Claude Code usage-cost calculations, broader current Claude Code settings coverage, and corrected settings JSON shapes.

## Verification
- `git diff --check`
- `cd backend && ./venv/bin/python3 -c "import app.main; from app.config import settings; print(settings.app_version)"`
- `cd frontend && npm run build`
- `cd docs && npm run build`
