### PR TITLE
Show Agent Team roles on Agent Bridge session cards

### DIFF
--- a/backend/app/api/v1/agent_bridge/router.py
+++ b/backend/app/api/v1/agent_bridge/router.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 import logging
 import secrets
 import time
-from typing import Literal
+from typing import Any, Literal
 from urllib.parse import urlparse
 
-from fastapi import APIRouter, HTTPException, Query, WebSocket
+from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket
 from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.database import get_db
+from app.models.database import AgentTeamPreset, AgentTeamSlot
 from app.services.agent_bridge.discovery import capture_pane_preview, discover_agent_sessions
 from app.services.agent_bridge.pty_relay import PtyRelay
 from app.services.agent_bridge.spawn import kill_session, spawn_session
@@ -55,12 +59,60 @@ class SpawnRequest(BaseModel):
     no_ask_user: bool = False
 
 
+async def _enrich_team_sessions(
+    sessions: list[dict[str, Any]],
+    db: AsyncSession,
+) -> list[dict[str, Any]]:
+    slot_ids = {
+        int(session["team_slot_id"])
+        for session in sessions
+        if isinstance(session.get("team_slot_id"), int)
+    }
+    if not slot_ids:
+        return sessions
+
+    slots = {
+        slot.id: slot
+        for slot in (
+            await db.execute(select(AgentTeamSlot).where(AgentTeamSlot.id.in_(slot_ids)))
+        ).scalars().all()
+    }
+    preset_ids = {slot.preset_id for slot in slots.values()}
+    presets = {
+        preset.id: preset
+        for preset in (
+            await db.execute(select(AgentTeamPreset).where(AgentTeamPreset.id.in_(preset_ids)))
+        ).scalars().all()
+    } if preset_ids else {}
+
+    enriched: list[dict[str, Any]] = []
+    for session in sessions:
+        updated = dict(session)
+        slot_id = updated.get("team_slot_id")
+        slot = slots.get(slot_id) if isinstance(slot_id, int) else None
+        if slot is not None:
+            preset = presets.get(slot.preset_id)
+            updated.update(
+                team_preset_id=slot.preset_id,
+                team_preset_name=preset.name if preset is not None else updated.get("team_preset_name"),
+                team_slot_name=slot.display_name,
+                team_slot_role=slot.role,
+                team_slot_charter=slot.charter,
+            )
+        enriched.append(updated)
+    return enriched
+
+
 @router.get("/sessions")
-def list_sessions(provider: str | None = Query(default=None)):
+async def list_sessions(
+    provider: str | None = Query(default=None),
+    db: AsyncSession = Depends(get_db),
+):
     try:
         sessions = discover_agent_sessions(provider)
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
+    sessions = await _enrich_team_sessions(sessions, db)
     return {"sessions": sessions, "count": len(sessions)}
 
 

--- a/backend/app/services/agent_bridge/discovery.py
+++ b/backend/app/services/agent_bridge/discovery.py
@@ -21,6 +21,53 @@ _PANE_FORMAT = (
     "|#{pane_current_command}"
 )
 
