### PR TITLE
Add Codex Bedrock platform launch

### DIFF
--- a/backend/app/services/agent_bridge/spawn.py
+++ b/backend/app/services/agent_bridge/spawn.py
@@ -69,6 +69,7 @@ def spawn_session(
         region=options.aws_region,
         aws_profile=options.aws_profile,
         model=options.bedrock_model,
+        provider_id=provider.id,
     )
     env_flags = _env_flags(platform_env)
     if extra_env:

--- a/backend/app/services/providers/codex_cli.py
+++ b/backend/app/services/providers/codex_cli.py
@@ -10,6 +10,10 @@ from app.services.providers.base import (
     argv0_name,
     has_binary_descendant,
 )
+from app.services.providers.platform_env import PLATFORM_BEDROCK
+
+
+CODEX_BEDROCK_MODEL_PROVIDER = 'model_provider="amazon-bedrock"'
 
 
 def get_codex_home() -> Path:
@@ -78,8 +82,16 @@ class CodexCliProvider(AgentProvider):
             raise ValueError(f"Unsupported Codex mode: {options.mode}")
 
         command = ["codex", "--cd", options.directory]
-        if options.model:
-            command += ["--model", options.model]
+        if options.platform == PLATFORM_BEDROCK:
+            command += ["--config", CODEX_BEDROCK_MODEL_PROVIDER]
+
+        effective_model = (
+            options.bedrock_model
+            if options.platform == PLATFORM_BEDROCK and options.bedrock_model
+            else options.model
+        )
+        if effective_model:
+            command += ["--model", effective_model]
         if options.profile:
             command += ["--profile", options.profile]
         if options.profile_v2:

--- a/backend/app/services/providers/platform_env.py
+++ b/backend/app/services/providers/platform_env.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 PLATFORM_ANTHROPIC = "anthropic"
 PLATFORM_BEDROCK = "bedrock"
+PROVIDER_CLAUDE_CODE = "claude-code"
+PROVIDER_CODEX_CLI = "codex-cli"
 
 
 def _clean(value: str | None) -> str | None:
@@ -27,18 +29,24 @@ def build_platform_env(
     region: str | None = None,
     aws_profile: str | None = None,
     model: str | None = None,
+    provider_id: str = PROVIDER_CLAUDE_CODE,
 ) -> dict[str, str]:
-    """Return the env vars for a platform selection (empty for Anthropic)."""
+    """Return non-secret env vars for a platform selection."""
     if platform != PLATFORM_BEDROCK:
         return {}
 
-    env: dict[str, str] = {"CLAUDE_CODE_USE_BEDROCK": "1"}
+    env: dict[str, str] = {}
     cleaned_region = _clean(region)
     if cleaned_region:
         env["AWS_REGION"] = cleaned_region
     cleaned_profile = _clean(aws_profile)
     if cleaned_profile:
         env["AWS_PROFILE"] = cleaned_profile
+
+    if provider_id == PROVIDER_CODEX_CLI:
+        return env
+
+    env = {"CLAUDE_CODE_USE_BEDROCK": "1", **env}
     cleaned_model = _clean(model)
     if cleaned_model:
         env["ANTHROPIC_MODEL"] = cleaned_model

--- a/backend/tests/test_agent_bridge_spawn.py
+++ b/backend/tests/test_agent_bridge_spawn.py
@@ -1,5 +1,6 @@
 """Tests for provider-aware tmux spawning."""
 import json
+import shlex
 from types import SimpleNamespace
 
 
@@ -101,6 +102,46 @@ def test_bedrock_platform_injects_env_flags(monkeypatch, tmp_path):
     assert "CLAUDE_CODE_USE_BEDROCK=1" in argv
     assert "AWS_REGION=us-east-1" in argv
     assert "AWS_PROFILE=bedrock-prod" in argv
