### PR TITLE
Fix generic project discovery

### DIFF
--- a/backend/app/api/v1/projects.py
+++ b/backend/app/api/v1/projects.py
@@ -43,7 +43,7 @@ async def discover_projects(
     request: ProjectDiscoveryRequest,
     db: AsyncSession = Depends(get_db)
 ):
-    """Auto-discover Claude Code projects in the specified path."""
+    """Auto-discover project folders in the specified path."""
     service = ProjectService(db)
     discovered = service.discover_projects(request.base_path)
     return ProjectDiscoveryResponse(discovered=discovered)

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -1,5 +1,4 @@
-"""Project management service for discovering and managing Claude Code projects."""
-import os
+"""Project management service for discovering and managing local projects."""
 from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
@@ -18,7 +17,7 @@ from app.utils.path_utils import (
 
 
 class ProjectService:
-    """Service for managing Claude Code projects."""
+    """Service for managing local projects."""
 
     def __init__(self, db: AsyncSession):
         """Initialize the project service."""
@@ -103,12 +102,13 @@ class ProjectService:
 
     def discover_projects(self, base_path: str) -> List[ProjectBase]:
         """
-        Scan a directory for Claude Code projects.
+        Scan a directory for project candidates.
 
-        A project is identified by the presence of:
+        Claude Code metadata is preserved when present:
         - .claude/ directory (source="configured")
         - .mcp.json file (source="configured")
         - A matching entry in ~/.claude/projects/ (source="session_history")
+        Otherwise, regular directories are returned with source="directory".
         """
         discovered = []
         discovered_paths: set[str] = set()
@@ -116,6 +116,19 @@ class ProjectService:
 
         if not base_dir.exists() or not base_dir.is_dir():
             return []
+
+        def add_discovered(directory: Path, source: str) -> None:
+            dir_str = str(directory)
+            if dir_str in discovered_paths:
+                return
+            discovered.append(
+                ProjectBase(
+                    name=directory.name,
+                    path=dir_str,
+                    source=source,
+                )
+            )
+            discovered_paths.add(dir_str)
 
         # Scan the base directory and its immediate subdirectories
         dirs_to_check = [base_dir]
@@ -135,15 +148,7 @@ class ProjectService:
                 mcp_file = get_project_mcp_config_file(str(directory))
 
                 if claude_dir.exists() or mcp_file.exists():
-                    project_name = directory.name
-                    discovered.append(
-                        ProjectBase(
-                            name=project_name,
-                            path=str(directory),
-                            source="configured",
-                        )
-                    )
-                    discovered_paths.add(str(directory))
+                    add_discovered(directory, "configured")
             except (PermissionError, OSError):
                 continue
 
@@ -164,15 +169,13 @@ class ProjectService:
 
                     encoded = convert_path_to_folder_name(dir_str)
                     if encoded in global_entries:
-                        discovered.append(
-                            ProjectBase(
-                                name=directory.name,
-                                path=dir_str,
-                                source="session_history",
-                            )
-                        )
+                        add_discovered(directory, "session_history")
         except (PermissionError, OSError):
             pass
+
+        # Phase 3: Include ordinary folders so projects are provider-agnostic.
+        for directory in dirs_to_check:
+            add_discovered(directory, "directory")
 
         return discovered
 

--- a/backend/tests/test_project_service.py
+++ b/backend/tests/test_project_service.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+
+def test_discover_projects_includes_plain_directory(tmp_path):
+    from app.services.project_service import ProjectService
+
+    project_dir = tmp_path / "regular-project"
+    project_dir.mkdir()
+
+    discovered = ProjectService(db=None).discover_projects(str(project_dir))
+
+    assert [(project.name, project.path, project.source) for project in discovered] == [
+        ("regular-project", str(project_dir), "directory")
+    ]
+
+
+def test_discover_projects_includes_plain_child_directories(tmp_path):
+    from app.services.project_service import ProjectService
+
+    child = tmp_path / "child-project"
+    hidden = tmp_path / ".hidden-project"
+    child.mkdir()
+    hidden.mkdir()
+
+    discovered = ProjectService(db=None).discover_projects(str(tmp_path))
+    by_path = {project.path: project for project in discovered}
+
+    assert str(tmp_path) in by_path
+    assert by_path[str(tmp_path)].source == "directory"
+    assert str(child) in by_path
+    assert by_path[str(child)].source == "directory"
+    assert str(hidden) not in by_path
+
+
+def test_discover_projects_preserves_configured_source_without_duplicates(tmp_path):
+    from app.services.project_service import ProjectService
+
+    project_dir = tmp_path / "configured-project"
+    (project_dir / ".claude").mkdir(parents=True)
+
+    discovered = ProjectService(db=None).discover_projects(str(project_dir))
+    matching = [project for project in discovered if Path(project.path) == project_dir]
+
+    assert len(matching) == 1
+    assert matching[0].source == "configured"
+
+
+def test_discover_projects_preserves_session_history_source(monkeypatch, tmp_path):
+    from app.services import project_service
+    from app.services.project_service import ProjectService
+    from app.utils.path_utils import convert_path_to_folder_name
+
+    project_dir = tmp_path / "history-project"
+    project_dir.mkdir()
+    claude_projects_dir = tmp_path / "claude-projects"
+    claude_projects_dir.mkdir()
+    (claude_projects_dir / convert_path_to_folder_name(str(project_dir))).mkdir()
+    monkeypatch.setattr(project_service, "get_claude_projects_dir", lambda: claude_projects_dir)
+
+    discovered = ProjectService(db=None).discover_projects(str(project_dir))
+    matching = [project for project in discovered if Path(project.path) == project_dir]
+
+    assert len(matching) == 1
+    assert matching[0].source == "session_history"

--- a/frontend/src/features/projects/ProjectDiscovery.tsx
+++ b/frontend/src/features/projects/ProjectDiscovery.tsx
@@ -1,13 +1,14 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useProjectContext } from '@/contexts/ProjectContext';
 import type { ProjectBase } from '@/types/projects';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { Folder, FolderOpen, ChevronRight, ArrowLeft } from 'lucide-react';