+_TEAM_ENV_KEYS = {
+    "CLAUDE_DECK_TEAM_PRESET_ID": "team_preset_id",
+    "CLAUDE_DECK_TEAM_PRESET_NAME": "team_preset_name",
+    "CLAUDE_DECK_TEAM_SLOT_ID": "team_slot_id",
+    "CLAUDE_DECK_TEAM_SLOT_NAME": "team_slot_name",
+    "CLAUDE_DECK_TEAM_SLOT_ROLE": "team_slot_role",
+}
+
+
+def _clean_int(value: str | None) -> int | None:
+    if not value:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def _parse_tmux_environment(stdout: str) -> dict[str, Any]:
+    context: dict[str, Any] = {}
+    for line in stdout.splitlines():
+        if not line or line.startswith("-") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        target = _TEAM_ENV_KEYS.get(key)
+        if target is None:
+            continue
+        context[target] = _clean_int(value) if target.endswith("_id") else value
+    return context
+
+
+def _team_context_for_session(session_name: str, cache: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    if session_name in cache:
+        return cache[session_name]
+    try:
+        result = subprocess.run(
+            ["tmux", "show-environment", "-t", session_name],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, subprocess.SubprocessError):
+        cache[session_name] = {}
+        return cache[session_name]
+    cache[session_name] = _parse_tmux_environment(result.stdout) if result.returncode == 0 else {}
+    return cache[session_name]
+
 
 def _build_session_info_from_parts(
     *,
@@ -31,6 +78,7 @@ def _build_session_info_from_parts(
     cwd: str,
     pid: str,
     provider: AgentProvider,
+    team_context: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     return {
         "provider": provider.id,
@@ -42,6 +90,7 @@ def _build_session_info_from_parts(
         "cwd": cwd,
         "pid": pid,
         "status": SessionStatus.ACTIVE,
+        **(team_context or {}),
     }
 
 
@@ -66,6 +115,7 @@ def discover_agent_sessions(provider_id: str | None = None) -> list[dict[str, An
         return []
 
     sessions: list[dict[str, Any]] = []
+    team_context_cache: dict[str, dict[str, Any]] = {}
     for line in result.stdout.strip().splitlines():
         parts = line.split("|", 6)
         if len(parts) != 7:
@@ -73,6 +123,7 @@ def discover_agent_sessions(provider_id: str | None = None) -> list[dict[str, An
         target, session_name, window_name, pane_id, cwd, pid, command = parts
         for provider in providers:
             if provider.is_process_match(command, pid):
+                team_context = _team_context_for_session(session_name, team_context_cache)
                 sessions.append(
                     _build_session_info_from_parts(
                         target=target,
@@ -82,6 +133,7 @@ def discover_agent_sessions(provider_id: str | None = None) -> list[dict[str, An
                         cwd=cwd,
                         pid=pid,
                         provider=provider,
+                        team_context=team_context,
                     )
                 )
                 break
@@ -100,4 +152,3 @@ def capture_pane_preview(target: str) -> str:
         return result.stdout if result.returncode == 0 else ""
     except Exception:
         return ""
-

--- a/backend/app/services/agent_team_service.py
+++ b/backend/app/services/agent_team_service.py
@@ -583,6 +583,7 @@ class AgentTeamService:
                     "CLAUDE_DECK_TEAM_PRESET_NAME": preset.name,
                     "CLAUDE_DECK_TEAM_SLOT_ID": str(slot.id),
                     "CLAUDE_DECK_TEAM_SLOT_NAME": slot.display_name,
+                    **({"CLAUDE_DECK_TEAM_SLOT_ROLE": slot.role} if slot.role else {}),
                 },
             )
             result = AgentTeamLaunchResultItem(

--- a/backend/tests/agent_teams/test_agent_bridge_session_metadata.py
+++ b/backend/tests/agent_teams/test_agent_bridge_session_metadata.py
@@ -1,0 +1,47 @@
+"""Agent Bridge session metadata for Agent Team launches."""
+
+import pytest
+
+from app.models.database import AgentTeamPreset, AgentTeamSlot
+
+
+@pytest.mark.asyncio
+async def test_agent_bridge_sessions_enrich_team_role_from_db(db, tmp_path):
+    from app.api.v1.agent_bridge.router import _enrich_team_sessions
+
+    preset = AgentTeamPreset(name="SnazzyEmail", description="", created_by="test")
+    db.add(preset)
+    await db.flush()
+    slot = AgentTeamSlot(
+        preset_id=preset.id,
+        position=0,
+        display_name="Architect",
+        provider="claude-code",
+        repo_id="repo-1",
+        repo_path=str(tmp_path),
+        repo_name="repo",
+        role="architect",
+        charter="Own architecture",
+        launch_mode="plain",
+        launch_options={},
+        enabled=True,
+    )
+    db.add(slot)
+    await db.commit()
+
+    sessions = await _enrich_team_sessions(
+        [
+            {
+                "provider": "claude-code",
+                "tmux_target": "snazzyemail:0.0",
+                "team_slot_id": slot.id,
+            }
+        ],
+        db,
+    )
+
+    assert sessions[0]["team_preset_id"] == preset.id
+    assert sessions[0]["team_preset_name"] == "SnazzyEmail"
+    assert sessions[0]["team_slot_name"] == "Architect"
+    assert sessions[0]["team_slot_role"] == "architect"
+    assert sessions[0]["team_slot_charter"] == "Own architecture"

--- a/backend/tests/test_agent_bridge_discovery.py
+++ b/backend/tests/test_agent_bridge_discovery.py
@@ -46,3 +46,47 @@ def test_discover_agent_sessions_can_filter_provider():
 
     assert len(sessions) == 1
     assert sessions[0]["provider"] == "codex-cli"
+
+
+def test_discover_agent_sessions_includes_team_environment():
+    from app.services.agent_bridge.discovery import discover_agent_sessions
+
+    tmux_output = "snazzyemail:0.0|snazzyemail|main|%1|/repo/a|111|codex"
+    env_output = "\n".join(
+        [
+            "CLAUDE_DECK_TEAM_PRESET_ID=10",
+            "CLAUDE_DECK_TEAM_PRESET_NAME=SnazzyEmail",
+            "CLAUDE_DECK_TEAM_SLOT_ID=20",
+            "CLAUDE_DECK_TEAM_SLOT_NAME=Lead Developer",
+            "CLAUDE_DECK_TEAM_SLOT_ROLE=lead developer",
+        ]
+    )
+
+    def fake_run(args, **_kwargs):
+        if args[:2] == ["tmux", "list-panes"]:
+            return SimpleNamespace(returncode=0, stdout=tmux_output, stderr="")
+        if args[:2] == ["tmux", "show-environment"]:
+            return SimpleNamespace(returncode=0, stdout=env_output, stderr="")
+        raise AssertionError(args)
+
+    with patch("app.services.agent_bridge.discovery.subprocess.run", side_effect=fake_run):
+        sessions = discover_agent_sessions("codex-cli")
+
+    assert sessions == [
+        {
+            "provider": "codex-cli",
+            "provider_display_name": "Codex",
+            "tmux_target": "snazzyemail:0.0",
+            "session_name": "snazzyemail",
+            "window_name": "main",
+            "pane_id": "%1",
+            "cwd": "/repo/a",
+            "pid": "111",
+            "status": "active",
+            "team_preset_id": 10,
+            "team_preset_name": "SnazzyEmail",
+            "team_slot_id": 20,
+            "team_slot_name": "Lead Developer",
+            "team_slot_role": "lead developer",
+        }
+    ]

--- a/frontend/src/features/cc-bridge/SessionCard.tsx
+++ b/frontend/src/features/cc-bridge/SessionCard.tsx
@@ -14,9 +14,27 @@ interface SessionCardProps {
   instance?: InstanceIdentity | null
 }
 
+function normalizeLabel(value: string | null | undefined) {
+  return (value ?? '').trim().toLowerCase().replace(/[\s_-]+/g, ' ')
+}
+
 export function SessionCard({ session, gridPosition, onClick, onKill, instance }: SessionCardProps) {
   const projectName = session.cwd.split('/').pop() || session.cwd
   const isActive = gridPosition !== null
+  const teamSlotLabel = session.team_slot_name?.trim()
+  const teamRoleLabel = session.team_slot_role?.trim()
+  const teamName = session.team_preset_name?.trim()
+  const primaryLabel = teamSlotLabel || session.session_name
+  const showRole = Boolean(
+    teamRoleLabel && normalizeLabel(teamRoleLabel) !== normalizeLabel(teamSlotLabel)
+  )
+  const showProject = !teamName || normalizeLabel(projectName) !== normalizeLabel(teamName)
+  const contextLine = teamName
+    ? `${teamName}${showProject ? ` · ${projectName}` : ''}`
+    : projectName
+  const contextTitle = teamName
+    ? `Team: ${teamName}${showProject ? ` · Repo: ${projectName}` : ''}`
+    : session.cwd
 
   return (
     <Card
@@ -36,13 +54,19 @@ export function SessionCard({ session, gridPosition, onClick, onKill, instance }
     >
       <CardContent className="p-3">
         <div className="flex items-center justify-between">
-          <span className="text-sm font-medium truncate">{session.session_name}</span>
+          <span
+            className="text-sm font-medium truncate"
+            title={teamSlotLabel ? `${session.session_name} · ${session.tmux_target}` : session.tmux_target}
+          >
+            {primaryLabel}
+          </span>
           <div className="flex items-center gap-1.5 shrink-0">
             <button
               className="h-5 w-5 flex items-center justify-center rounded text-muted-foreground/50 hover:text-destructive transition-colors"
               onClick={(e) => { e.stopPropagation(); onKill(session) }}
               onKeyDown={(e) => e.stopPropagation()}
               title="Kill session"
+              aria-label={`Kill ${primaryLabel}`}
             >
               <Trash2 className="h-3 w-3" />
             </button>
@@ -55,11 +79,18 @@ export function SessionCard({ session, gridPosition, onClick, onKill, instance }
             )}
           </div>
         </div>
-        <Badge variant="outline" className="mt-2 max-w-full truncate">
-          {session.provider_display_name}
-        </Badge>
-        <p className="text-xs text-muted-foreground truncate mt-1" title={session.cwd}>
-          {projectName}
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          <Badge variant="outline" className="max-w-full truncate">
+            {session.provider_display_name}
+          </Badge>
+          {showRole && (
+            <Badge variant="secondary" className="max-w-full truncate" title={`Role: ${teamRoleLabel}`}>
+              {teamRoleLabel}
+            </Badge>
+          )}
+        </div>
+        <p className="text-xs text-muted-foreground truncate mt-1" title={contextTitle}>
+          {contextLine}
         </p>
         <p
           className="text-xs text-muted-foreground mt-0.5 truncate"

--- a/frontend/src/features/cc-bridge/types.ts
+++ b/frontend/src/features/cc-bridge/types.ts
@@ -10,6 +10,12 @@ export interface AgentSession {
   cwd: string
   pid: string
   status: string
+  team_preset_id?: number | null
+  team_preset_name?: string | null
+  team_slot_id?: number | null
+  team_slot_name?: string | null
+  team_slot_role?: string | null
+  team_slot_charter?: string | null
 }
 
 export type CCSession = AgentSession


### PR DESCRIPTION
## Summary
Closes #248.

Adds Agent Team slot/role context to Agent Bridge session discovery and displays it on session cards without repeating team, role, repo, and tmux labels.

## Changes
- Include team metadata from tmux env and DB enrichment in `/agent-bridge/sessions`.
- Export `CLAUDE_DECK_TEAM_SLOT_ROLE` for future team launches.
- Show slot name as the primary session card label when present.
- Show role only when it adds information beyond the slot name.
- Preserve clean fallback display for manually-started sessions.

## Validation
- `PYTHONPATH=backend backend/venv/bin/python -m pytest backend/tests/test_agent_bridge_discovery.py backend/tests/agent_teams/test_agent_bridge_session_metadata.py backend/tests/agent_teams/test_agent_team_service.py::test_launch_requires_confirmed_plan_hash_and_passes_team_env`
- `npx eslint src/features/cc-bridge/SessionCard.tsx --quiet`
- `npm run build`