+    assert spawn.get_spawned_sessions()["repo-abcd"]["platform"] == "bedrock"
+
+
+def test_codex_bedrock_platform_sets_config_override_and_aws_env(monkeypatch, tmp_path):
+    from app.services.agent_bridge import spawn
+    from app.services.providers.base import SpawnCommandOptions
+
+    calls = []
+
+    def fake_run(args, capture_output=True, text=True, timeout=10):
+        calls.append(args)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(spawn, "_session_name_for", lambda directory: "repo-abcd")
+    monkeypatch.setattr(spawn.subprocess, "run", fake_run)
+    spawn.get_spawned_sessions().clear()
+
+    spawn.spawn_session(
+        "codex-cli",
+        SpawnCommandOptions(
+            directory=str(tmp_path),
+            mode="plain",
+            platform="bedrock",
+            aws_region="us-east-2",
+            aws_profile="codex-bedrock",
+            bedrock_model="openai.gpt-5.5",
+        ),
+    )
+
+    argv = calls[0]
+    assert argv[:7] == ["tmux", "new-session", "-d", "-s", "repo-abcd", "-c", str(tmp_path)]
+    assert "AWS_REGION=us-east-2" in argv
+    assert "AWS_PROFILE=codex-bedrock" in argv
+    assert "CLAUDE_CODE_USE_BEDROCK=1" not in argv
+    assert "ANTHROPIC_MODEL=openai.gpt-5.5" not in argv
+
+    command_parts = shlex.split(argv[-1])
+    assert command_parts[:3] == ["codex", "--cd", str(tmp_path)]
+    assert command_parts[command_parts.index("--config") + 1] == 'model_provider="amazon-bedrock"'
+    assert command_parts[command_parts.index("--model") + 1] == "openai.gpt-5.5"
     assert spawn.get_spawned_sessions()["repo-abcd"]["platform"] == "bedrock"
 
 

--- a/backend/tests/test_platform_env.py
+++ b/backend/tests/test_platform_env.py
@@ -63,3 +63,26 @@ def test_bedrock_rejects_null_byte_in_value():
 
     with pytest.raises(ValueError):
         build_platform_env(PLATFORM_BEDROCK, model="bad\x00value")
+
+
+def test_codex_bedrock_only_sets_shared_aws_env():
+    from app.services.providers.platform_env import build_platform_env, PLATFORM_BEDROCK
+
+    env = build_platform_env(
+        PLATFORM_BEDROCK,
+        region="us-east-2",
+        aws_profile="codex-bedrock",
+        model="openai.gpt-5.5",
+        provider_id="codex-cli",
+    )
+
+    assert env == {
+        "AWS_REGION": "us-east-2",
+        "AWS_PROFILE": "codex-bedrock",
+    }
+
+
+def test_codex_bedrock_without_region_or_profile_has_no_env():
+    from app.services.providers.platform_env import build_platform_env, PLATFORM_BEDROCK
+
+    assert build_platform_env(PLATFORM_BEDROCK, provider_id="codex-cli") == {}

--- a/docs/api/agent-bridge.md
+++ b/docs/api/agent-bridge.md
@@ -85,6 +85,22 @@ Codex example:
 }
 ```
 
+Codex on Amazon Bedrock:
+
+```json
+{
+  "provider": "codex-cli",
+  "directory": "/home/user/repo",
+  "mode": "plain",
+  "platform": "bedrock",
+  "aws_region": "us-east-2",
+  "aws_profile": "bedrock-prod",
+  "bedrock_model": "openai.gpt-5.5"
+}
+```
+
+When `platform` is `bedrock` for Codex, Agent Bridge launches Codex with `model_provider = "amazon-bedrock"` as a per-session config override. `aws_region` and `aws_profile` are optional non-secret environment hints; AWS credentials must already be available to the spawned process through the environment or AWS SDK credential chain.
+
 ### Delete Session
 
 ```http

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 All notable changes to Claude Deck are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## Unreleased
+
+### Added
+
+- Agent Bridge can launch Codex CLI sessions on Amazon Bedrock with a provider-aware platform selector, a per-session Codex `model_provider = "amazon-bedrock"` override, and optional AWS region/profile/model fields.
+
 ## 2.0.1 — 2026-06-20
 
 ### Added

--- a/docs/features/agent-bridge.md
+++ b/docs/features/agent-bridge.md
@@ -42,6 +42,13 @@ Codex CLI supports:
 
 Dangerous Codex bypass mode is exposed as an explicit advanced option because it disables approval and sandbox protections.
 
