### PR TITLE
Block unsafe Codex resume-last Agent Team launches

### DIFF
--- a/backend/app/api/v1/agent_mail.py
+++ b/backend/app/api/v1/agent_mail.py
@@ -159,6 +159,9 @@ def _hook_session_key(payload: dict) -> Optional[str]:
         return None
     provider = _hook_provider(payload)
     prefix = "cc" if provider == "claude-code" else "codex"
+    team_slot_id = _payload_int(payload, "team_slot_id")
+    if team_slot_id is not None:
+        return f"{prefix}:{session_id}:team-slot:{team_slot_id}"
     return f"{prefix}:{session_id}"
 
 

--- a/backend/app/services/agent_team_service.py
+++ b/backend/app/services/agent_team_service.py
@@ -389,6 +389,7 @@ class AgentTeamService:
         discovered = self._discover_sessions()
         install_status = await agent_mail_install_service.get_install_status()
         reuse_group_counts = self._reuse_group_counts(slots)
+        unsafe_resume_last_slot_ids = self._unsafe_codex_resume_last_slot_ids(slots)
 
         items: list[AgentTeamLaunchPlanItem] = []
         used_matching_sessions: set[str] = set()
@@ -404,7 +405,16 @@ class AgentTeamService:
                 if request.reuse_existing and slot.enabled
                 else None
             )
-            item = self._plan_slot(slot, matching, install_status)
+            item = self._plan_slot(
+                slot,
+                matching,
+                install_status,
+                unsafe_spawn_reason=(
+                    self._codex_resume_last_block_reason()
+                    if matching is None and slot.id in unsafe_resume_last_slot_ids
+                    else None
+                ),
+            )
             items.append(item)
 
         plan_hash = self._plan_hash(preset, slots, items)
@@ -603,6 +613,8 @@ class AgentTeamService:
         slot: AgentTeamSlot,
         matching_session: dict[str, Any] | None,
         install_status: Any,
+        *,
+        unsafe_spawn_reason: str | None = None,
     ) -> AgentTeamLaunchPlanItem:
         if not slot.enabled:
             return AgentTeamLaunchPlanItem(
@@ -646,6 +658,10 @@ class AgentTeamService:
                 reasons=["A matching running session is already available"],
                 matching_session=matching_session,
             )
+
+        if block_code is None and unsafe_spawn_reason:
+            reasons.append(unsafe_spawn_reason)
+            block_code = "unsafe_codex_resume_last"
 
         if block_code is None:
             validation_error = self._validate_spawn_options(slot)
@@ -696,6 +712,40 @@ class AgentTeamService:
                 return "Codex Agent Mail hooks are missing"
             return None
         return None
+
+    def _unsafe_codex_resume_last_slot_ids(self, slots: list[AgentTeamSlot]) -> set[int]:
+        groups: dict[tuple[str, str], list[AgentTeamSlot]] = {}
+        for slot in slots:
+            if not slot.enabled or not self._is_codex_resume_last_slot(slot):
+                continue
+            key = (slot.provider, slot.repo_id)
+            groups.setdefault(key, []).append(slot)
+        return {
+            slot.id
+            for grouped_slots in groups.values()
+            if len(grouped_slots) > 1
+            for slot in grouped_slots
+        }
+
+    def _is_codex_resume_last_slot(self, slot: AgentTeamSlot) -> bool:
+        if slot.provider != "codex-cli":
+            return False
+        if (slot.launch_mode or "plain").strip() != "resume":
+            return False
+        return self._truthy_launch_option((slot.launch_options or {}).get("use_last"))
+
+    def _truthy_launch_option(self, value: Any) -> bool:
+        if value is True:
+            return True
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        return False
+
+    def _codex_resume_last_block_reason(self) -> str:
+        return (
+            "Codex resume --last cannot be used for multiple same-repo team slots. "
+            "Use fresh/plain sessions, or provide a distinct session_id per slot."
+        )
 
     async def _fallback_provider(self) -> str:
         install_status = await agent_mail_install_service.get_install_status()

--- a/backend/tests/agent_mail/test_hooks_api.py
+++ b/backend/tests/agent_mail/test_hooks_api.py
@@ -2,12 +2,14 @@
 import httpx
 import pytest
 import pytest_asyncio
