### PR TITLE
Fix same-repo Agent Mail wakeability

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -79,6 +79,19 @@ async def _sqlite_has_unique_repo_id_index(conn) -> bool:
     return False
 
 
+async def _sqlite_agent_team_slots_has_unique_preset_repo_index(conn) -> bool:
+    result = await conn.execute(text("PRAGMA index_list(agent_team_slots)"))
+    for row in result.fetchall():
+        index_name = row[1]
+        is_unique = bool(row[2])
+        if not is_unique:
+            continue
+        info = await conn.execute(text(f"PRAGMA index_info({_sqlite_ident(index_name)})"))
+        if [index_row[2] for index_row in info.fetchall()] == ["preset_id", "repo_id"]:
+            return True
+    return False
+
+
 async def _sqlite_rebuild_mail_team_members(conn, columns: set[str]) -> None:
     """Replace the legacy repo-unique table without losing referencing rows."""
     await conn.commit()
@@ -184,6 +197,96 @@ async def _sqlite_rebuild_mail_team_members(conn, columns: set[str]) -> None:
     await conn.commit()
 
 
+async def _sqlite_rebuild_agent_team_slots(conn, columns: set[str]) -> None:
+    """Replace the legacy same-repo-unique slots table without losing slot ids."""
+    await conn.commit()
+    await conn.execute(text("PRAGMA foreign_keys=OFF"))
+    await conn.commit()
+
+    bootstrap_expr = "bootstrap_prompt" if "bootstrap_prompt" in columns else "NULL"
+    launch_mode_expr = "COALESCE(NULLIF(launch_mode, ''), 'plain')" if "launch_mode" in columns else "'plain'"
+    launch_options_expr = "launch_options" if "launch_options" in columns else "NULL"
+    enabled_expr = "COALESCE(enabled, 1)" if "enabled" in columns else "1"
+
+    await conn.execute(text("DROP TABLE IF EXISTS agent_team_slots_new"))
+    await conn.execute(
+        text(
+            """
+            CREATE TABLE agent_team_slots_new (
+                id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+                preset_id INTEGER NOT NULL,
+                position INTEGER NOT NULL,
+                display_name VARCHAR NOT NULL,
+                provider VARCHAR NOT NULL,
+                repo_id VARCHAR NOT NULL,
+                repo_path VARCHAR NOT NULL,
+                repo_name VARCHAR NOT NULL,
+                role VARCHAR,
+                charter VARCHAR,
+                bootstrap_prompt VARCHAR,
+                launch_mode VARCHAR NOT NULL,
+                launch_options JSON,
+                enabled BOOLEAN NOT NULL,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL,
+                FOREIGN KEY(preset_id) REFERENCES agent_team_presets (id) ON DELETE CASCADE
+            )
+            """
+        )
+    )
+    await conn.execute(
+        text(
+            f"""
+            INSERT INTO agent_team_slots_new (
+                id,
+                preset_id,
+                position,
+                display_name,
+                provider,
+                repo_id,
+                repo_path,
+                repo_name,
+                role,
+                charter,
+                bootstrap_prompt,
+                launch_mode,
+                launch_options,
+                enabled,
+                created_at,
+                updated_at
+            )
+            SELECT
+                id,
+                preset_id,
+                position,
+                display_name,
+                provider,
+                repo_id,
+                repo_path,
+                repo_name,
+                role,
+                charter,
+                {bootstrap_expr},
+                {launch_mode_expr},
+                {launch_options_expr},
+                {enabled_expr},
+                created_at,
+                updated_at
+            FROM agent_team_slots
+            """
+        )
+    )
+    await conn.execute(text("DROP TABLE agent_team_slots"))
+    await conn.execute(text("ALTER TABLE agent_team_slots_new RENAME TO agent_team_slots"))
+    await conn.execute(
+        text("CREATE INDEX ix_agent_team_slots_preset_id ON agent_team_slots (preset_id)")
+    )
+    await conn.execute(text("CREATE INDEX ix_agent_team_slots_repo_id ON agent_team_slots (repo_id)"))
+    await conn.commit()
+    await conn.execute(text("PRAGMA foreign_keys=ON"))
+    await conn.commit()
+
+
 async def _run_sqlite_compat_migrations(conn) -> None:
     columns = await _sqlite_columns(conn, "mail_team_members")
     if columns:
@@ -257,6 +360,9 @@ async def _run_sqlite_compat_migrations(conn) -> None:
 
     result = await conn.execute(text("PRAGMA table_info(agent_team_slots)"))
     slot_columns = {row[1] for row in result.fetchall()}