+import { Folder, FolderOpen, ChevronRight, ArrowLeft, Search } from 'lucide-react';
 import { apiClient } from '@/lib/api';
 import { MODAL_SIZES } from '@/lib/constants';
 
@@ -41,6 +42,14 @@ export function ProjectDiscovery({ onProjectsDiscovered }: ProjectDiscoveryProps
   const [browseResult, setBrowseResult] = useState<BrowseResult | null>(null);
   const [browseLoading, setBrowseLoading] = useState(false);
   const [browseError, setBrowseError] = useState<string | null>(null);
+  const [directoryFilter, setDirectoryFilter] = useState('');
+
+  const filteredDirectories = useMemo(() => {
+    if (!browseResult) return [];
+    const query = directoryFilter.trim().toLowerCase();
+    if (!query) return browseResult.directories;
+    return browseResult.directories.filter((dir) => dir.toLowerCase().includes(query));
+  }, [browseResult, directoryFilter]);
 
   const handleDiscover = async () => {
     if (!searchPath.trim()) {
@@ -53,7 +62,7 @@ export function ProjectDiscovery({ onProjectsDiscovered }: ProjectDiscoveryProps
       const discovered = await discoverProjects(searchPath);
       setDiscoveredProjects(discovered);
       if (discovered.length === 0) {
-        setError('No Claude Code projects found in this directory');
+        setError('No project folders found in this directory');
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to discover projects');
@@ -89,6 +98,7 @@ export function ProjectDiscovery({ onProjectsDiscovered }: ProjectDiscoveryProps
         `projects/browse?path=${encodeURIComponent(path)}`
       );
       setBrowseResult(result);
+      setDirectoryFilter('');
     } catch (err) {
       setBrowseError(err instanceof Error ? err.message : 'Failed to read directory');
     } finally {
@@ -113,7 +123,7 @@ export function ProjectDiscovery({ onProjectsDiscovered }: ProjectDiscoveryProps
       <CardHeader>
         <CardTitle>Discover Projects</CardTitle>
         <CardDescription>
-          Enter a directory path to scan for Claude Code projects
+          Enter a directory path to find project folders
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -167,6 +177,8 @@ export function ProjectDiscovery({ onProjectsDiscovered }: ProjectDiscoveryProps
                             <Badge variant="outline" className="border-green-500 text-green-600">Configured</Badge>
                           ) : project.source === "session_history" ? (
                             <Badge variant="outline" className="border-blue-500 text-blue-600">Session History</Badge>
+                          ) : project.source === "directory" ? (
+                            <Badge variant="outline">Folder</Badge>
                           ) : (
                             <Badge variant="outline">Discovered</Badge>
                           )}
@@ -222,6 +234,22 @@ export function ProjectDiscovery({ onProjectsDiscovered }: ProjectDiscoveryProps
               <p className="text-sm text-destructive">{browseError}</p>
             )}
 
+            {browseResult && (
+              <div className="space-y-2">
+                <Label htmlFor="directory-filter">Filter directories</Label>
+                <div className="relative">
+                  <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    id="directory-filter"
+                    value={directoryFilter}
+                    onChange={(event) => setDirectoryFilter(event.target.value)}
+                    placeholder="Type a directory name"
+                    className="pl-9"
+                  />
+                </div>
+              </div>
+            )}
+
             {browseLoading && (
               <p className="text-sm text-muted-foreground text-center py-4">Loading…</p>
             )}
@@ -232,14 +260,18 @@ export function ProjectDiscovery({ onProjectsDiscovered }: ProjectDiscoveryProps
                 <p className="text-sm text-muted-foreground text-center py-4">
                   No subdirectories
                 </p>
+              ) : filteredDirectories.length === 0 ? (
+                <p className="text-sm text-muted-foreground text-center py-4">
+                  No directories match this filter
+                </p>
               ) : (
                 <ScrollArea className="h-64 rounded-md border">
                   <div className="p-1">
-                    {browseResult.directories.map((dir) => (
+                    {filteredDirectories.map((dir) => (
                       <button
                         key={dir}
                         type="button"
-                        className="w-full flex items-center gap-2 px-3 py-2 rounded text-sm hover:bg-accent hover:text-accent-foreground transition-colors text-left"
+                        className="w-full flex items-center gap-2 px-3 py-2 rounded text-sm hover:bg-accent hover:text-accent-foreground transition-colors text-left cursor-pointer"
                         onClick={() => browseTo(`${browseResult.path}/${dir}`)}
                       >
                         <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />

--- a/frontend/src/features/projects/ProjectList.tsx
+++ b/frontend/src/features/projects/ProjectList.tsx
@@ -55,7 +55,7 @@ export function ProjectList({ projects, loading }: ProjectListProps) {
     return (
       <div className="text-center py-8 text-muted-foreground">
         <p>No projects tracked yet.</p>
-        <p className="text-sm mt-2">Use the discovery wizard to find Claude Code projects.</p>
+        <p className="text-sm mt-2">Use the discovery wizard to find project folders.</p>
       </div>
     );
   }

--- a/frontend/src/features/projects/ProjectsPage.tsx
+++ b/frontend/src/features/projects/ProjectsPage.tsx
@@ -23,7 +23,7 @@ export function ProjectsPage() {
             Projects
           </h1>
           <p className="text-muted-foreground mt-2">
-            Manage Claude Code project directories
+            Manage local project directories
           </p>
         </div>
         <div className="flex gap-2">

--- a/frontend/src/types/projects.ts
+++ b/frontend/src/types/projects.ts
@@ -5,7 +5,7 @@
 export interface ProjectBase {
   name: string;
   path: string;
-  source?: "configured" | "session_history";
+  source?: "configured" | "session_history" | "directory";
 }
 
 export interface ProjectResponse extends ProjectBase {


### PR DESCRIPTION
## Summary
- allow Projects discovery to return ordinary local folders with a `directory` source
- preserve configured/session-history source labels and avoid duplicate discovery rows
- add a client-side filter input to the directory browser modal
- update Projects copy to avoid Claude Code-only wording

Closes #237

## Verification
- `backend/venv/bin/pytest backend/tests/test_project_service.py -q`
- `backend/venv/bin/pytest backend/tests -q`
- `npm --prefix frontend run build`
- `git diff --check`

## Notes
- `npm --prefix frontend run lint` is still blocked by existing repository-wide lint errors outside this patch, including `frontend/src/components/ui/chart.tsx`, `frontend/src/contexts/ProviderContext.tsx`, and several existing React hook/compiler warnings.