+from sqlalchemy import select
 
 from app.database import get_db
 from app.main import app
-from app.models.database import MailTeamMember
+from app.models.database import AgentTeamPreset, AgentTeamSlot, MailAgentSession, MailTeamMember
 from app.models.schemas import MailMessageCreate
 from app.services.agent_mail_service import agent_mail_service
+from app.utils.repo_utils import derive_repo_identity
 
 
 @pytest_asyncio.fixture
@@ -58,6 +60,64 @@ async def test_codex_hook_registers_with_codex_session_key(client, db, tmp_path)
     team = await agent_mail_service.list_team(db)
     assert team[0].sessions[0].provider == "codex-cli"
     assert team[0].sessions[0].session_key == "codex:codex-session"
+
+
+@pytest.mark.asyncio
+async def test_codex_hook_session_key_is_team_slot_qualified(client, db, tmp_path):
+    cwd = tmp_path / "myrepo"
+    cwd.mkdir()
+    ident = derive_repo_identity(str(cwd))
+    preset = AgentTeamPreset(name="Same repo team")
+    db.add(preset)
+    await db.flush()
+    planner = AgentTeamSlot(
+        preset_id=preset.id,
+        position=0,
+        display_name="Planner",
+        provider="codex-cli",
+        repo_id=ident["repo_id"],
+        repo_path=ident["repo_root"],
+        repo_name=ident["repo_name"],
+    )
+    implementer = AgentTeamSlot(
+        preset_id=preset.id,
+        position=1,
+        display_name="Implementer",
+        provider="codex-cli",
+        repo_id=ident["repo_id"],
+        repo_path=ident["repo_root"],
+        repo_name=ident["repo_name"],
+    )
+    db.add_all([planner, implementer])
+    await db.commit()
+    await db.refresh(preset)
+    await db.refresh(planner)
+    await db.refresh(implementer)
+
+    for slot in (planner, implementer):
+        resp = await client.post(
+            "/api/v1/agent-mail/hooks/session-start",
+            json={
+                "provider": "codex-cli",
+                "session_id": "shared-resumed-session",
+                "cwd": str(cwd),
+                "pid": 123,
+                "team_preset_id": preset.id,
+                "team_slot_id": slot.id,
+            },
+        )
+        assert resp.status_code == 200
+
+    sessions = (
+        await db.execute(
+            select(MailAgentSession).order_by(MailAgentSession.session_key.asc())
+        )
+    ).scalars().all()
+    assert {session.session_key for session in sessions} == {
+        f"codex:shared-resumed-session:team-slot:{planner.id}",
+        f"codex:shared-resumed-session:team-slot:{implementer.id}",
+    }
+    assert {session.team_slot_id for session in sessions} == {planner.id, implementer.id}
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_teams/test_agent_team_service.py
+++ b/backend/tests/agent_teams/test_agent_team_service.py
@@ -112,6 +112,84 @@ async def test_duplicate_enabled_repo_slots_are_allowed(db, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_multiple_same_repo_codex_resume_last_slots_are_blocked(db, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    preset = await agent_team_service.create_preset(
+        db,
+        AgentTeamPresetCreate(
+            name="Project team",
+            slots=[
+                AgentTeamSlotCreate(
+                    display_name="Planner",
+                    provider="codex-cli",
+                    repo_path=str(repo),
+                    launch_mode="resume",
+                    launch_options={"use_last": True},
+                ),
+                AgentTeamSlotCreate(
+                    display_name="Implementer",
+                    provider="codex-cli",
+                    repo_path=str(repo),
+                    launch_mode="resume",
+                    launch_options={"use_last": True},
+                ),
+            ],
+        ),
+    )
+
+    plan = await agent_team_service.plan_launch(
+        db,
+        preset.id,
+        AgentTeamLaunchRequest(reuse_existing=False),
+    )
+
+    assert plan.can_launch is False
+    assert plan.spawn_count == 0
+    assert plan.blocked_count == 2
+    assert {item.block_code for item in plan.items} == {"unsafe_codex_resume_last"}
+    assert all("resume --last cannot be used" in item.reasons[0] for item in plan.items)
+
+
+@pytest.mark.asyncio
+async def test_explicit_same_repo_codex_resume_sessions_are_allowed(db, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    preset = await agent_team_service.create_preset(
+        db,
+        AgentTeamPresetCreate(
+            name="Project team",
+            slots=[
+                AgentTeamSlotCreate(
+                    display_name="Planner",
+                    provider="codex-cli",
+                    repo_path=str(repo),
+                    launch_mode="resume",
+                    launch_options={"use_last": False, "session_id": "planner-session"},
+                ),
+                AgentTeamSlotCreate(
+                    display_name="Implementer",
+                    provider="codex-cli",
+                    repo_path=str(repo),
+                    launch_mode="resume",
+                    launch_options={"use_last": False, "session_id": "implementer-session"},
+                ),
+            ],
+        ),
+    )
+
+    plan = await agent_team_service.plan_launch(
+        db,
+        preset.id,
+        AgentTeamLaunchRequest(reuse_existing=False),
+    )
+
+    assert plan.can_launch is True
+    assert plan.spawn_count == 2
+    assert plan.blocked_count == 0
+
+
+@pytest.mark.asyncio
 async def test_blank_repo_path_is_rejected(db):
     with pytest.raises(ValueError, match="Repo path is required"):
         await agent_team_service.create_preset(

--- a/docs/api/agent-teams.md
+++ b/docs/api/agent-teams.md
@@ -87,7 +87,9 @@ POST /api/v1/agent-teams/presets/{preset_id}/plan-launch
 }
 ```
 
-The plan checks provider availability, Agent Mail MCP/hooks readiness, reusable Agent Bridge sessions, disabled slots, and launch-option validity.
+The plan checks provider availability, Agent Mail MCP/hooks readiness, reusable Agent Bridge sessions, disabled slots, launch-option validity, and unsafe launch combinations.
+
+For Codex CLI slots, `resume` with `use_last: true` is blocked when multiple enabled slots target the same repository and would need to spawn. Use `plain` for fresh agents, or provide a distinct `session_id` per slot.
 
 ### Launch
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ All notable changes to Claude Deck are documented here. The format follows [Keep
 
 - Agent Bridge can launch Codex CLI sessions on Amazon Bedrock with a provider-aware platform selector, a per-session Codex `model_provider = "amazon-bedrock"` override, and optional AWS region/profile/model fields.
 
+### Fixed
+
+- Agent Teams now blocks unsafe multi-slot Codex `resume --last` launches in the same repository and keeps Codex hook session keys distinct per team slot.
+
 ## 2.0.1 — 2026-06-20
 
 ### Added

--- a/docs/features/agent-teams.md
+++ b/docs/features/agent-teams.md
@@ -47,8 +47,11 @@ Before launch, Claude Deck computes a plan. The plan checks:
 - live Agent Bridge tmux sessions that can be reused
 - disabled slots
 - provider launch option validity
+- unsafe launch combinations, such as multiple same-repo Codex slots using `resume --last`
 
 By default, launch only includes enabled slots and only reuses wakeable sessions observed through Agent Bridge. Connected non-tmux Agent Mail sessions can still communicate, but they are not reliable team launch/reuse targets.
+
+For same-repo Codex teams, prefer fresh sessions (`plain`) or explicit `resume` session ids per slot. Do not use `resume --last` for more than one slot in the same repo: each slot can resume the same Codex conversation and lose the role-specific team boundary.
 
 ## External Local Agents
 


### PR DESCRIPTION
## Summary

- Blocks Agent Team launch plans when multiple enabled same-repo Codex slots would spawn with `resume --last`.
- Allows same-repo Codex resume when slots use explicit distinct `session_id` values instead of `use_last`.
- Qualifies Codex hook session keys with `team-slot:<slot_id>` when team slot context is present, preventing different slots from sharing a hook session key when Codex reports the same resumed session id.
- Documents the same-repo Codex team launch rule.

Closes #228.

## Verification

- `cd backend && venv/bin/python3 -m pytest tests/agent_teams/test_agent_team_service.py tests/agent_mail/test_hooks_api.py`
- `cd backend && venv/bin/python3 -m pytest`