+    if slot_columns and await _sqlite_agent_team_slots_has_unique_preset_repo_index(conn):
+        await _sqlite_rebuild_agent_team_slots(conn, slot_columns)
+        slot_columns = await _sqlite_columns(conn, "agent_team_slots")
     if slot_columns and "bootstrap_prompt" not in slot_columns:
         await conn.execute(
             text("ALTER TABLE agent_team_slots ADD COLUMN bootstrap_prompt VARCHAR")

--- a/backend/app/services/agent_mail_service.py
+++ b/backend/app/services/agent_mail_service.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 from typing import List, Optional
 
 from sqlalchemy import func, or_, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.database import (
@@ -113,8 +114,17 @@ class AgentMailService:
         member = result.scalar_one_or_none()
         if member is None:
             member = MailTeamMember(**values)
-            db.add(member)
-            await db.flush()
+            try:
+                async with db.begin_nested():
+                    db.add(member)
+                    await db.flush()
+            except IntegrityError:
+                result = await db.execute(
+                    select(MailTeamMember).where(
+                        MailTeamMember.identity_key == values["identity_key"]
+                    )
+                )
+                member = result.scalar_one()
         else:
             member.repo_id = str(values["repo_id"])
             member.repo_path = str(values["repo_path"])
@@ -145,6 +155,21 @@ class AgentMailService:
     async def register_session(
         self, db: AsyncSession, request: MailAgentRegisterRequest
     ) -> tuple[MailTeamMember, MailAgentSession]:
+        inferred_team_preset_id, inferred_team_slot_id = await self._infer_team_context_from_process(
+            db,
+            request,
+        )
+        if (
+            request.team_preset_id is None
+            and request.team_slot_id is None
+            and (inferred_team_preset_id is not None or inferred_team_slot_id is not None)
+        ):
+            request = request.model_copy(
+                update={
+                    "team_preset_id": inferred_team_preset_id,
+                    "team_slot_id": inferred_team_slot_id,
+                }
+            )
         has_team_context = request.team_preset_id is not None or request.team_slot_id is not None
         team_preset_id, team_slot_id = await self._resolve_team_context(db, request)
         result = await db.execute(
@@ -191,6 +216,43 @@ class AgentMailService:
         await db.refresh(member)
         await db.refresh(session)
         return member, session
+
+    async def _infer_team_context_from_process(
+        self,
+        db: AsyncSession,
+        request: MailAgentRegisterRequest,
+    ) -> tuple[int | None, int | None]:
+        if request.team_preset_id is not None or request.team_slot_id is not None or request.pid is None:
+            return None, None
+        try:
+            repo_id = derive_repo_identity(request.cwd)["repo_id"]
+        except Exception:
+            repo_id = None
+        now = datetime.utcnow()
+        result = await db.execute(
+            select(MailAgentSession)
+            .where(
+                MailAgentSession.source != "observed",
+                MailAgentSession.provider == request.provider,
+                MailAgentSession.team_slot_id.is_not(None),
+                MailAgentSession.pid.is_not(None),
+                MailAgentSession.last_seen_at >= now - timedelta(seconds=HEARTBEAT_TTL_SECONDS),
+            )
+            .order_by(MailAgentSession.last_seen_at.desc())
+        )
+        for session in result.scalars().all():
+            if not session.pid or not self._pids_related(int(request.pid), int(session.pid)):
+                continue
+            if repo_id is not None:
+                try:
+                    if derive_repo_identity(session.cwd or "")["repo_id"] != repo_id:
+                        continue
+                except Exception:
+                    continue
+            if self._effective_status(session, now) == "offline":
+                continue
+            return session.team_preset_id, session.team_slot_id
+        return None, None
 
     async def _session_team_context_matches_registration(
         self,
@@ -355,22 +417,59 @@ class AgentMailService:
                 .where(
                     MailAgentSession.source != "observed",
                     MailAgentSession.provider == provider,
-                    MailAgentSession.pid == pid,
+                    MailAgentSession.pid.is_not(None),
+                    MailAgentSession.last_seen_at >= now - timedelta(seconds=HEARTBEAT_TTL_SECONDS),
                 )
                 .order_by(MailAgentSession.last_seen_at.desc())
-                .limit(1)
             )
-            registered_session = result.scalar_one_or_none()
-            if registered_session is not None and self._registered_session_matches_observed(
-                registered_session,
-                info,
-                now,
-            ):
-                member = await db.get(MailTeamMember, registered_session.member_id)
-                if member is not None:
-                    return member
+            for registered_session in result.scalars().all():
+                if not registered_session.pid or not self._pids_related(pid, int(registered_session.pid)):
+                    continue
+                if registered_session is not None and self._registered_session_matches_observed(
+                    registered_session,
+                    info,
+                    now,
+                ):
+                    member = await db.get(MailTeamMember, registered_session.member_id)
+                    if member is not None:
+                        return member
 
         return await self._get_or_create_repo_member(db, cwd)
+
+    def _pids_related(self, left_pid: int, right_pid: int) -> bool:
+        return (
+            left_pid == right_pid
+            or self._pid_is_descendant(left_pid, right_pid)
+            or self._pid_is_descendant(right_pid, left_pid)
+        )
+
+    def _pid_is_descendant(self, child_pid: int, ancestor_pid: int) -> bool:
+        current = child_pid
+        visited: set[int] = set()
+        for _ in range(8):
+            if current == ancestor_pid:
+                return True
+            if current in visited:
+                return False
+            visited.add(current)
+            try:
+                result = subprocess.run(
+                    ["ps", "-o", "ppid=", "-p", str(current)],
+                    capture_output=True,
+                    text=True,
+                    timeout=1,
+                )
+            except (OSError, subprocess.SubprocessError):
+                return False
+            if result.returncode != 0:
+                return False
+            try:
+                current = int(result.stdout.strip() or "0")
+            except ValueError:
+                return False
+            if current <= 1:
+                return False
+        return False
 
     async def _member_for_existing_observed_session(
         self,

--- a/backend/mcp_shim/agent_mail_server.py
+++ b/backend/mcp_shim/agent_mail_server.py
@@ -11,7 +11,7 @@ from mcp.server.fastmcp import FastMCP
 DECK_URL = os.environ.get("CLAUDE_DECK_URL", "http://127.0.0.1:8000").rstrip("/")
 PROVIDER = os.environ.get("CLAUDE_DECK_PROVIDER", "unknown")
 API = f"{DECK_URL}/api/v1/agent-mail"
-DECK_HTTP_TIMEOUT = httpx.Timeout(connect=0.3, read=2.0, write=2.0, pool=0.3)
+DECK_HTTP_TIMEOUT = httpx.Timeout(connect=0.5, read=15.0, write=5.0, pool=0.5)
 OFFLINE_BACKOFF_SECONDS = 2.0
 HEARTBEAT_INTERVAL_SECONDS = 60.0
 HEARTBEAT_UNAVAILABLE_INTERVAL_SECONDS = 300.0
@@ -68,7 +68,7 @@ def _ensure_registered() -> dict:
             "provider": PROVIDER,
             "cwd": os.getcwd(),
             "session_key": _state["session_key"],
-            "pid": os.getpid(),
+            "pid": os.getppid(),
         }
         team_preset_id = _env_int("CLAUDE_DECK_TEAM_PRESET_ID")
         team_slot_id = _env_int("CLAUDE_DECK_TEAM_SLOT_ID")
@@ -153,7 +153,7 @@ def deck_list_team() -> dict:
     err = _guard()
     if err:
         return err
-    result = _request("GET", "/team?sync=true")
+    result = _request("GET", "/team?sync=false")
     if not result["ok"]:
         return result
     members = [

--- a/backend/tests/agent_mail/test_mcp_shim.py
+++ b/backend/tests/agent_mail/test_mcp_shim.py
@@ -18,7 +18,7 @@ def test_ensure_registered_refreshes_cached_member(monkeypatch):
     monkeypatch.setitem(shim._state, "member_id", 7)
     monkeypatch.setitem(shim._state, "session_key", "mcp:test")
     monkeypatch.setattr(shim.os, "getcwd", lambda: "/tmp/repo")
-    monkeypatch.setattr(shim.os, "getpid", lambda: 1234)
+    monkeypatch.setattr(shim.os, "getppid", lambda: 1234)
 
     def fake_request(method, path, **kwargs):
         requests.append((method, path, kwargs))
@@ -121,6 +121,46 @@ def test_deck_reply_only_uses_answer_for_context_requests(monkeypatch):
     assert posted[0]["kind"] == "message"
 
 
+def test_deck_list_team_uses_cached_roster(monkeypatch):
+    import mcp_shim.agent_mail_server as shim
+
+    requests = []
+    shim._state["member_id"] = 7
+
+    def fake_request(method, path, **kwargs):
+        requests.append((method, path, kwargs))
+        if path == "/team?sync=false":
+            return {
+                "ok": True,
+                "data": {
+                    "members": [
+                        {
+                            "id": 7,
+                            "display_name": "Planner",
+                            "participant_kind": "team_slot",
+                            "role": "Planner",
+                            "repo_name": "deck",
+                            "status": "connected",
+                            "charter": "Plan work",
+                            "team_preset_name": "Test team",
+                            "team_slot_name": "Planner",
+                        }
+                    ]
+                },
+            }
+        if path.startswith("/agent/inbox"):
+            return {"ok": True, "data": {"unread_count": 0, "pending_count": 0}}
+        raise AssertionError((method, path, kwargs))
+
+    monkeypatch.setattr(shim, "_request", fake_request)
+    monkeypatch.setattr(shim, "_ensure_registered", lambda: {"ok": True})
+
+    result = shim.deck_list_team()
+
+    assert result["ok"] is True
+    assert requests[0][1] == "/team?sync=false"
+
+
 def test_deck_check_inbox_returns_deck_unreachable_on_http_error(monkeypatch):
     import mcp_shim.agent_mail_server as shim
 
@@ -157,8 +197,8 @@ def test_mcp_request_uses_short_timeout_and_offline_backoff(monkeypatch):
     assert first["ok"] is False
     assert second["ok"] is False
     assert len(calls) == 1
-    assert calls[0].connect == 0.3
-    assert calls[0].read == 2.0
+    assert calls[0].connect == 0.5
+    assert calls[0].read == 15.0
 
 
 def test_codex_hook_shim_emits_backend_json(monkeypatch, capsys):

--- a/backend/tests/agent_mail/test_registry.py
+++ b/backend/tests/agent_mail/test_registry.py
@@ -154,6 +154,96 @@ async def test_same_repo_team_slots_are_distinct_mail_participants(db, svc, tmp_
 
 
 @pytest.mark.asyncio
+async def test_mcp_registration_infers_slot_from_related_hook_process(
+    db,
+    svc,
+    tmp_path,
+    monkeypatch,
+):
+    cwd = tmp_path / "r"
+    cwd.mkdir()
+    preset, slot = await _slot(db, str(cwd), "Planner")
+    slot_member, hook_session = await svc.register_session(
+        db,
+        MailAgentRegisterRequest(
+            source="hook",
+            provider="codex-cli",
+            cwd=str(cwd),
+            session_key="codex:planner",
+            pid=200,
+            team_preset_id=preset.id,
+            team_slot_id=slot.id,
+        ),
+    )
+    monkeypatch.setattr(svc, "_pids_related", lambda left, right: {left, right} == {300, 200})
+
+    mcp_member, mcp_session = await svc.register_session(
+        db,
+        MailAgentRegisterRequest(
+            source="mcp",
+            provider="codex-cli",
+            cwd=str(cwd),
+            session_key="mcp:planner",
+            pid=300,
+        ),
+    )
+
+    assert mcp_member.id == slot_member.id
+    assert mcp_session.member_id == slot_member.id
+    assert mcp_session.team_preset_id == preset.id
+    assert mcp_session.team_slot_id == slot.id
+    assert hook_session.team_slot_id == slot.id
+
+
+@pytest.mark.asyncio
+async def test_observed_tmux_session_infers_slot_from_related_hook_process(
+    db,
+    svc,
+    tmp_path,
+    monkeypatch,
+):
+    cwd = tmp_path / "r"
+    cwd.mkdir()
+    preset, slot = await _slot(db, str(cwd), "Planner")
+    slot_member, _hook_session = await svc.register_session(
+        db,
+        MailAgentRegisterRequest(
+            source="hook",
+            provider="codex-cli",
+            cwd=str(cwd),
+            session_key="codex:planner",
+            pid=200,
+            team_preset_id=preset.id,
+            team_slot_id=slot.id,
+        ),
+    )
+    monkeypatch.setattr(svc, "_pids_related", lambda left, right: {left, right} == {100, 200})
+    monkeypatch.setattr(
+        "app.services.agent_mail_service.discover_agent_sessions",
+        lambda: [
+            {
+                "provider": "codex-cli",
+                "cwd": str(cwd),
+                "pane_id": "%1",
+                "pid": "100",
+                "tmux_target": "planner:0.0",
+            }
+        ],
+    )
+
+    await svc.sync_observed_sessions(db)
+
+    result = await db.execute(
+        select(MailAgentSession).where(MailAgentSession.session_key == "tmux:%1")
+    )
+    observed = result.scalar_one()
+    assert observed.member_id == slot_member.id
+    assert observed.team_preset_id == preset.id
+    assert observed.team_slot_id == slot.id
+    assert observed.tmux_target == "planner:0.0"
+
+
+@pytest.mark.asyncio
 async def test_reused_session_key_clears_stale_team_slot_context(db, svc, tmp_path):
     repo_a = tmp_path / "repo-a"
     repo_b = tmp_path / "repo-b"

--- a/backend/tests/test_sqlite_compat_migrations.py
+++ b/backend/tests/test_sqlite_compat_migrations.py
@@ -1,0 +1,132 @@
+"""SQLite compatibility migration regressions."""
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from app.database import (
+    _sqlite_agent_team_slots_has_unique_preset_repo_index,
+    _sqlite_columns,
+    _sqlite_rebuild_agent_team_slots,
+)
+
+
+@pytest.mark.asyncio
+async def test_rebuild_agent_team_slots_removes_legacy_same_repo_unique_constraint():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(
+                text(
+                    """
+                    CREATE TABLE agent_team_presets (
+                        id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+                        name VARCHAR NOT NULL
+                    )
+                    """
+                )
+            )
+            await conn.execute(text("INSERT INTO agent_team_presets (id, name) VALUES (1, 'E2E')"))
+            await conn.execute(
+                text(
+                    """
+                    CREATE TABLE agent_team_slots (
+                        id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+                        preset_id INTEGER NOT NULL,
+                        position INTEGER NOT NULL,
+                        display_name VARCHAR NOT NULL,
+                        provider VARCHAR NOT NULL,
+                        repo_id VARCHAR NOT NULL,
+                        repo_path VARCHAR NOT NULL,
+                        repo_name VARCHAR NOT NULL,
+                        role VARCHAR,
+                        charter VARCHAR,
+                        launch_mode VARCHAR NOT NULL,
+                        launch_options JSON,
+                        enabled BOOLEAN NOT NULL,
+                        created_at DATETIME NOT NULL,
+                        updated_at DATETIME NOT NULL,
+                        UNIQUE (preset_id, repo_id),
+                        FOREIGN KEY(preset_id) REFERENCES agent_team_presets (id) ON DELETE CASCADE
+                    )
+                    """
+                )
+            )
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO agent_team_slots (
+                        preset_id,
+                        position,
+                        display_name,
+                        provider,
+                        repo_id,
+                        repo_path,
+                        repo_name,
+                        launch_mode,
+                        enabled,
+                        created_at,
+                        updated_at
+                    )
+                    VALUES (
+                        1,
+                        0,
+                        'Planner',
+                        'codex-cli',
+                        'repo-1',
+                        '/home/user/repo',
+                        'repo',
+                        'plain',
+                        1,
+                        '2026-06-21 00:00:00',
+                        '2026-06-21 00:00:00'
+                    )
+                    """
+                )
+            )
+            await conn.commit()
+
+            assert await _sqlite_agent_team_slots_has_unique_preset_repo_index(conn)
+
+            columns = await _sqlite_columns(conn, "agent_team_slots")
+            await _sqlite_rebuild_agent_team_slots(conn, columns)
+
+            assert not await _sqlite_agent_team_slots_has_unique_preset_repo_index(conn)
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO agent_team_slots (
+                        preset_id,
+                        position,
+                        display_name,
+                        provider,
+                        repo_id,
+                        repo_path,
+                        repo_name,
+                        launch_mode,
+                        enabled,
+                        created_at,
+                        updated_at
+                    )
+                    VALUES (
+                        1,
+                        1,
+                        'Reviewer',
+                        'codex-cli',
+                        'repo-1',
+                        '/home/user/repo',
+                        'repo',
+                        'plain',
+                        1,
+                        '2026-06-21 00:00:00',
+                        '2026-06-21 00:00:00'
+                    )
+                    """
+                )
+            )
+            count = (
+                await conn.execute(text("SELECT COUNT(*) FROM agent_team_slots WHERE repo_id = 'repo-1'"))
+            ).scalar_one()
+            assert count == 2
+    finally:
+        await engine.dispose()

--- a/docs/api/agent-teams.md
+++ b/docs/api/agent-teams.md
@@ -71,6 +71,8 @@ POST /api/v1/agent-teams/presets/{preset_id}/slots/reorder
 
 Slots store provider, repository path, display name, role, charter, bootstrap prompt, launch mode, provider options, and enabled state.
 
+Multiple enabled slots can point at the same repository. Use this for same-repo roles such as planner/reviewer or implementer/reviewer. Each launched slot gets a distinct Agent Mail identity, so external tools should route follow-up Agent Mail requests to the slot member returned by Agent Mail discovery.
+
 ## Launch Planning
 
 ### Plan Launch

--- a/docs/features/agent-teams.md
+++ b/docs/features/agent-teams.md
@@ -16,6 +16,20 @@ Each team has slots. A slot stores:
 
 Agent Teams do not create a second messaging system. Once agents are launched or reused, use Agent Mail for messages, context requests, and handoffs.
 
+## Same-Repo Role Workflows
+
+Use Agent Teams when multiple agents need distinct roles inside the same repository. A common setup is:
+
+1. create one slot named `Planner` for the repository
+2. create a second slot named `Reviewer` for the same repository
+3. give each slot a role, charter, and optional bootstrap prompt
+4. plan and launch the team from Agent Teams
+5. use Agent Mail for context requests, replies, and handoffs between the slots
+
+Launching through Agent Teams is important because each slot receives its own Agent Mail identity. Two manually started sessions in the same repository may be represented as one repo-level participant, which is not reliable for planner/reviewer routing.
+
+Use `reuse existing` only when the existing sessions already belong to the intended team slots. For a clean planner/reviewer workflow, spawn fresh slots from the team.
+
 ## Creating Teams
 
 You can create a team manually, import selected Agent Mail members, or snapshot currently visible Agent Bridge sessions.

--- a/docs/features/external-agent-orchestration.md
+++ b/docs/features/external-agent-orchestration.md
@@ -147,6 +147,17 @@ curl -s -X POST "$DECK_API/agent-teams/presets/3/launch" \
 
 Once agents register through Agent Mail, use `/external/agent-mail/members` to discover their participant/member ids, then send context requests or handoffs through the external Agent Mail endpoints.
 
+### Same-Repo Role Routing
+
+External orchestrators should launch same-repo multi-agent workflows through Agent Teams before sending Agent Mail requests. For example, a planner/reviewer workflow should use two slots that point at the same repository:
+
+- `Planner`: creates or revises the plan
+- `Reviewer`: reviews the plan and replies with feedback
+
+After launch, discover participants with `/external/agent-mail/members` and route by the returned slot participant ids. Do not rely on manually started same-repo sessions for role-based routing; without Agent Team slot context they can appear as a single repo-level participant.
+
+If `wake_state` is `wakeable`, Deck can nudge the visible tmux session when mail arrives. If it is `delivered_waiting`, the message is stored but the recipient must poll or reach a hook boundary.
+
 ## Safeguards
 
 - External actor tokens are distinct from Agent Mail members and are shown by name in the Agent Mail UI.

--- a/frontend/src/features/agent-teams/AgentTeamsHelpDialog.tsx
+++ b/frontend/src/features/agent-teams/AgentTeamsHelpDialog.tsx
@@ -1,0 +1,91 @@
+import { BookOpen, Inbox, Rocket, UsersRound } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { MODAL_SIZES } from '@/lib/constants'
+
+interface AgentTeamsHelpDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+function HelpSection({
+  icon: Icon,
+  title,
+  children,
+}: {
+  icon: typeof BookOpen
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <section className="rounded-lg border p-4">
+      <div className="mb-3 flex items-center gap-2">
+        <Icon className="h-4 w-4 text-muted-foreground" />
+        <h3 className="text-sm font-semibold">{title}</h3>
+      </div>
+      <div className="space-y-2 text-sm leading-6 text-muted-foreground">{children}</div>
+    </section>
+  )
+}
+
+export function AgentTeamsHelpDialog({ open, onOpenChange }: AgentTeamsHelpDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className={MODAL_SIZES.MD}>
+        <DialogHeader>
+          <DialogTitle>Agent Teams guide</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <HelpSection icon={UsersRound} title="What a team slot is">
+            <p>
+              A team is a saved roster of named slots. Each slot stores a provider, repository,
+              role, charter, and optional bootstrap prompt. When launched from Agent Teams, each
+              slot receives its own Agent Mail identity.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <Badge variant="outline">Provider</Badge>
+              <Badge variant="outline">Repo</Badge>
+              <Badge variant="outline">Role</Badge>
+              <Badge variant="outline">Charter</Badge>
+            </div>
+          </HelpSection>
+
+          <HelpSection icon={Inbox} title="Same-repo planner and reviewer">
+            <p>
+              Use separate slots when two agents work in the same repository but need distinct
+              roles, inboxes, and routing. For example, create one slot named Planner and one slot
+              named Reviewer, both pointing at the same repo.
+            </p>
+            <p>
+              Manually started same-repo sessions can collapse into one repo-level participant.
+              Launching through Agent Teams gives Agent Mail a durable slot identity for each role.
+            </p>
+          </HelpSection>
+
+          <HelpSection icon={Rocket} title="Launch and reuse rules">
+            <ol className="list-decimal space-y-1 pl-5">
+              <li>Create the slots with distinct names and role prompts.</li>
+              <li>Use Plan launch to confirm what will spawn or reuse.</li>
+              <li>Launch from Agent Teams so MCP, hooks, and tmux observation attach to the slot.</li>
+              <li>Use reuse only when the existing sessions already belong to the intended slots.</li>
+            </ol>
+          </HelpSection>
+
+          <HelpSection icon={BookOpen} title="After launch">
+            <p>
+              Use Agent Mail for the actual coordination. Agents should call <code>deck_whoami</code>
+              to confirm their slot identity, then use <code>deck_request_context</code>,
+              <code> deck_reply</code>, and handoffs to coordinate.
+            </p>
+          </HelpSection>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/features/agent-teams/AgentTeamsPage.tsx
+++ b/frontend/src/features/agent-teams/AgentTeamsPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   ArrowDown,
   ArrowUp,
+  BookOpen,
   Copy,
   Edit,
   GitBranch,
@@ -64,6 +65,7 @@ import {
 } from './api'
 import { fetchAgentMailTeam } from '@/features/agent-mail/api'
 import type { MailMemberResponse } from '@/types/agentMail'
+import { AgentTeamsHelpDialog } from './AgentTeamsHelpDialog'
 
 type PresetDialogState = 'new' | 'from-mail' | 'from-bridge' | null
 type SlotDialogState = { mode: 'add' | 'edit'; slot?: AgentTeamSlot } | null
@@ -555,6 +557,7 @@ export function AgentTeamsPage() {
   const [planLoading, setPlanLoading] = useState(false)
   const [launching, setLaunching] = useState(false)
   const [plannedSlotIds, setPlannedSlotIds] = useState<number[] | null>(null)
+  const [helpOpen, setHelpOpen] = useState(false)
 
   const selectedPreset = useMemo(
     () => presets.find((preset) => preset.id === selectedPresetId),
@@ -778,6 +781,10 @@ export function AgentTeamsPage() {
             <RefreshCw className={cn('mr-2 h-4 w-4', loading && 'animate-spin')} />
             Refresh
           </Button>
+          <Button variant="outline" onClick={() => setHelpOpen(true)}>
+            <BookOpen className="mr-2 h-4 w-4" />
+            How it works
+          </Button>
           <Button variant="outline" onClick={() => setPresetDialog('from-mail')}>
             <GitBranch className="mr-2 h-4 w-4" />
             From Mail
@@ -907,6 +914,14 @@ export function AgentTeamsPage() {
                 </div>
               </div>
 
+              <div className="rounded-lg border border-primary/30 bg-primary/5 p-4 text-sm text-muted-foreground">
+                <p>
+                  For same-repo planner/reviewer workflows, create separate slots with distinct
+                  names and launch them from this team. That gives Agent Mail separate inboxes and
+                  reliable routing for each role.
+                </p>
+              </div>
+
               <div className="space-y-3">
                 {selectedPreset.slots.length === 0 && (
                   <div className="rounded-lg border p-5 text-sm text-muted-foreground">
@@ -983,6 +998,7 @@ export function AgentTeamsPage() {
 
       <NewPresetDialog mode={presetDialog} onOpenChange={setPresetDialog} onCreate={createPreset} />
       <SlotDialog state={slotDialog} onOpenChange={setSlotDialog} onSave={saveSlot} />
+      <AgentTeamsHelpDialog open={helpOpen} onOpenChange={setHelpOpen} />
       <LaunchPlanDialog
         plan={plan}
         result={launchResult}

--- a/scripts/e2e-agent-mail-same-repo-codex.sh
+++ b/scripts/e2e-agent-mail-same-repo-codex.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+# End-to-end probe for two same-repo Codex agents communicating through Agent Mail.
+# The planner intentionally stops after requesting review, so success requires Deck
+# to wake it before it reads the reviewer feedback.
+#
+# Requirements:
+# - Claude Deck backend running on DECK_URL, default http://127.0.0.1:8000
+# - Codex Agent Mail MCP/hooks installed
+# - tmux, codex, curl, jq
+#
+# Usage:
+#   scripts/e2e-agent-mail-same-repo-codex.sh [/absolute/repo/path]
+#
+# Set KEEP_E2E_SESSIONS=1 to preserve tmux sessions and the Agent Team preset.
+
+set -euo pipefail
+
+DECK_URL="${DECK_URL:-http://127.0.0.1:8000}"
+REPO_PATH="${1:-$(pwd)}"
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-420}"
+KEEP_E2E_SESSIONS="${KEEP_E2E_SESSIONS:-0}"
+
+RUN_ID="$(date +%Y%m%d%H%M%S)"
+PRESET_NAME="E2E same-repo mail ${RUN_ID}"
+PLANNER="E2E Planner ${RUN_ID}"
+REVIEWER="E2E Reviewer ${RUN_ID}"
+SUBJECT="E2E plan review ${RUN_ID}"
+SUCCESS_TOKEN="E2E_AGENT_MAIL_ROUNDTRIP_${RUN_ID}"
+FEEDBACK_TOKEN="E2E_REVIEW_FEEDBACK_${RUN_ID}"
+WAITING_TOKEN="E2E_PLANNER_WAITING_FOR_NUDGE_${RUN_ID}"
+INBOX_NUDGE_PREFIX='Claude Deck Agent Mail: please call `deck_check_inbox'
+TMP_DIR="${TMPDIR:-/tmp}/claude-deck-agent-mail-e2e-${RUN_ID}"
+
+PRESET_ID=""
+PLANNER_ID=""
+REVIEWER_ID=""
+PASSED=0
+
+mkdir -p "$TMP_DIR"
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 2
+  fi
+}
+
+api() {
+  local method="$1"
+  local path="$2"
+  local body="${3:-}"
+  if [ -n "$body" ]; then
+    curl -fsS -X "$method" "${DECK_URL%/}/api/v1${path}" \
+      -H 'Content-Type: application/json' \
+      --data-binary "$body"
+  else
+    curl -fsS -X "$method" "${DECK_URL%/}/api/v1${path}"
+  fi
+}
+
+cleanup() {
+  if [ "$PASSED" -eq 1 ] && [ "$KEEP_E2E_SESSIONS" != "1" ]; then
+    if [ -f "$TMP_DIR/launch.json" ]; then
+      jq -r '.items[].session_name // empty' "$TMP_DIR/launch.json" | while IFS= read -r session; do
+        tmux kill-session -t "$session" 2>/dev/null || true
+      done
+    fi
+    if [ -n "$PRESET_ID" ]; then
+      api DELETE "/agent-teams/presets/${PRESET_ID}" >/dev/null 2>&1 || true
+    fi
+  else
+    echo "Preserved E2E artifacts in $TMP_DIR" >&2
+    if [ -f "$TMP_DIR/launch.json" ]; then
+      jq -r '.items[] | "tmux: " + (.tmux_target // "")' "$TMP_DIR/launch.json" >&2 || true
+    fi
+  fi
+}
+trap cleanup EXIT
+
+capture_pane() {
+  tmux capture-pane -t "$1" -p -S -260 2>/dev/null || true
+}
+
+approve_visible_prompts() {
+  local target pane
+  jq -r '.items[].tmux_target // empty' "$TMP_DIR/launch.json" | while IFS= read -r target; do
+    pane="$(capture_pane "$target")"
+    if printf '%s' "$pane" | rg -q 'Allow the claude-deck-mail MCP server to run tool'; then
+      tmux send-keys -t "$target" Down Enter
+      sleep 0.8
+    fi
+  done
+}
+
+load_member_ids() {
+  local team_json
+  team_json="$(api GET '/agent-mail/team?sync=true')"
+  PLANNER_ID="$(printf '%s' "$team_json" | jq -r --arg name "$PLANNER" '.members[] | select(.display_name == $name) | .id' | head -1)"
+  REVIEWER_ID="$(printf '%s' "$team_json" | jq -r --arg name "$REVIEWER" '.members[] | select(.display_name == $name) | .id' | head -1)"
+  [ -n "$PLANNER_ID" ] && [ "$PLANNER_ID" != "null" ] && [ -n "$REVIEWER_ID" ] && [ "$REVIEWER_ID" != "null" ]
+}
+
+slots_are_wakeable() {
+  api GET '/agent-mail/team?sync=true' |
+    jq -e --arg planner "$PLANNER" --arg reviewer "$REVIEWER" '
+      [.members[]
+       | select(.display_name == $planner or .display_name == $reviewer)
+       | select(.participant_kind == "team_slot")
+       | select(.status == "connected")
+       | select(.wake_state == "wakeable")
+       | select([.sessions[] | select(.source == "mcp" or .source == "hook" or .source == "observed")] | length >= 3)
+      ] | length == 2
+    ' >/dev/null
+}
+
+request_ids() {
+  api GET '/agent-mail/messages' |
+    jq -r --arg subject "$SUBJECT" --argjson reviewer_id "$REVIEWER_ID" '
+      .[]
+      | select(.kind == "context_request")
+      | select((.subject // "") | startswith($subject))
+      | select(.recipient_member_id == $reviewer_id)
+      | .id
+    '
+}
+
+thread_has_feedback() {
+  local request_id="$1"
+  api GET "/agent-mail/messages/${request_id}/thread" |
+    jq -e --arg feedback "$FEEDBACK_TOKEN" '
+      any(.replies[]?; .kind == "answer" and ((.body_markdown // "") | contains($feedback)))
+    ' >/dev/null
+}
+
+planner_target() {
+  jq -r --arg planner "$PLANNER" '.items[] | select(.slot_name == $planner) | .tmux_target' "$TMP_DIR/launch.json"
+}
+
+reviewer_target() {
+  jq -r --arg reviewer "$REVIEWER" '.items[] | select(.slot_name == $reviewer) | .tmux_target' "$TMP_DIR/launch.json"
+}
+
+planner_waiting_for_nudge() {
+  capture_pane "$(planner_target)" | rg -q "• ${WAITING_TOKEN}|^${WAITING_TOKEN}$"
+}
+
+planner_was_nudged() {
+  capture_pane "$(planner_target)" | rg -qF "$INBOX_NUDGE_PREFIX"
+}
+
+reviewer_was_nudged() {
+  capture_pane "$(reviewer_target)" | rg -qF "$INBOX_NUDGE_PREFIX"
+}
+
+planner_read_feedback() {
+  api GET "/agent-mail/agent/inbox?member_id=${PLANNER_ID}&unread_only=false&mark_read=false&limit=50" |
+    jq -e --arg feedback "$FEEDBACK_TOKEN" '
+      any(.messages[]?; .kind == "answer" and ((.body_markdown // "") | contains($feedback)) and .read_at != null)
+    ' >/dev/null
+}
+
+planner_printed_success() {
+  capture_pane "$(planner_target)" | rg -q "• ${SUCCESS_TOKEN}|^${SUCCESS_TOKEN}$"
+}
+
+print_status() {
+  echo "--- status $(date -Is) ---"
+  api GET '/agent-mail/team?sync=true' |
+    jq --arg planner "$PLANNER" --arg reviewer "$REVIEWER" '
+      [.members[]
+       | select(.display_name == $planner or .display_name == $reviewer)
+       | {
+           id,
+           display_name,
+           status,
+           wake_state,
+           wake_methods,
+           last_inbox_checked_at,
+           unread_count,
+           pending_count,
+           sessions: [.sessions[] | {source, tmux_target, team_slot_name, mailbox_status, last_seen_at}]
+         }]
+    '
+  if [ -n "$REVIEWER_ID" ] && [ "$REVIEWER_ID" != "null" ]; then
+    api GET '/agent-mail/messages' |
+      jq --arg subject "$SUBJECT" --argjson reviewer_id "$REVIEWER_ID" '
+        [.[] | select(((.subject // "") | startswith($subject)) or .recipient_member_id == $reviewer_id)
+         | {id, thread_root_id, kind, sender_name, recipient_member_id, subject, request_status, created_at}]
+      '
+  fi
+}
+
+require_command curl
+require_command jq
+require_command rg
+require_command tmux
+require_command codex
+
+if [ ! -d "$REPO_PATH" ]; then
+  echo "Repo path does not exist: $REPO_PATH" >&2
+  exit 2
+fi
+REPO_PATH="$(cd "$REPO_PATH" && pwd -P)"
+
+curl -fsS "${DECK_URL%/}/health" >/dev/null
+
+echo "Creating temporary Agent Team: $PRESET_NAME"
+payload="$(
+  jq -n \
+    --arg name "$PRESET_NAME" \
+    --arg repo "$REPO_PATH" \
+    --arg planner "$PLANNER" \
+    --arg reviewer "$REVIEWER" \
+    --arg subject "$SUBJECT" \
+    --arg success "$SUCCESS_TOKEN" \
+    --arg feedback "$FEEDBACK_TOKEN" \
+    --arg waiting "$WAITING_TOKEN" \
+    '{
+      name: $name,
+      description: "Temporary automated Agent Mail same-repo Codex E2E test",
+      created_by: "codex-e2e",
+      slots: [
+        {
+          display_name: $planner,
+          provider: "codex-cli",
+          repo_path: $repo,
+          role: "Planner",
+          charter: "Create a tiny plan, request review from the reviewer slot, then confirm when feedback is received.",
+          bootstrap_prompt: (
+            "You are the planner in an automated Claude Deck Agent Mail E2E test. " +
+            "First call deck_whoami and deck_list_team. Find the teammate named \"" + $reviewer + "\". " +
+            "Send deck_request_context to that teammate. The topic must start with \"" + $subject + "\" and include this tiny markdown plan:\n\n" +
+            "## Tiny Plan\n\n1. Confirm the planner and reviewer can exchange Agent Mail.\n2. Ask the reviewer to sanity-check this tiny plan.\n3. Report the reviewer feedback once received.\n\n" +
+            "Use why_needed \"Automated same-repo Agent Mail test\". " +
+            "After sending the request, do not call deck_check_inbox again in this turn. " +
+            "Print exactly " + $waiting + " and end your turn. " +
+            "When a later Claude Deck Agent Mail nudge prompt arrives in a new turn, call deck_check_inbox(unread_only=false), read the reviewer answer, then print exactly " + $success + " and summarize the feedback. " +
+            "Do not edit files."
+          ),
+          launch_mode: "plain",
+          launch_options: {approval_policy: "never", sandbox: "workspace-write", no_alt_screen: true},
+          enabled: true,
+          position: 0
+        },
+        {
+          display_name: $reviewer,
+          provider: "codex-cli",
+          repo_path: $repo,
+          role: "Reviewer",
+          charter: "Review planner requests and reply with concise feedback.",
+          bootstrap_prompt: (
+            "You are the reviewer in an automated Claude Deck Agent Mail E2E test. " +
+            "First call deck_whoami and deck_check_inbox(unread_only=false). " +
+            "If you receive a context request from \"" + $planner + "\" whose subject starts with \"" + $subject + "\", " +
+            "reply using deck_reply with this exact token in the body: " + $feedback + ". " +
+            "Include one concrete review comment. Do not edit files."
+          ),
+          launch_mode: "plain",
+          launch_options: {approval_policy: "never", sandbox: "workspace-write", no_alt_screen: true},
+          enabled: true,
+          position: 1
+        }
+      ]
+    }'
+)"
+
+api POST '/agent-teams/presets' "$payload" > "$TMP_DIR/preset.json"
+PRESET_ID="$(jq -r .id "$TMP_DIR/preset.json")"
+
+echo "Planning launch for preset $PRESET_ID"
+api POST "/agent-teams/presets/${PRESET_ID}/plan-launch" '{"reuse_existing":false}' > "$TMP_DIR/plan.json"
+jq -e '.can_launch == true and .spawn_count == 2 and .blocked_count == 0' "$TMP_DIR/plan.json" >/dev/null
+plan_hash="$(jq -r .plan_hash "$TMP_DIR/plan.json")"
+
+echo "Launching two Codex tmux sessions"
+launch_body="$(jq -n --arg hash "$plan_hash" '{requested_by:"codex-e2e", reuse_existing:false, confirm_plan_hash:$hash}')"
+api POST "/agent-teams/presets/${PRESET_ID}/launch" "$launch_body" > "$TMP_DIR/launch.json"
+jq '{launch_id,status,items:[.items[]|{slot_name,status,session_name,tmux_target}]}' "$TMP_DIR/launch.json"
+
+start="$(date +%s)"
+last_report=0
+while true; do
+  elapsed="$(($(date +%s) - start))"
+  approve_visible_prompts
+
+  if [ -z "$PLANNER_ID" ] || [ -z "$REVIEWER_ID" ]; then
+    load_member_ids || true
+  fi
+
+  if [ -n "$PLANNER_ID" ] && [ -n "$REVIEWER_ID" ]; then
+    if slots_are_wakeable; then
+      while IFS= read -r request_id; do
+        [ -n "$request_id" ] || continue
+        if thread_has_feedback "$request_id" &&
+          planner_waiting_for_nudge &&
+          reviewer_was_nudged &&
+          planner_was_nudged &&
+          planner_read_feedback &&
+          planner_printed_success; then
+          echo "PASS: same-repo Codex Agent Mail wakeability round-trip succeeded in ${elapsed}s"
+          echo "Planner: $PLANNER_ID ($PLANNER)"
+          echo "Reviewer: $REVIEWER_ID ($REVIEWER)"
+          echo "Planner waiting token: $WAITING_TOKEN"
+          echo "Feedback token: $FEEDBACK_TOKEN"
+          PASSED=1
+          exit 0
+        fi
+      done < <(request_ids)
+    fi
+  fi
+
+  if [ $((elapsed - last_report)) -ge 30 ]; then
+    print_status
+    last_report="$elapsed"
+  fi
+
+  if [ "$elapsed" -ge "$TIMEOUT_SECONDS" ]; then
+    echo "FAIL: timed out after ${elapsed}s waiting for same-repo Agent Mail round-trip" >&2
+    jq -r '.items[].tmux_target // empty' "$TMP_DIR/launch.json" | while IFS= read -r target; do
+      echo "--- $target" >&2
+      capture_pane "$target" | tail -220 >&2
+    done
+    exit 1
+  fi
+
+  sleep 2
+done


### PR DESCRIPTION
## Summary

Closes #224.

This fixes the same-repo planner/reviewer Agent Mail workflow for Agent Team slots. The intended behavior applies to Claude Code slots, Codex slots, and mixed-provider teams; the live reproduction and reusable E2E coverage use two Codex CLI slots.

Fixes included:

- Rebuild legacy SQLite `agent_team_slots` tables that still have `UNIQUE(preset_id, repo_id)`, preserving slot ids while allowing duplicate same-repo team slots.
- Infer Agent Team slot context for MCP and tmux-observed sessions using related process pids, so MCP, hooks, and observed sessions attach to the same member.
- Make `mail_team_members.identity_key` creation race-tolerant during concurrent hook/MCP startup.
- Register the Codex MCP shim with the parent Codex pid, increase local HTTP timeout tolerance, and make `deck_list_team` use the cached roster instead of forcing bridge sync.
- Add `scripts/e2e-agent-mail-same-repo-codex.sh`, which launches two Codex agents on the same repo and requires Deck nudges on both sides before passing.
- Add Agent Teams in-app guidance plus docs for UI users and external/agentic orchestrators explaining same-repo slot routing.

## Verification

- `cd backend && venv/bin/python3 -m pytest tests/agent_mail/test_registry.py tests/agent_mail/test_mcp_shim.py tests/agent_teams/test_agent_team_service.py tests/test_sqlite_compat_migrations.py`
- `bash -n scripts/e2e-agent-mail-same-repo-codex.sh`
- `git diff --check`
- `cd frontend && npm run build`
- `cd docs && npm run build`
- Live E2E: `TIMEOUT_SECONDS=420 scripts/e2e-agent-mail-same-repo-codex.sh /home/joni/repos/claude-deck`
  - Result: `PASS: same-repo Codex Agent Mail wakeability round-trip succeeded in 111s`