+Both providers support a launch-time platform choice:
+
+- Claude Code: Anthropic or Amazon Bedrock
+- Codex CLI: OpenAI or Amazon Bedrock
+
+For Codex Bedrock sessions, Deck passes a per-session Codex config override for `model_provider = "amazon-bedrock"`. Optional AWS region and profile values are passed as process environment variables. Deck does not collect AWS secret keys or Bedrock bearer tokens; Codex resolves credentials from the existing shell environment or AWS SDK credential chain.
+
 ## Compatibility
 
 The frontend route `/agent-bridge` is the primary route. `/cc-bridge` remains as a compatibility alias.

--- a/frontend/src/features/cc-bridge/NewSessionDialog.tsx
+++ b/frontend/src/features/cc-bridge/NewSessionDialog.tsx
@@ -154,6 +154,13 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
   const { listSessions } = useSessionsApi()
   const { projects, activeProject } = useProjectContext()
   const isCodex = provider === 'codex-cli'
+  const isBedrock = platform === 'bedrock'
+  const defaultPlatformLabel = isCodex ? 'OpenAI' : 'Anthropic'
+  const bedrockHelpText = isCodex
+    ? 'Codex uses Amazon Bedrock for this session. Credentials resolve from your shell or AWS config.'
+    : 'Uses AWS credentials from the server environment. Region is usually required.'
+  const bedrockModelLabel = isCodex ? 'Bedrock model ID (optional)' : 'Model ARN / ID (optional)'
+  const bedrockModelPlaceholder = isCodex ? 'openai.gpt-5.5' : 'arn:aws:bedrock:...'
   const modeOptions = isCodex ? CODEX_MODE_OPTIONS : MODE_OPTIONS
   const filteredProjects = useMemo(
     () => projects.filter((project) => matchesProjectSearch(project, projectSearch)),
@@ -352,12 +359,11 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
     setSubmitting(true)
 
     try {
-      const isBedrock = !isCodex && platform === 'bedrock'
       try {
         localStorage.setItem(
           PLATFORM_STORAGE_KEY,
           JSON.stringify({
-            platform: isCodex ? 'anthropic' : platform,
+            platform,
             aws_region: awsRegion,
             aws_profile: awsProfile,
             bedrock_model: bedrockModel,
@@ -377,7 +383,7 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
         }),
         ...(provider === 'claude-code' && skipPermissions && { skip_permissions: true }),
         ...(isCodex && prompt.trim() && { prompt: prompt.trim() }),
-        ...(isCodex && model.trim() && { model: model.trim() }),
+        ...(isCodex && !isBedrock && model.trim() && { model: model.trim() }),
         ...(isCodex && profile.trim() && { profile: profile.trim() }),
         ...(isCodex && sandbox && { sandbox }),
         ...(isCodex && approvalPolicy && { approval_policy: approvalPolicy }),
@@ -539,6 +545,39 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
             />
           </div>
 
+          <div className="space-y-1.5">
+            <Label>Platform</Label>
+            <Select value={platform} onValueChange={(value) => setPlatform(value as Platform)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="anthropic">{defaultPlatformLabel} (default)</SelectItem>
+                <SelectItem value="bedrock">Amazon Bedrock</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {isBedrock && (
+            <div className="space-y-3 rounded-md border border-border p-3">
+              <p className="text-xs text-muted-foreground">
+                {bedrockHelpText}
+              </p>
+              <div className="space-y-1.5">
+                <Label htmlFor="aws-region">AWS Region</Label>
+                <Input id="aws-region" value={awsRegion} onChange={(e) => setAwsRegion(e.target.value)} placeholder="e.g. us-east-1" />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="aws-profile">AWS Profile (optional)</Label>
+                <Input id="aws-profile" value={awsProfile} onChange={(e) => setAwsProfile(e.target.value)} placeholder="e.g. bedrock-prod" />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="bedrock-model">{bedrockModelLabel}</Label>
+                <Input id="bedrock-model" value={bedrockModel} onChange={(e) => setBedrockModel(e.target.value)} placeholder={bedrockModelPlaceholder} />
+              </div>
+            </div>
+          )}
+
           {/* Worktree name (only in worktree mode) */}
           {!isCodex && mode === 'worktree' && (
             <div className="space-y-1.5">
@@ -629,33 +668,35 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
 
           {isCodex && (
             <div className="grid grid-cols-2 gap-3">
-              <div className="space-y-1.5">
-                <Label htmlFor="codex-model">Model</Label>
-                <Select value={modelSelectValue} onValueChange={handleModelSelect}>
-                  <SelectTrigger id="codex-model">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value={DEFAULT_SELECT_VALUE}>{defaultModelLabel}</SelectItem>
-                    {modelOptions.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {formatModelOption(option)}
-                      </SelectItem>
-                    ))}
-                    <SelectItem value={CUSTOM_SELECT_VALUE}>Custom model</SelectItem>
-                  </SelectContent>
-                </Select>
-                {modelSelectValue === CUSTOM_SELECT_VALUE && (
-                  <Input
-                    id="codex-model-custom"
-                    value={model}
-                    onChange={(event) => setModel(event.target.value)}
-                    placeholder="model name"
-                    autoComplete="off"
-                    aria-label="Custom Codex model"
-                  />
-                )}
-              </div>
+              {!isBedrock && (
+                <div className="space-y-1.5">
+                  <Label htmlFor="codex-model">Model</Label>
+                  <Select value={modelSelectValue} onValueChange={handleModelSelect}>
+                    <SelectTrigger id="codex-model">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={DEFAULT_SELECT_VALUE}>{defaultModelLabel}</SelectItem>
+                      {modelOptions.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {formatModelOption(option)}
+                        </SelectItem>
+                      ))}
+                      <SelectItem value={CUSTOM_SELECT_VALUE}>Custom model</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  {modelSelectValue === CUSTOM_SELECT_VALUE && (
+                    <Input
+                      id="codex-model-custom"
+                      value={model}
+                      onChange={(event) => setModel(event.target.value)}
+                      placeholder="model name"
+                      autoComplete="off"
+                      aria-label="Custom Codex model"
+                    />
+                  )}
+                </div>
+              )}
               <div className="space-y-1.5">
                 <Label htmlFor="codex-profile">Profile</Label>
                 <Select value={profileSelectValue} onValueChange={handleProfileSelect}>
@@ -716,41 +757,6 @@ export function NewSessionDialog({ open, onOpenChange, onSpawned, initialProvide
               <div className="col-span-2 space-y-1.5">
                 <Label htmlFor="codex-prompt">Initial Prompt</Label>
                 <Input id="codex-prompt" value={prompt} onChange={(e) => setPrompt(e.target.value)} placeholder="Optional prompt" />
-              </div>
-            </div>
-          )}
-
-          {!isCodex && (
-            <div className="space-y-1.5">
-              <Label>Platform</Label>
-              <Select value={platform} onValueChange={(value) => setPlatform(value as Platform)}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="anthropic">Anthropic (default)</SelectItem>
-                  <SelectItem value="bedrock">Amazon Bedrock</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          )}
-
-          {!isCodex && platform === 'bedrock' && (
-            <div className="space-y-3 rounded-md border border-border p-3">
-              <p className="text-xs text-muted-foreground">
-                Uses AWS credentials from the server environment. Region is usually required.
-              </p>
-              <div className="space-y-1.5">
-                <Label htmlFor="aws-region">AWS Region</Label>
-                <Input id="aws-region" value={awsRegion} onChange={(e) => setAwsRegion(e.target.value)} placeholder="e.g. us-east-1" />
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="aws-profile">AWS Profile (optional)</Label>
-                <Input id="aws-profile" value={awsProfile} onChange={(e) => setAwsProfile(e.target.value)} placeholder="e.g. bedrock-prod" />
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="bedrock-model">Model ARN / ID (optional)</Label>
-                <Input id="bedrock-model" value={bedrockModel} onChange={(e) => setBedrockModel(e.target.value)} placeholder="arn:aws:bedrock:..." />
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary

- Adds provider-aware Bedrock launch behavior for Codex CLI sessions.
- Launches Codex with a per-session `model_provider = "amazon-bedrock"` config override when `platform=bedrock`.
- Passes optional AWS region/profile to Codex without injecting Claude-Code-only Bedrock env vars.
- Updates the New Agent Session dialog to show OpenAI/Amazon Bedrock for Codex and Anthropic/Amazon Bedrock for Claude Code.
- Documents Codex Bedrock spawn behavior and credential expectations.

Closes #226.

## Verification

- `cd backend && venv/bin/python3 -m pytest tests/test_platform_env.py tests/test_agent_bridge_spawn.py`
- `cd backend && venv/bin/python3 -m pytest tests/test_multi_provider_smoke.py`
- `cd backend && venv/bin/python3 -m pytest`
- `cd frontend && npm run build`
