### PR TITLE
Add Agent Bridge image attachments

### DIFF
--- a/backend/app/api/v1/agent_bridge/router.py
+++ b/backend/app/api/v1/agent_bridge/router.py
@@ -7,13 +7,22 @@ import time
 from typing import Any, Literal
 from urllib.parse import urlparse
 
-from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket
+from fastapi import APIRouter, Depends, File, Form, Header, HTTPException, Query, Request, UploadFile, WebSocket
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.models.database import AgentTeamPreset, AgentTeamSlot
+from app.models.schemas import (
+    BridgeAttachmentDeleteResponse,
+    BridgeAttachmentListResponse,
+    BridgeAttachmentPasteRequest,
+    BridgeAttachmentPasteResponse,
+    BridgeAttachmentResponse,
+)
+from app.config import settings
+from app.services.agent_bridge.attachments import agent_bridge_attachment_service
 from app.services.agent_bridge.discovery import capture_pane_preview, discover_agent_sessions
 from app.services.agent_bridge.pty_relay import PtyRelay
 from app.services.agent_bridge.spawn import kill_session, spawn_session
@@ -137,7 +146,7 @@ async def get_terminal_token():
     return {"token": token}
 
 
-def _is_same_origin(origin: str, websocket: WebSocket) -> bool:
+def _is_same_origin_host(origin: str, request_host: str) -> bool:
     try:
         origin_host = urlparse(origin).netloc.lower()
     except ValueError:
@@ -145,15 +154,29 @@ def _is_same_origin(origin: str, websocket: WebSocket) -> bool:
     if not origin_host:
         return False
 
-    request_host = (websocket.headers.get("host") or "").lower()
     if request_host and origin_host == request_host:
         return True
     return origin_host.split(":")[0] in {"localhost", "127.0.0.1", "[::1]"}
 
 
+def _is_same_origin(origin: str, websocket: WebSocket) -> bool:
+    return _is_same_origin_host(origin, (websocket.headers.get("host") or "").lower())
+
+
 def _validate_token(token: str) -> bool:
     issued_at = _tokens.pop(token, None)
     return issued_at is not None and (time.time() - issued_at) <= _TOKEN_TTL
+
+
+def _require_attachment_access(
+    request: Request,
+    token: str,
+) -> None:
+    origin = request.headers.get("origin", "")
+    if origin and not _is_same_origin_host(origin, (request.headers.get("host") or "").lower()):
+        raise HTTPException(status_code=403, detail="Invalid origin")
+    if not _validate_token(token):
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
 
 
 @router.websocket("/sessions/{target:path}/terminal")
@@ -174,6 +197,91 @@ async def session_terminal(
 
     relay = PtyRelay(target=target, read_only=mode != "interactive")
     await relay.run(websocket)
+
+
+@router.post("/sessions/{target:path}/attachments", response_model=BridgeAttachmentResponse)
+async def upload_session_attachment(
+    target: str,
+    request: Request,
+    file: UploadFile = File(...),
+    template: str | None = Form(default=None),
+    prompt: str | None = Form(default=None),
+    created_by: str | None = Form(default="deck-ui"),
+    token: str = Header(default="", alias="X-Claude-Deck-Terminal-Token"),
+    db: AsyncSession = Depends(get_db),
+):
+    _require_attachment_access(request, token)
+    try:
+        content = await file.read(settings.bridge_attachment_max_bytes + 1)
+        return await agent_bridge_attachment_service.create_attachment(
+            db,
+            target=target,
+            content=content,
+            original_filename=file.filename,
+            prompt=prompt,
+            template=template,
+            created_by=created_by,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/sessions/{target:path}/attachments", response_model=BridgeAttachmentListResponse)
+async def list_session_attachments(
+    target: str,
+    request: Request,
+    token: str = Header(default="", alias="X-Claude-Deck-Terminal-Token"),
+    db: AsyncSession = Depends(get_db),
+):
+    _require_attachment_access(request, token)
+    attachments = await agent_bridge_attachment_service.list_attachments(db, target=target)
+    return BridgeAttachmentListResponse(attachments=attachments)
+
+
+@router.post(
+    "/sessions/{target:path}/attachments/{attachment_id}/paste",
+    response_model=BridgeAttachmentPasteResponse,
+)
+async def paste_session_attachment(
+    target: str,
+    attachment_id: int,
+    paste_request: BridgeAttachmentPasteRequest,
+    request: Request,
+    token: str = Header(default="", alias="X-Claude-Deck-Terminal-Token"),
+    db: AsyncSession = Depends(get_db),
+):
+    _require_attachment_access(request, token)
+    try:
+        return await agent_bridge_attachment_service.paste_attachment(
+            db,
+            target=target,
+            attachment_id=attachment_id,
+            request=paste_request,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.delete(
+    "/sessions/{target:path}/attachments/{attachment_id}",
+    response_model=BridgeAttachmentDeleteResponse,
+)
+async def delete_session_attachment(
+    target: str,
+    attachment_id: int,
+    request: Request,
+    token: str = Header(default="", alias="X-Claude-Deck-Terminal-Token"),
+    db: AsyncSession = Depends(get_db),
+):
+    _require_attachment_access(request, token)
+    try:
+        return await agent_bridge_attachment_service.delete_attachment(
+            db,
+            target=target,
+            attachment_id=attachment_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.post("/sessions")

--- a/backend/app/api/v1/agent_bridge/router.py
+++ b/backend/app/api/v1/agent_bridge/router.py
@@ -24,7 +24,7 @@ from app.models.schemas import (
 from app.config import settings
 from app.services.agent_bridge.attachments import agent_bridge_attachment_service
 from app.services.agent_bridge.discovery import capture_pane_preview, discover_agent_sessions
-from app.services.agent_bridge.pty_relay import PtyRelay
+from app.services.agent_bridge.pty_relay import PtyRelay, is_target_interactive
 from app.services.agent_bridge.spawn import kill_session, spawn_session
 from app.services.providers import get_provider
 from app.services.providers.base import SpawnCommandOptions
@@ -251,6 +251,8 @@ async def paste_session_attachment(
     db: AsyncSession = Depends(get_db),
 ):
     _require_attachment_access(request, token)
+    if paste_request.require_interactive_relay and not is_target_interactive(target):
+        raise HTTPException(status_code=409, detail="Terminal relay is read-only or not attached")
     try:
         return await agent_bridge_attachment_service.paste_attachment(
             db,

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -28,6 +28,13 @@ class Settings(BaseSettings):
     # Database settings
     database_url: str = "sqlite+aiosqlite:///./claude_registry.db"
 
+    # Agent Bridge attachment settings
+    bridge_attachment_dir: str = "~/.claude-registry/bridge-attachments"
+    bridge_attachment_agent_root: str | None = None
+    bridge_attachment_max_bytes: int = 10 * 1024 * 1024
+    bridge_attachment_retention_days: int = 7
+    bridge_attachment_max_per_session_per_day: int = 100
+
     # Server settings
     host: str = "0.0.0.0"
     port: int = 8000

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,14 +1,19 @@
 """FastAPI application entry point."""
+import logging
+import os
 from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-
-from app.config import settings
-from app.database import init_db
-from app.api.v1.router import router as api_v1_router
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse, JSONResponse
-import os
+
+from app.api.v1.router import router as api_v1_router
+from app.config import settings
+from app.database import AsyncSessionLocal, init_db
+from app.services.agent_bridge.attachments import agent_bridge_attachment_service
+
+logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
@@ -16,6 +21,11 @@ async def lifespan(app: FastAPI):
     """Application lifespan manager."""
     # Startup: Initialize database
     await init_db()
+    try:
+        async with AsyncSessionLocal() as db:
+            await agent_bridge_attachment_service.cleanup_expired(db)
+    except Exception:
+        logger.exception("Failed to clean up expired Agent Bridge attachments")
     # Clean up any orphaned relay processes from previous runs
     from app.services.cc_bridge.pty_relay import close_all_relays, cleanup_orphaned_relays
     cleanup_orphaned_relays()

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -200,6 +200,27 @@ class AgentTeamLaunchItem(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
 
 
+class BridgeSessionAttachment(Base):
+    """Image attachment uploaded for an Agent Bridge tmux session."""
+
+    __tablename__ = "bridge_session_attachments"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    target: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    session_name: Mapped[str | None] = mapped_column(String, nullable=True)
+    provider: Mapped[str | None] = mapped_column(String, nullable=True)
+    original_filename: Mapped[str | None] = mapped_column(String, nullable=True)
+    mime_type: Mapped[str] = mapped_column(String, nullable=False)
+    size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
+    sha256: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    storage_path: Mapped[str] = mapped_column(String, nullable=False)
+    agent_path: Mapped[str] = mapped_column(String, nullable=False)
+    prompt_text: Mapped[str] = mapped_column(String, nullable=False)
+    created_by: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+
 class MailTeamMember(Base):
     """Durable Agent Mail routable participant, grouped by repository."""
 

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -2204,3 +2204,41 @@ class AgentTeamLaunchResult(BaseModel):
     launched_at: datetime
     completed_at: datetime
     items: List[AgentTeamLaunchResultItem] = Field(default_factory=list)
+
+
+class BridgeAttachmentResponse(BaseModel):
+    id: int
+    target: str
+    session_name: Optional[str] = None
+    provider: Optional[str] = None
+    original_filename: Optional[str] = None
+    mime_type: str
+    size_bytes: int
+    sha256: str
+    agent_path: str
+    prompt_text: str
+    created_by: Optional[str] = None
+    created_at: datetime
+    expires_at: Optional[datetime] = None
+
+
+class BridgeAttachmentListResponse(BaseModel):
+    attachments: List[BridgeAttachmentResponse] = Field(default_factory=list)
+
+
+class BridgeAttachmentPasteRequest(BaseModel):
+    submit: bool = False
+    prefix: str = ""
+    suffix: str = ""
+
+
+class BridgeAttachmentPasteResponse(BaseModel):
+    pasted: bool
+    submitted: bool
+    target: str
+
+
+class BridgeAttachmentDeleteResponse(BaseModel):
+    deleted: bool
+    target: str
+    attachment_id: int

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -2230,6 +2230,7 @@ class BridgeAttachmentPasteRequest(BaseModel):
     submit: bool = False
     prefix: str = ""
     suffix: str = ""
+    require_interactive_relay: bool = False
 
 
 class BridgeAttachmentPasteResponse(BaseModel):

--- a/backend/app/services/agent_bridge/attachments.py
+++ b/backend/app/services/agent_bridge/attachments.py
@@ -1,0 +1,333 @@
+"""Image attachment handling for Agent Bridge tmux sessions."""
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import subprocess
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.models.database import BridgeSessionAttachment
+from app.models.schemas import (
+    BridgeAttachmentDeleteResponse,
+    BridgeAttachmentPasteRequest,
+    BridgeAttachmentPasteResponse,
+    BridgeAttachmentResponse,
+)
+from app.services.agent_bridge.discovery import discover_agent_sessions
+from app.services.agent_mail_service import TMUX_ENTER_DELAY_SECONDS
+
+_SAFE_SEGMENT_PATTERN = re.compile(r"[^A-Za-z0-9_.-]+")
+_PROMPT_TEMPLATES = {
+    "claude-code": "Please inspect this image: {path}",
+    "codex-cli": "Please inspect this image: {path}",
+    "opencode-cli": "Please inspect this image: {path}",
+    "copilot-cli": "Please inspect this image: {path}",
+    "unknown": "Please inspect this image: {path}",
+}
+_MAX_PROMPT_LENGTH = 4000
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+class AgentBridgeAttachmentService:
+    """Stores images where the tmux agent can read them and injects references."""
+
+    async def create_attachment(
+        self,
+        db: AsyncSession,
+        *,
+        target: str,
+        content: bytes,
+        original_filename: str | None = None,
+        prompt: str | None = None,
+        template: str | None = None,
+        created_by: str | None = None,
+    ) -> BridgeAttachmentResponse:
+        session = self._require_live_session(target)
+        mime_type, extension = self._detect_image(content)
+        sha256 = hashlib.sha256(content).hexdigest()
+        await self._enforce_daily_limit(db, target)
+
+        now = _utcnow()
+        storage_path = self._storage_path(
+            session=session,
+            created_at=now,
+            sha256=sha256,
+            extension=extension,
+        )
+        storage_path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = storage_path.with_suffix(storage_path.suffix + ".tmp")
+        temp_path.write_bytes(content)
+        os.replace(temp_path, storage_path)
+
+        agent_path = self._agent_path(storage_path)
+        prompt_text = self._build_prompt(
+            provider=str(session.get("provider") or "unknown"),
+            agent_path=agent_path,
+            prompt=prompt,
+            template=template,
+        )
+        attachment = BridgeSessionAttachment(
+            target=target,
+            session_name=self._clean_optional(session.get("session_name")),
+            provider=self._clean_optional(session.get("provider")),
+            original_filename=self._clean_optional(original_filename),
+            mime_type=mime_type,
+            size_bytes=len(content),
+            sha256=sha256,
+            storage_path=str(storage_path),
+            agent_path=agent_path,
+            prompt_text=prompt_text,
+            created_by=self._clean_optional(created_by),
+            created_at=now,
+            expires_at=now + timedelta(days=max(settings.bridge_attachment_retention_days, 1)),
+        )
+        db.add(attachment)
+        await db.commit()
+        await db.refresh(attachment)
+        return self._response(attachment)
+
+    async def list_attachments(
+        self,
+        db: AsyncSession,
+        *,
+        target: str,
+    ) -> list[BridgeAttachmentResponse]:
+        statement = (
+            select(BridgeSessionAttachment)
+            .where(BridgeSessionAttachment.target == target)
+            .order_by(BridgeSessionAttachment.created_at.desc())
+        )
+        attachments = (await db.execute(statement)).scalars().all()
+        return [self._response(attachment) for attachment in attachments]
+
+    async def paste_attachment(
+        self,
+        db: AsyncSession,
+        *,
+        target: str,
+        attachment_id: int,
+        request: BridgeAttachmentPasteRequest,
+    ) -> BridgeAttachmentPasteResponse:
+        self._require_live_session(target)
+        attachment = await self._require_attachment(db, target, attachment_id)
+        prompt_text = self._clean_prompt_text(
+            f"{request.prefix or ''}{attachment.prompt_text}{request.suffix or ''}"
+        )
+        self._send_tmux_prompt(target, prompt_text, submit=request.submit)
+        return BridgeAttachmentPasteResponse(
+            pasted=True,
+            submitted=request.submit,
+            target=target,
+        )
+
+    async def delete_attachment(
+        self,
+        db: AsyncSession,
+        *,
+        target: str,
+        attachment_id: int,
+    ) -> BridgeAttachmentDeleteResponse:
+        attachment = await self._require_attachment(db, target, attachment_id)
+        self._unlink_attachment_file(attachment.storage_path)
+        await db.delete(attachment)
+        await db.commit()
+        return BridgeAttachmentDeleteResponse(
+            deleted=True,
+            target=target,
+            attachment_id=attachment_id,
+        )
+
+    async def cleanup_expired(self, db: AsyncSession, *, now: datetime | None = None) -> int:
+        current = now or _utcnow()
+        statement = select(BridgeSessionAttachment).where(
+            BridgeSessionAttachment.expires_at.is_not(None),
+            BridgeSessionAttachment.expires_at <= current,
+        )
+        attachments = (await db.execute(statement)).scalars().all()
+        for attachment in attachments:
+            self._unlink_attachment_file(attachment.storage_path)
+        if attachments:
+            await db.execute(
+                delete(BridgeSessionAttachment).where(
+                    BridgeSessionAttachment.id.in_([attachment.id for attachment in attachments])
+                )
+            )
+            await db.commit()
+        return len(attachments)
+
+    def _require_live_session(self, target: str) -> dict[str, Any]:
+        for session in discover_agent_sessions():
+            if session.get("tmux_target") == target:
+                return session
+        raise ValueError("Agent Bridge session target not found")
+
+    async def _require_attachment(
+        self,
+        db: AsyncSession,
+        target: str,
+        attachment_id: int,
+    ) -> BridgeSessionAttachment:
+        attachment = await db.get(BridgeSessionAttachment, attachment_id)
+        if attachment is None or attachment.target != target:
+            raise ValueError("Attachment not found for target")
+        return attachment
+
+    async def _enforce_daily_limit(self, db: AsyncSession, target: str) -> None:
+        limit = settings.bridge_attachment_max_per_session_per_day
+        if limit <= 0:
+            return
+        today = _utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+        count = (
+            await db.execute(
+                select(func.count(BridgeSessionAttachment.id)).where(
+                    BridgeSessionAttachment.target == target,
+                    BridgeSessionAttachment.created_at >= today,
+                )
+            )
+        ).scalar_one()
+        if count >= limit:
+            raise ValueError("Daily attachment limit reached for this session")
+
+    def _detect_image(self, content: bytes) -> tuple[str, str]:
+        max_bytes = settings.bridge_attachment_max_bytes
+        if not content:
+            raise ValueError("Attachment file is empty")
+        if len(content) > max_bytes:
+            raise ValueError(f"Attachment exceeds maximum size of {max_bytes} bytes")
+        if content.startswith(b"\x89PNG\r\n\x1a\n"):
+            return "image/png", "png"
+        if content.startswith(b"\xff\xd8\xff"):
+            return "image/jpeg", "jpg"
+        if content.startswith((b"GIF87a", b"GIF89a")):
+            return "image/gif", "gif"
+        if len(content) >= 12 and content[:4] == b"RIFF" and content[8:12] == b"WEBP":
+            return "image/webp", "webp"
+        raise ValueError("Unsupported image type")
+
+    def _storage_path(
+        self,
+        *,
+        session: dict[str, Any],
+        created_at: datetime,
+        sha256: str,
+        extension: str,
+    ) -> Path:
+        root = self._storage_root()
+        segment = self._safe_segment(
+            self._clean_optional(session.get("session_name"))
+            or self._clean_optional(session.get("tmux_target"))
+            or sha256[:12]
+        )
+        date_segment = created_at.strftime("%Y-%m-%d")
+        filename = f"{created_at.strftime('%H%M%S')}-{sha256[:12]}.{extension}"
+        return root / segment / date_segment / filename
+
+    def _storage_root(self) -> Path:
+        return Path(settings.bridge_attachment_dir).expanduser().resolve()
+
+    def _agent_path(self, storage_path: Path) -> str:
+        storage_root = self._storage_root()
+        relative_path = storage_path.resolve().relative_to(storage_root)
+        configured_agent_root = self._clean_optional(settings.bridge_attachment_agent_root)
+        if not configured_agent_root:
+            return str(storage_path)
+        return str(Path(configured_agent_root).expanduser() / relative_path)
+
+    def _build_prompt(
+        self,
+        *,
+        provider: str,
+        agent_path: str,
+        prompt: str | None = None,
+        template: str | None = None,
+    ) -> str:
+        template_text = prompt or _PROMPT_TEMPLATES.get(template or provider) or _PROMPT_TEMPLATES["unknown"]
+        if "{path}" not in template_text:
+            raise ValueError("Attachment prompt must include {path}")
+        return self._clean_prompt_text(template_text.replace("{path}", agent_path))
+
+    def _clean_prompt_text(self, value: str) -> str:
+        text = value.replace("\x00", "")
+        text = re.sub(r"[\r\n]+", " ", text)
+        text = re.sub(r"\s+", " ", text).strip()
+        if not text:
+            raise ValueError("Attachment prompt is empty")
+        if len(text) > _MAX_PROMPT_LENGTH:
+            raise ValueError("Attachment prompt is too long")
+        return text
+
+    def _send_tmux_prompt(self, target: str, prompt_text: str, *, submit: bool) -> None:
+        try:
+            subprocess.run(
+                ["tmux", "send-keys", "-t", target, "-l", prompt_text],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=True,
+            )
+            if submit:
+                time.sleep(TMUX_ENTER_DELAY_SECONDS)
+                subprocess.run(
+                    ["tmux", "send-keys", "-t", target, "Enter"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                    check=True,
+                )
+        except FileNotFoundError as exc:
+            raise ValueError("tmux is not installed or not available") from exc
+        except subprocess.CalledProcessError as exc:
+            raise ValueError(f"tmux send-keys failed: {(exc.stderr or '')[:200]}") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise ValueError("tmux send-keys timed out") from exc
+
+    def _unlink_attachment_file(self, storage_path: str) -> None:
+        try:
+            root = self._storage_root()
+            path = Path(storage_path).resolve()
+            path.relative_to(root)
+            if path.is_file():
+                path.unlink()
+        except (OSError, ValueError):
+            return
+
+    def _safe_segment(self, value: str) -> str:
+        segment = _SAFE_SEGMENT_PATTERN.sub("-", value.strip()).strip(".-")
+        return segment[:80] or hashlib.sha256(value.encode()).hexdigest()[:12]
+
+    def _clean_optional(self, value: Any) -> str | None:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+
+    def _response(self, attachment: BridgeSessionAttachment) -> BridgeAttachmentResponse:
+        return BridgeAttachmentResponse(
+            id=attachment.id,
+            target=attachment.target,
+            session_name=attachment.session_name,
+            provider=attachment.provider,
+            original_filename=attachment.original_filename,
+            mime_type=attachment.mime_type,
+            size_bytes=attachment.size_bytes,
+            sha256=attachment.sha256,
+            agent_path=attachment.agent_path,
+            prompt_text=attachment.prompt_text,
+            created_by=attachment.created_by,
+            created_at=attachment.created_at,
+            expires_at=attachment.expires_at,
+        )
+
+
+agent_bridge_attachment_service = AgentBridgeAttachmentService()

--- a/backend/app/services/cc_bridge/pty_relay.py
+++ b/backend/app/services/cc_bridge/pty_relay.py
@@ -24,6 +24,12 @@ _active_relays: dict[str, "PtyRelay"] = {}
 _PR_SET_PDEATHSIG = 1
 
 
+def is_target_interactive(target: str) -> bool:
+    """Return whether a live relay for target currently accepts input."""
+    relay = _active_relays.get(target)
+    return relay is not None and not relay.read_only
+
+
 def _child_preexec() -> None:
     """Set up the child process: new session + death signal."""
     os.setsid()

--- a/backend/mcp_shim/agent_mail_server.py
+++ b/backend/mcp_shim/agent_mail_server.py
@@ -4,6 +4,7 @@ import threading
 import time
 import uuid
 from typing import Any, Optional
+from urllib.parse import quote
 
 import httpx
 from mcp.server.fastmcp import FastMCP
@@ -103,6 +104,32 @@ def _request(method: str, path: str, **kwargs) -> dict:
 
 def _team_request(method: str, path: str, **kwargs) -> dict:
     return _deck_request(method, "agent-teams", path, **kwargs)
+
+
+def _bridge_request(method: str, path: str, **kwargs) -> dict:
+    return _deck_request(method, "agent-bridge", path, **kwargs)
+
+
+def _bridge_request_with_token(method: str, path: str, **kwargs) -> dict:
+    token_result = _bridge_request("GET", "/token")
+    if not token_result["ok"]:
+        return token_result
+    token = token_result["data"].get("token")
+    if not token:
+        return {
+            "ok": False,
+            "error": {
+                "code": "missing_terminal_token",
+                "message": "Claude Deck did not return an Agent Bridge terminal token.",
+            },
+        }
+    headers = dict(kwargs.pop("headers", {}) or {})
+    headers["X-Claude-Deck-Terminal-Token"] = token
+    return _bridge_request(method, path, headers=headers, **kwargs)
+
+
+def _bridge_session_path(target: str) -> str:
+    return f"/sessions/{quote(target, safe='')}"
 
 
 def _ensure_registered() -> dict:
@@ -383,6 +410,78 @@ def deck_create_handoff(
     if not result["ok"]:
         return result
     return {"ok": True, "handoff_id": result["data"]["id"], **_counts()}
+
+
+@mcp.tool()
+def deck_attach_image_to_bridge_session(
+    target: str,
+    file_path: str,
+    submit: bool = False,
+    prompt: str = "",
+) -> dict:
+    """Upload a local image file to an Agent Bridge tmux session, paste the
+    generated image-path prompt, and optionally submit it. target is the
+    tmux target from Agent Bridge, such as "repo-1234:0.0". file_path must
+    point to an image readable by this MCP server process."""
+    expanded_path = os.path.abspath(os.path.expanduser(file_path))
+    if not os.path.isfile(expanded_path):
+        return {
+            "ok": False,
+            "error": {
+                "code": "image_file_not_found",
+                "message": f"Image file not found: {expanded_path}",
+            },
+        }
+
+    data = {"created_by": "mcp"}
+    if prompt:
+        data["prompt"] = prompt
+    with open(expanded_path, "rb") as handle:
+        upload = _bridge_request_with_token(
+            "POST",
+            f"{_bridge_session_path(target)}/attachments",
+            files={"file": (os.path.basename(expanded_path), handle)},
+            data=data,
+        )
+    if not upload["ok"]:
+        return upload
+
+    attachment = upload["data"]
+    paste = _bridge_request_with_token(
+        "POST",
+        f"{_bridge_session_path(target)}/attachments/{attachment['id']}/paste",
+        json={"submit": submit},
+    )
+    if not paste["ok"]:
+        return {"ok": False, "attachment": attachment, "error": paste["error"]}
+    return {"ok": True, "attachment": attachment, "paste": paste["data"]}
+
+
+@mcp.tool()
+def deck_list_bridge_attachments(target: str) -> dict:
+    """List recent image attachments for an Agent Bridge tmux target."""
+    result = _bridge_request_with_token("GET", f"{_bridge_session_path(target)}/attachments")
+    if not result["ok"]:
+        return result
+    return {"ok": True, **result["data"]}
+
+
+@mcp.tool()
+def deck_paste_bridge_attachment(
+    target: str,
+    attachment_id: int,
+    submit: bool = False,
+) -> dict:
+    """Paste an existing Agent Bridge attachment prompt into a tmux session,
+    optionally submitting it with Enter."""
+    result = _bridge_request_with_token(
+        "POST",
+        f"{_bridge_session_path(target)}/attachments/{attachment_id}/paste",
+        json={"submit": submit},
+    )
+    if not result["ok"]:
+        return result
+    return {"ok": True, "paste": result["data"]}
 
 
 @mcp.tool()

--- a/backend/mcp_shim/agent_mail_server.py
+++ b/backend/mcp_shim/agent_mail_server.py
@@ -422,7 +422,7 @@ def deck_attach_image_to_bridge_session(
     """Upload a local image file to an Agent Bridge tmux session, paste the
     generated image-path prompt, and optionally submit it. target is the
     tmux target from Agent Bridge, such as "repo-1234:0.0". file_path must
-    point to an image readable by this MCP server process."""
+    point to an image readable by this trusted MCP server process."""
     expanded_path = os.path.abspath(os.path.expanduser(file_path))
     if not os.path.isfile(expanded_path):
         return {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,6 +5,7 @@ description = "Backend API for Claude Deck"
 requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.109.0",
+    "python-multipart>=0.0.9",
     "uvicorn[standard]>=0.27.0",
     "sqlalchemy>=2.0.25",
     "pydantic>=2.6.0",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 fastapi>=0.109.0
+python-multipart>=0.0.9
 uvicorn[standard]>=0.27.0
 sqlalchemy>=2.0.25
 pydantic>=2.6.0

--- a/backend/tests/agent_mail/test_mcp_shim.py
+++ b/backend/tests/agent_mail/test_mcp_shim.py
@@ -278,6 +278,71 @@ def test_deck_create_team_posts_to_team_api(monkeypatch):
     assert requests[0][2]["json"]["slots"][0]["ui_color"] == "blue"
 
 
+def test_deck_attach_image_to_bridge_session_uploads_and_pastes(monkeypatch, tmp_path):
+    import mcp_shim.agent_mail_server as shim
+
+    image_path = tmp_path / "screen.png"
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\nimage")
+    requests = []
+
+    def fake_bridge_request(method, path, **kwargs):
+        requests.append((method, path, kwargs))
+        if (method, path) == ("GET", "/token"):
+            return {"ok": True, "data": {"token": f"token-{len(requests)}"}}
+        assert kwargs["headers"]["X-Claude-Deck-Terminal-Token"].startswith("token-")
+        if method == "POST" and path == "/sessions/snazzy%3A0.0/attachments":
+            assert kwargs["data"]["created_by"] == "mcp"
+            assert kwargs["data"]["prompt"] == "Inspect {path}"
+            assert kwargs["files"]["file"][0] == "screen.png"
+            return {"ok": True, "data": {"id": 7, "prompt_text": "Inspect /tmp/screen.png"}}
+        if method == "POST" and path == "/sessions/snazzy%3A0.0/attachments/7/paste":
+            assert kwargs["json"] == {"submit": True}
+            return {"ok": True, "data": {"pasted": True, "submitted": True, "target": "snazzy:0.0"}}
+        raise AssertionError((method, path))
+
+    monkeypatch.setattr(shim, "_bridge_request", fake_bridge_request)
+
+    result = shim.deck_attach_image_to_bridge_session(
+        "snazzy:0.0",
+        str(image_path),
+        submit=True,
+        prompt="Inspect {path}",
+    )
+
+    assert result["ok"] is True
+    assert result["attachment"]["id"] == 7
+    assert result["paste"]["submitted"] is True
+
+
+def test_deck_attach_image_to_bridge_session_rejects_missing_file():
+    import mcp_shim.agent_mail_server as shim
+
+    result = shim.deck_attach_image_to_bridge_session("snazzy:0.0", "/tmp/does-not-exist.png")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "image_file_not_found"
+
+
+def test_deck_list_bridge_attachments_uses_bridge_api(monkeypatch):
+    import mcp_shim.agent_mail_server as shim
+
+    requests = []
+
+    def fake_bridge_request(method, path, **kwargs):
+        requests.append((method, path, kwargs))
+        if (method, path) == ("GET", "/token"):
+            return {"ok": True, "data": {"token": "token"}}
+        assert kwargs["headers"]["X-Claude-Deck-Terminal-Token"] == "token"
+        return {"ok": True, "data": {"attachments": [{"id": 1}]}}
+
+    monkeypatch.setattr(shim, "_bridge_request", fake_bridge_request)
+
+    result = shim.deck_list_bridge_attachments("snazzy:0.0")
+
+    assert result == {"ok": True, "attachments": [{"id": 1}]}
+    assert requests[1][0:2] == ("GET", "/sessions/snazzy%3A0.0/attachments")
+
+
 def test_deck_plan_team_launch_returns_plan_hash(monkeypatch):
     import mcp_shim.agent_mail_server as shim
 

--- a/backend/tests/test_agent_bridge_attachments.py
+++ b/backend/tests/test_agent_bridge_attachments.py
@@ -1,0 +1,219 @@
+"""Agent Bridge image attachment API tests."""
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+import app.models.database  # noqa: F401
+from app.config import settings
+from app.database import Base, get_db
+from app.main import app
+from app.models.database import BridgeSessionAttachment
+from app.services.agent_bridge.attachments import agent_bridge_attachment_service
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+
+
+@pytest_asyncio.fixture
+async def db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(db):
+    async def _override():
+        yield db
+
+    app.dependency_overrides[get_db] = _override
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(autouse=True)
+def attachment_boundaries(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings, "bridge_attachment_dir", str(tmp_path / "attachments"))
+    monkeypatch.setattr(settings, "bridge_attachment_agent_root", None)
+    monkeypatch.setattr(settings, "bridge_attachment_max_bytes", 1024)
+    monkeypatch.setattr(settings, "bridge_attachment_retention_days", 7)
+    monkeypatch.setattr(settings, "bridge_attachment_max_per_session_per_day", 100)
+    monkeypatch.setattr(
+        "app.services.agent_bridge.attachments.discover_agent_sessions",
+        lambda: [
+            {
+                "tmux_target": "snazzyemail:0.0",
+                "session_name": "snazzyemail",
+                "provider": "claude-code",
+            }
+        ],
+    )
+
+
+async def _token(client) -> str:
+    response = await client.get("/api/v1/agent-bridge/token")
+    assert response.status_code == 200
+    return response.json()["token"]
+
+
+@pytest.mark.asyncio
+async def test_upload_image_attachment_persists_metadata_and_file(client, db):
+    response = await client.post(
+        "/api/v1/agent-bridge/sessions/snazzyemail:0.0/attachments",
+        headers={"X-Claude-Deck-Terminal-Token": await _token(client)},
+        files={"file": ("../../screen.png", PNG_BYTES, "image/png")},
+        data={"prompt": "Please inspect\n{path}", "created_by": "test"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["target"] == "snazzyemail:0.0"
+    assert body["provider"] == "claude-code"
+    assert body["mime_type"] == "image/png"
+    assert body["original_filename"] == "../../screen.png"
+    assert "\n" not in body["prompt_text"]
+    assert body["agent_path"].endswith(".png")
+
+    attachment = await db.get(BridgeSessionAttachment, body["id"])
+    assert attachment is not None
+    assert attachment.created_by == "test"
+    assert attachment.storage_path.endswith(".png")
+
+
+@pytest.mark.asyncio
+async def test_attachment_token_is_required_and_single_use(client):
+    token = await _token(client)
+    first = await client.get(
+        "/api/v1/agent-bridge/sessions/snazzyemail:0.0/attachments",
+        headers={"X-Claude-Deck-Terminal-Token": token},
+    )
+    second = await client.get(
+        "/api/v1/agent-bridge/sessions/snazzyemail:0.0/attachments",
+        headers={"X-Claude-Deck-Terminal-Token": token},
+    )
+    missing = await client.get("/api/v1/agent-bridge/sessions/snazzyemail:0.0/attachments")
+
+    assert first.status_code == 200
+    assert second.status_code == 401
+    assert missing.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_attachment_endpoint_rejects_cross_origin(client):
+    response = await client.get(
+        "/api/v1/agent-bridge/sessions/snazzyemail:0.0/attachments",
+        headers={
+            "X-Claude-Deck-Terminal-Token": await _token(client),
+            "Origin": "https://evil.example",
+            "Host": "test",
+        },
+    )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_unsupported_file(client):
+    response = await client.post(
+        "/api/v1/agent-bridge/sessions/snazzyemail:0.0/attachments",
+        headers={"X-Claude-Deck-Terminal-Token": await _token(client)},
+        files={"file": ("notes.txt", b"not an image", "text/plain")},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Unsupported image type"
+
+
+@pytest.mark.asyncio
+async def test_paste_attachment_sends_literal_text_then_delayed_enter(client, monkeypatch):
+    upload = await client.post(
+        "/api/v1/agent-bridge/sessions/snazzyemail:0.0/attachments",
+        headers={"X-Claude-Deck-Terminal-Token": await _token(client)},
+        files={"file": ("screen.png", PNG_BYTES, "image/png")},
+    )
+    attachment_id = upload.json()["id"]
+    calls = []
+
+    def fake_run(args, **_kwargs):
+        calls.append(args)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("app.services.agent_bridge.attachments.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "app.services.agent_bridge.attachments.time.sleep",
+        lambda seconds: calls.append(["sleep", seconds]),
+    )
+
+    response = await client.post(
+        f"/api/v1/agent-bridge/sessions/snazzyemail:0.0/attachments/{attachment_id}/paste",
+        headers={"X-Claude-Deck-Terminal-Token": await _token(client)},
+        json={"submit": True, "prefix": "Look: ", "suffix": "\nthanks"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["submitted"] is True
+    assert calls[0][:5] == ["tmux", "send-keys", "-t", "snazzyemail:0.0", "-l"]
+    assert "\n" not in calls[0][5]
+    assert calls[1][0] == "sleep"
+    assert calls[2] == ["tmux", "send-keys", "-t", "snazzyemail:0.0", "Enter"]
+
+
+@pytest.mark.asyncio
+async def test_delete_attachment_removes_file_and_row(client, db):
+    upload = await client.post(
+        "/api/v1/agent-bridge/sessions/snazzyemail:0.0/attachments",
+        headers={"X-Claude-Deck-Terminal-Token": await _token(client)},
+        files={"file": ("screen.png", PNG_BYTES, "image/png")},
+    )
+    attachment_id = upload.json()["id"]
+    attachment = await db.get(BridgeSessionAttachment, attachment_id)
+    assert attachment is not None
+    storage_path = attachment.storage_path
+
+    response = await client.delete(
+        f"/api/v1/agent-bridge/sessions/snazzyemail:0.0/attachments/{attachment_id}",
+        headers={"X-Claude-Deck-Terminal-Token": await _token(client)},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["deleted"] is True
+    assert not Path(storage_path).exists()
+    assert await db.get(BridgeSessionAttachment, attachment_id) is None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_expired_removes_file_and_row(db, tmp_path):
+    storage_path = tmp_path / "attachments" / "expired.png"
+    storage_path.parent.mkdir(parents=True, exist_ok=True)
+    storage_path.write_bytes(PNG_BYTES)
+    now = datetime.now(UTC).replace(tzinfo=None)
+    attachment = BridgeSessionAttachment(
+        target="snazzyemail:0.0",
+        mime_type="image/png",
+        size_bytes=len(PNG_BYTES),
+        sha256="abc123",
+        storage_path=str(storage_path),
+        agent_path=str(storage_path),
+        prompt_text=f"Please inspect this image: {storage_path}",
+        created_at=now - timedelta(days=10),
+        expires_at=now - timedelta(days=1),
+    )
+    db.add(attachment)
+    await db.commit()
+    await db.refresh(attachment)
+
+    removed = await agent_bridge_attachment_service.cleanup_expired(db, now=now)
+
+    assert removed == 1
+    assert not storage_path.exists()
+    assert await db.get(BridgeSessionAttachment, attachment.id) is None

--- a/backend/tests/test_agent_bridge_attachments.py
+++ b/backend/tests/test_agent_bridge_attachments.py
@@ -169,6 +169,36 @@ async def test_paste_attachment_sends_literal_text_then_delayed_enter(client, mo
 
 
 @pytest.mark.asyncio
+async def test_paste_attachment_can_require_interactive_relay(client, monkeypatch):
+    upload = await client.post(
+        "/api/v1/agent-bridge/sessions/snazzyemail:0.0/attachments",
+        headers={"X-Claude-Deck-Terminal-Token": await _token(client)},
+        files={"file": ("screen.png", PNG_BYTES, "image/png")},
+    )
+    attachment_id = upload.json()["id"]
+    calls = []
+
+    monkeypatch.setattr(
+        "app.api.v1.agent_bridge.router.is_target_interactive",
+        lambda _target: False,
+    )
+    monkeypatch.setattr(
+        "app.services.agent_bridge.attachments.subprocess.run",
+        lambda args, **_kwargs: calls.append(args),
+    )
+
+    response = await client.post(
+        f"/api/v1/agent-bridge/sessions/snazzyemail:0.0/attachments/{attachment_id}/paste",
+        headers={"X-Claude-Deck-Terminal-Token": await _token(client)},
+        json={"submit": False, "require_interactive_relay": True},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Terminal relay is read-only or not attached"
+    assert calls == []
+
+
+@pytest.mark.asyncio
 async def test_delete_attachment_removes_file_and_row(client, db):
     upload = await client.post(
         "/api/v1/agent-bridge/sessions/snazzyemail:0.0/attachments",

--- a/docs/api/agent-bridge.md
+++ b/docs/api/agent-bridge.md
@@ -101,11 +101,14 @@ X-Claude-Deck-Terminal-Token: {token}
 
 ```json
 {
-  "submit": false
+  "submit": false,
+  "require_interactive_relay": true
 }
 ```
 
 `submit: true` sends Enter after a short delay. Generated prompt text strips newlines so `submit: false` cannot submit accidentally.
+
+When `require_interactive_relay` is `true`, the backend rejects the paste with `409` unless an active websocket relay for that target exists and is currently interactive. The web UI sets this flag so read-only mode is enforced server-side for UI paste actions.
 
 ```http
 GET /api/v1/agent-bridge/sessions/{target}/attachments
@@ -127,6 +130,8 @@ Agentic interfaces can use the MCP shim tools:
 - `deck_attach_image_to_bridge_session(target, file_path, submit, prompt)`
 - `deck_list_bridge_attachments(target)`
 - `deck_paste_bridge_attachment(target, attachment_id, submit)`
+
+MCP tools intentionally omit `require_interactive_relay`; MCP callers are trusted agentic callers and may paste into a live tmux target without an attached browser relay. `file_path` is resolved on the MCP host and may point to any image readable by that trusted MCP process; the backend validates the image and copies it into the attachment store before generating the agent-visible prompt.
 
 ### Spawn Session
 

--- a/docs/api/agent-bridge.md
+++ b/docs/api/agent-bridge.md
@@ -64,6 +64,70 @@ WS /api/v1/agent-bridge/sessions/{target}/terminal?token={token}&mode={mode}
 
 `mode` can be `readonly` or `interactive`.
 
+### Image Attachments
+
+Use image attachments to upload a screenshot or mockup to the Claude Deck host, then paste a file-path prompt into a live tmux session.
+
+All attachment endpoints require a fresh token from `GET /api/v1/agent-bridge/token` in the `X-Claude-Deck-Terminal-Token` header.
+
+```http
+POST /api/v1/agent-bridge/sessions/{target}/attachments
+Content-Type: multipart/form-data
+X-Claude-Deck-Terminal-Token: {token}
+```
+
+Multipart fields:
+
+- `file`: PNG, JPEG, WebP, or GIF image
+- `prompt`: optional prompt template containing `{path}`
+- `created_by`: optional source label
+
+```json
+{
+  "id": 123,
+  "target": "repo-1234:0.0",
+  "provider": "codex-cli",
+  "mime_type": "image/png",
+  "size_bytes": 482103,
+  "agent_path": "/home/user/.claude-registry/bridge-attachments/repo-1234/2026-06-29/185422-a1b2c3d4.png",
+  "prompt_text": "Please inspect this image: /home/user/.claude-registry/bridge-attachments/repo-1234/2026-06-29/185422-a1b2c3d4.png"
+}
+```
+
+```http
+POST /api/v1/agent-bridge/sessions/{target}/attachments/{attachment_id}/paste
+X-Claude-Deck-Terminal-Token: {token}
+```
+
+```json
+{
+  "submit": false
+}
+```
+
+`submit: true` sends Enter after a short delay. Generated prompt text strips newlines so `submit: false` cannot submit accidentally.
+
+```http
+GET /api/v1/agent-bridge/sessions/{target}/attachments
+DELETE /api/v1/agent-bridge/sessions/{target}/attachments/{attachment_id}
+```
+
+Attachments are stored by default under `~/.claude-registry/bridge-attachments`. In remote deployments, this path is on the Claude Deck host and must be readable by the tmux agent process.
+
+Configuration:
+
+- `BRIDGE_ATTACHMENT_DIR`: host storage directory
+- `BRIDGE_ATTACHMENT_AGENT_ROOT`: optional agent-visible root to use in pasted paths
+- `BRIDGE_ATTACHMENT_MAX_BYTES`: maximum accepted upload size
+- `BRIDGE_ATTACHMENT_RETENTION_DAYS`: retention window for startup cleanup
+- `BRIDGE_ATTACHMENT_MAX_PER_SESSION_PER_DAY`: per-session daily upload limit
+
+Agentic interfaces can use the MCP shim tools:
+
+- `deck_attach_image_to_bridge_session(target, file_path, submit, prompt)`
+- `deck_list_bridge_attachments(target)`
+- `deck_paste_bridge_attachment(target, attachment_id, submit)`
+
 ### Spawn Session
 
 ```http

--- a/docs/superpowers/specs/2026-06-29-agent-bridge-image-paste-design.md
+++ b/docs/superpowers/specs/2026-06-29-agent-bridge-image-paste-design.md
@@ -172,11 +172,12 @@ If the terminal is read-only:
 - pasting/dropping can still upload the image and show the generated prompt,
 - the final `Paste reference` / `Paste and submit` action should be disabled until the user switches to interactive mode, or offer a one-click "Switch to interactive and paste" action.
 
-Important implementation detail: read-only is currently per-websocket relay state (`PtyRelay.read_only`), not a persisted server-side session policy. The REST paste endpoint cannot infer which browser tab's read-only toggle should govern a target, and it should remain usable even when no browser is attached. Therefore:
+Important implementation detail: read-only is currently per-websocket relay state (`PtyRelay.read_only`), not a persisted server-side session policy. The paste API should support both browser-driven paste actions and trusted agentic callers. Therefore:
 
-- read-only is a UI/client affordance, not an API authorization boundary,
-- the frontend must not call the paste endpoint from a read-only terminal unless the user explicitly switches to interactive mode,
-- the backend paste endpoint is protected by the terminal token/same-origin write contract in §6.6, not by read-only relay state.
+- the paste request may set `require_interactive_relay=true` to require a live interactive websocket relay for the target,
+- the web UI must set `require_interactive_relay=true` so the backend rejects paste from a read-only or detached terminal,
+- MCP/agentic callers may omit `require_interactive_relay` because they are intentionally privileged and may operate without an attached browser relay,
+- all paste calls remain protected by the terminal token/same-origin write contract in §6.6.
 
 ---
 
@@ -329,6 +330,7 @@ Body:
 ```json
 {
   "submit": false,
+  "require_interactive_relay": true,
   "prefix": "",
   "suffix": ""
 }
@@ -512,7 +514,7 @@ This is useful when an agent has already created an image file on the Deck host.
 
 Security constraints:
 
-- file must be under an allowed root,
+- `file_path` is resolved by the trusted MCP process; deployments that expose MCP to less-trusted callers should wrap this tool with an allowed-root policy,
 - image MIME/signature validation still applies,
 - copy file into the Deck attachment store instead of referencing arbitrary paths directly.
 
@@ -532,7 +534,7 @@ deck_paste_bridge_attachment(
 ) -> dict
 ```
 
-MCP should surface backend validation errors verbatim, including file size/type and path-visibility errors.
+MCP should surface validation errors verbatim, including local source-file errors and backend file size/type errors.
 
 ---
 

--- a/docs/superpowers/specs/2026-06-29-agent-bridge-image-paste-design.md
+++ b/docs/superpowers/specs/2026-06-29-agent-bridge-image-paste-design.md
@@ -1,0 +1,715 @@
+# Agent Bridge Image Paste — Design Spec & Implementation Plan
+
+**Status:** Draft for review (no implementation committed)
+**Date:** 2026-06-29
+**Target version:** post-2.0.1
+**Scope:** Add image paste / drag-drop support to Agent Bridge terminal sessions so a browser user can provide screenshots, mockups, diagrams, and other images to Claude Code, Codex CLI, OpenCode CLI, and future tmux-backed agents.
+
+---
+
+## 1. Problem & Motivation
+
+Agent Bridge is now usable for observing and interacting with local/remote tmux-backed agent sessions, but it is still missing the main affordance users expect from native agent UIs: **paste an image into the active agent conversation**.
+
+The current terminal bridge can relay keyboard input into a `tmux attach-session` pty, but a browser clipboard image is binary data and the underlying CLIs do not receive browser attachments through tmux. The right user-facing outcome is:
+
+1. user focuses an Agent Bridge terminal,
+2. user pastes or drops an image,
+3. Claude Deck stores the image somewhere the tmux agent process can read,
+4. Claude Deck injects a concise prompt containing the image file path,
+5. the agent CLI handles the image path using its own multimodal/file-ingestion behavior.
+
+This is especially important when Claude Deck is running on a remote machine. In that case, the browser clipboard image originates on the user's laptop, but the agent and tmux session run on the remote host. Uploading the image to the Deck backend solves that mismatch cleanly: the pasted path is remote-local to the agent process.
+
+---
+
+## 2. Current Architecture (as-is)
+
+### 2.1 Terminal relay path
+
+Current Agent Bridge terminal input flows through:
+
+```
+frontend/src/features/cc-bridge/useTerminal.ts
+  └─ WebSocket to /api/v1/agent-bridge/sessions/{target}/terminal
+       └─ backend/app/api/v1/agent_bridge/router.py
+            └─ PtyRelay(target)
+                 └─ backend/app/services/agent_bridge/pty_relay.py
+                      ├─ pty.openpty()
+                      ├─ subprocess.Popen(["tmux", "attach-session", "-t", target], stdin/out/err=slave_fd)
+                      └─ websocket text/bytes frames write to pty master fd
+```
+
+Important consequences:
+
+- The browser can send text/bytes to the pty, but the relay has no concept of browser files or attachments.
+- The relay already has control messages (`resize`, `mode`) via JSON text frames.
+- The public Agent Bridge namespace is `backend/app/services/agent_bridge/`; the legacy `cc_bridge` backend modules are compatibility shims and should not be the target for new code. The frontend directory is still `frontend/src/features/cc-bridge/`.
+- Interactive input is disabled when a specific websocket relay is in read-only mode.
+- Any pasted text is currently treated as terminal input by `xterm` / `term.onData`.
+
+### 2.2 Agent Bridge session metadata
+
+Agent Bridge sessions expose provider/session/team metadata via:
+
+- `GET /api/v1/agent-bridge/sessions`
+- `frontend/src/features/cc-bridge/types.ts`
+
+The target session has enough metadata to choose a provider-aware prompt template:
+
+- `provider`
+- `provider_display_name`
+- `tmux_target`
+- `session_name`
+- optional Agent Team role/color metadata
+
+### 2.3 Storage assumptions
+
+Claude Deck defaults to local SQLite (`claude_registry.db`) and does not currently have a general attachment store. Existing filesystem state lives under user-owned directories, not a formal Deck data directory.
+
+For this feature, attachments should be stored in a Deck-managed path on the same machine/filesystem namespace as the tmux process.
+
+---
+
+## 3. Goals
+
+### G1 — Browser image paste
+
+When an Agent Bridge terminal is focused, `Ctrl/Cmd+V` with an image in the clipboard should offer to attach that image to the active tmux session.
+
+### G2 — Drag/drop image
+
+Dragging an image file onto a terminal pane should follow the same attachment flow as clipboard paste.
+
+### G3 — Remote Deck compatibility
+
+If Claude Deck runs on a remote machine, the image must be uploaded to and saved on that remote machine, then referenced by a path visible to the tmux agent.
+
+### G4 — Explicit user control
+
+Users should be able to choose:
+
+- paste image reference into the terminal without submitting,
+- paste image reference and submit,
+- cancel.
+
+The safe default should be **paste without auto-submit**.
+
+### G5 — Provider-aware prompt templates
+
+The generated prompt should be provider-aware, while falling back to a generic file-path instruction:
+
+```
+Please inspect this image: /path/to/image.png
+```
+
+Provider-specific templates can evolve independently.
+
+### G6 — API-accessible attachment flow
+
+The feature should be usable through REST, not only the React UI.
+
+### G7 — Agentic interface support
+
+Agentic callers should be able to attach an existing server-side file or uploaded image to a Bridge session through MCP/deck tools once the backend API exists.
+
+### G8 — Quotas, validation, and cleanup
+
+The backend must enforce file type, size, storage, and retention controls.
+
+---
+
+## 4. Non-Goals
+
+- Rendering images inside the terminal using Kitty graphics, Sixel, iTerm inline images, or OSC escape sequences.
+- Sending raw base64 image data into the terminal input stream.
+- Building a general-purpose file manager.
+- Guaranteeing every provider CLI can consume every image format. Deck's responsibility is to store the file and inject a usable reference.
+- Supporting remote agent processes that cannot see the Deck attachment directory unless an explicit mount/path mapping is configured.
+- Adding chat-style rich message UI to Agent Bridge.
+
+---
+
+## 5. Proposed UX
+
+### 5.1 Clipboard paste flow
+
+1. User focuses an interactive Agent Bridge terminal.
+2. User presses `Ctrl+V` / `Cmd+V`.
+3. Frontend detects image clipboard item(s).
+4. Frontend uploads the selected image to:
+
+   ```
+   POST /api/v1/agent-bridge/sessions/{target}/attachments
+   ```
+
+5. Frontend shows a compact confirmation dialog/toast:
+
+   - thumbnail preview,
+   - file name,
+   - size,
+   - target session label,
+   - generated prompt text,
+   - actions:
+     - `Paste reference`
+     - `Paste and submit`
+     - `Cancel`
+
+6. On confirmation, frontend calls the REST paste endpoint to inject the generated text into the active session.
+
+### 5.2 Drag/drop flow
+
+1. User drags one image onto a terminal pane.
+2. Terminal pane highlights as a drop target.
+3. Drop follows the same upload + confirmation flow.
+
+For MVP, support one image per action. Multiple image support can be added after the storage/API semantics are stable.
+
+### 5.3 Read-only mode behavior
+
+If the terminal is read-only:
+
+- pasting/dropping can still upload the image and show the generated prompt,
+- the final `Paste reference` / `Paste and submit` action should be disabled until the user switches to interactive mode, or offer a one-click "Switch to interactive and paste" action.
+
+Important implementation detail: read-only is currently per-websocket relay state (`PtyRelay.read_only`), not a persisted server-side session policy. The REST paste endpoint cannot infer which browser tab's read-only toggle should govern a target, and it should remain usable even when no browser is attached. Therefore:
+
+- read-only is a UI/client affordance, not an API authorization boundary,
+- the frontend must not call the paste endpoint from a read-only terminal unless the user explicitly switches to interactive mode,
+- the backend paste endpoint is protected by the terminal token/same-origin write contract in §6.6, not by read-only relay state.
+
+---
+
+## 6. Backend Design
+
+### 6.1 Attachment storage
+
+Add a configured attachment root:
+
+```
+Settings.bridge_attachment_dir
+env: CLAUDE_DECK_BRIDGE_ATTACHMENT_DIR
+default: ~/.claude-registry/bridge-attachments
+```
+
+Add this as a `Settings` field in `backend/app/config.py` using the existing `pydantic-settings` mechanism. Do not add free-floating `os.getenv()` reads. The codebase already uses `~/.claude-registry` for user-owned app data such as backups, so attachments should live there rather than introducing a new `~/.claude-deck` directory.
+
+Store files under a session-scoped directory:
+
+```
+{attachment_root}/{safe_session_name_or_target_hash}/{yyyy-mm-dd}/{timestamp}-{short_sha256}.{ext}
+```
+
+Example:
+
+```
+/home/juan/.claude-registry/bridge-attachments/snazzyemail-85b9/2026-06-29/185422-a1b2c3d4.png
+```
+
+The saved path returned to the frontend must be the path visible to the agent process. By default, this is the absolute host path.
+
+### 6.2 Docker / namespace path mapping
+
+Add optional config for deployments where the backend and tmux agent do not share the same filesystem namespace:
+
+```
+Settings.bridge_attachment_agent_root
+env: CLAUDE_DECK_BRIDGE_ATTACHMENT_AGENT_ROOT
+default: same as Settings.bridge_attachment_dir
+```
+
+If set, API responses use `agent_path` computed by replacing the storage root prefix with the agent root prefix:
+
+```
+storage_path: /app/data/bridge-attachments/session/img.png
+agent_path:   /home/user/.claude-registry/bridge-attachments/session/img.png
+```
+
+This supports Docker bind mounts:
+
+```
+host:      ~/.claude-registry/bridge-attachments
+container: /app/data/bridge-attachments
+```
+
+If no shared path exists, the API should return a clear configuration error instead of generating a path the agent cannot read.
+
+### 6.3 File validation
+
+Allow only image MIME types:
+
+- `image/png`
+- `image/jpeg`
+- `image/webp`
+- `image/gif` (optional for MVP; static/animated ambiguity)
+
+Recommended defaults:
+
+- max file size: `10 MB`
+- max decoded dimensions: `12000 x 12000`
+- max attachments per session per day: `100`
+- max total attachment storage: configurable, default `1 GB`
+- filename length limit: generated names only; ignore user-supplied path components
+
+Validation should inspect file signatures, not only `Content-Type`.
+
+### 6.4 Metadata persistence
+
+Add a lightweight SQLAlchemy ORM model in `backend/app/models/database.py`. This is a brand-new table, so `Base.metadata.create_all()` can create it safely for existing SQLite users; no destructive rebuild of existing tables is required.
+
+```python
+class BridgeSessionAttachment(Base):
+    __tablename__ = "bridge_session_attachments"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    target: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    session_name: Mapped[str | None] = mapped_column(String, nullable=True)
+    provider: Mapped[str | None] = mapped_column(String, nullable=True)
+    original_filename: Mapped[str | None] = mapped_column(String, nullable=True)
+    mime_type: Mapped[str] = mapped_column(String, nullable=False)
+    size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
+    sha256: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    storage_path: Mapped[str] = mapped_column(String, nullable=False)
+    agent_path: Mapped[str] = mapped_column(String, nullable=False)
+    prompt_text: Mapped[str] = mapped_column(String, nullable=False)
+    created_by: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+```
+
+Rationale:
+
+- enables listing recent attachments,
+- enables cleanup,
+- gives auditability for agentic calls,
+- allows API response reconstruction.
+
+### 6.5 REST endpoints
+
+#### Upload image
+
+```http
+POST /api/v1/agent-bridge/sessions/{target}/attachments
+Content-Type: multipart/form-data
+X-Claude-Deck-Terminal-Token: <token from GET /api/v1/agent-bridge/token>
+```
+
+Fields:
+
+- `file`: required image file
+- `template`: optional template id, default provider-specific default
+- `prompt`: optional explicit prompt override containing `{path}` placeholder
+- `created_by`: optional source label (`deck-ui`, `mcp`, etc.)
+
+Response:
+
+```json
+{
+  "id": 123,
+  "target": "snazzyemail-85b9:0.0",
+  "provider": "claude-code",
+  "mime_type": "image/png",
+  "size_bytes": 482103,
+  "sha256": "...",
+  "agent_path": "/home/juan/.claude-registry/bridge-attachments/snazzyemail-85b9/2026-06-29/185422-a1b2c3d4.png",
+  "prompt_text": "Please inspect this image: /home/juan/.claude-registry/bridge-attachments/snazzyemail-85b9/2026-06-29/185422-a1b2c3d4.png",
+  "created_at": "2026-06-29T18:54:22Z"
+}
+```
+
+#### Paste attachment prompt into tmux
+
+```http
+POST /api/v1/agent-bridge/sessions/{target}/attachments/{attachment_id}/paste
+X-Claude-Deck-Terminal-Token: <fresh token from GET /api/v1/agent-bridge/token>
+```
+
+Body:
+
+```json
+{
+  "submit": false,
+  "prefix": "",
+  "suffix": ""
+}
+```
+
+Behavior:
+
+- validate target matches attachment,
+- validate target currently exists,
+- inject `prompt_text` into the tmux session,
+- if `submit=true`, send Enter after the prompt.
+
+Response:
+
+```json
+{
+  "pasted": true,
+  "submitted": false,
+  "target": "snazzyemail-85b9:0.0"
+}
+```
+
+#### List recent attachments
+
+```http
+GET /api/v1/agent-bridge/sessions/{target}/attachments
+X-Claude-Deck-Terminal-Token: <fresh token from GET /api/v1/agent-bridge/token>
+```
+
+Useful for recovery and future UI.
+
+#### Delete attachment
+
+```http
+DELETE /api/v1/agent-bridge/sessions/{target}/attachments/{attachment_id}
+X-Claude-Deck-Terminal-Token: <fresh token from GET /api/v1/agent-bridge/token>
+```
+
+Delete DB row and file if the file is still under the configured attachment root.
+
+### 6.6 Write authorization
+
+All attachment endpoints should require the same short-lived, single-use token mechanism used by the terminal websocket. Upload, paste, and delete are write surfaces; list is read-only but exposes sensitive local file paths.
+
+1. frontend calls `GET /api/v1/agent-bridge/token`,
+2. frontend sends the returned token in `X-Claude-Deck-Terminal-Token`,
+3. backend validates and consumes the token with the same TTL semantics as websocket attach.
+
+The paste endpoint is especially sensitive because it can inject keystrokes and optionally press Enter. It must not be less protected than the terminal websocket.
+
+REST endpoints should also perform an Origin/Host same-origin check when the request has an `Origin` header. Implement this as a request-aware helper equivalent to the websocket `_is_same_origin` logic.
+
+### 6.7 Injection mechanism
+
+Use `tmux send-keys -l` for REST paste endpoint, following the existing precedent in `agent_mail_service._send_tmux_inbox_check`:
+
+```bash
+tmux send-keys -t "$target" -l "$prompt_text"
+sleep "$TMUX_ENTER_DELAY_SECONDS"
+tmux send-keys -t "$target" Enter   # only if submit=true
+```
+
+Keep the delay between literal text injection and Enter. Agent TUIs can miss or partially process pasted text if Enter is sent immediately.
+
+Reuse the same error semantics as `_send_tmux_inbox_check`:
+
+- `FileNotFoundError` → `ValueError("tmux is not installed or not available")`
+- `subprocess.CalledProcessError` → include the first part of stderr
+- `subprocess.TimeoutExpired` → `ValueError("tmux send-keys timed out")`
+
+Do not write the prompt through an arbitrary active websocket relay. REST injection should work even if the user is not currently attached in the browser.
+
+The websocket relay can still support a frontend-only path later, but the REST endpoint is the more useful primitive.
+
+### 6.8 Provider-aware prompt templates
+
+Initial templates:
+
+| Provider | Template |
+|---|---|
+| `claude-code` | `Please inspect this image: {path}` |
+| `codex-cli` | `Please inspect this image: {path}` |
+| `opencode-cli` | `Please inspect this image: {path}` |
+| `copilot-cli` | `Please inspect this image: {path}` |
+| unknown | `Please inspect this image: {path}` |
+
+Future templates can be customized if a provider has a better file-attachment syntax.
+
+Prompt override rules:
+
+- reject overrides missing `{path}`,
+- cap final prompt length,
+- strip NUL characters,
+- strip all newlines from the final `prompt_text`; embedded `\n` sent through `tmux send-keys -l` can submit text even when `submit=false`,
+- do not shell-expand paths.
+
+---
+
+## 7. Frontend Design
+
+### 7.1 Files to touch
+
+Likely frontend touch points:
+
+- `frontend/src/features/cc-bridge/TerminalView.tsx`
+- `frontend/src/features/cc-bridge/useTerminal.ts`
+- `frontend/src/features/cc-bridge/api.ts`
+- `frontend/src/features/cc-bridge/types.ts`
+- new component: `frontend/src/features/cc-bridge/ImageAttachmentDialog.tsx`
+
+### 7.2 Clipboard detection
+
+Add a paste handler to the terminal wrapper:
+
+- ignore if no active `target`,
+- inspect `event.clipboardData.items`,
+- find image items,
+- call `preventDefault()` only when handling an image,
+- preserve existing text paste behavior for non-image clipboard contents.
+
+The handler should live at the terminal pane level, not globally, so normal app text inputs keep their existing paste behavior.
+
+### 7.3 Drag/drop detection
+
+Add `dragover`, `dragleave`, and `drop` behavior on the terminal wrapper:
+
+- show visual drop overlay only for image files,
+- reject non-image files with a clear toast,
+- support one image for MVP.
+
+### 7.4 Confirmation dialog
+
+Dialog state should contain:
+
+```ts
+{
+  file: File
+  previewUrl: string
+  target: string
+  session?: CCSession | null
+  uploadState: 'idle' | 'uploading' | 'uploaded' | 'error'
+  uploadedAttachment?: BridgeAttachment
+}
+```
+
+The dialog should:
+
+- show thumbnail preview,
+- show target/session label,
+- show generated prompt text after upload,
+- offer `Paste reference`, `Paste and submit`, and `Cancel`.
+
+### 7.5 Read-only mode
+
+`TerminalView` already knows `readOnly` from `useTerminal`. Use it to disable paste actions that inject text, or to show a controlled "Switch to interactive" affordance.
+
+### 7.6 Accessibility
+
+- Dialog buttons must be keyboard reachable.
+- Drop overlay must not trap focus.
+- Error messages must be visible as text, not only toast.
+
+---
+
+## 8. Agentic / MCP Interface
+
+Once REST endpoints exist, add MCP tools through a shared Deck MCP surface rather than continuing to grow a file named only for mail. Short-term implementation may still touch `backend/mcp_shim/agent_mail_server.py` because that is the installed Deck MCP shim today, but the implementation should introduce prefix-aware request helpers and keep the tool names Bridge-specific.
+
+### 8.1 Attach existing server-side file
+
+```python
+deck_attach_image_to_bridge_session(
+    target: str,
+    file_path: str,
+    submit: bool = False,
+    prompt: str | None = None,
+) -> dict
+```
+
+This is useful when an agent has already created an image file on the Deck host.
+
+Security constraints:
+
+- file must be under an allowed root,
+- image MIME/signature validation still applies,
+- copy file into the Deck attachment store instead of referencing arbitrary paths directly.
+
+### 8.2 List attachments
+
+```python
+deck_list_bridge_attachments(target: str) -> dict
+```
+
+### 8.3 Paste existing attachment
+
+```python
+deck_paste_bridge_attachment(
+    target: str,
+    attachment_id: int,
+    submit: bool = False,
+) -> dict
+```
+
+MCP should surface backend validation errors verbatim, including file size/type and path-visibility errors.
+
+---
+
+## 9. Security & Privacy Considerations
+
+### 9.1 Upload surface
+
+Image upload is a new write surface. It must inherit existing same-origin/token assumptions and should not be exposed without the same trust boundary as Agent Bridge interactive input.
+
+Controls:
+
+- same-origin checks for websocket remain unchanged,
+- all attachment REST endpoints require a fresh single-use terminal token,
+- REST attachment endpoints reject cross-origin browser requests when `Origin` does not match `Host` or localhost,
+- reject non-images,
+- reject over-limit images before storing,
+- generate server-side filenames,
+- never write outside the configured attachment root,
+- do not follow symlinks during delete/cleanup,
+- do not expose raw storage paths for files outside the attachment root.
+
+### 9.2 Prompt injection through filenames
+
+Do not include user-supplied filenames in pasted prompts. Only include server-generated `agent_path`.
+
+### 9.3 Sensitive images
+
+The UI should communicate that pasted images are saved on the Deck host until cleanup/expiry.
+
+Possible copy:
+
+> Image will be uploaded to this Claude Deck host and saved as a temporary attachment visible to the selected tmux session.
+
+### 9.4 Cleanup
+
+Add a scheduled or startup cleanup task:
+
+- delete expired DB rows and files,
+- default retention: `7 days`,
+- configurable via `Settings.bridge_attachment_retention_days` / `CLAUDE_DECK_BRIDGE_ATTACHMENT_RETENTION_DAYS`,
+- allow manual delete from API.
+
+---
+
+## 10. Remote Deployment Matrix
+
+| Deck backend | Browser | tmux/agent | Expected behavior |
+|---|---|---|---|
+| local host | same local browser | same host | Upload saves locally; pasted path works. |
+| remote host | local browser over HTTPS/tunnel | same remote host | Upload saves remotely; pasted remote path works. |
+| Docker container | browser anywhere | tmux inside same container | Container path works. |
+| Docker container | browser anywhere | tmux on host | Requires bind mount + `CLAUDE_DECK_BRIDGE_ATTACHMENT_AGENT_ROOT`; otherwise block with config error. |
+| host backend | browser anywhere | agent inside separate container | Requires bind mount path visible inside container; otherwise block/warn. |
+| remote SSH-only tmux not on Deck host | browser anywhere | different machine | Out of scope unless Deck gains a remote file transfer backend. |
+
+Key rule:
+
+> The `agent_path` in the pasted prompt must be readable by the tmux agent process.
+
+---
+
+## 11. Implementation Plan
+
+### Phase 1 — Backend storage and REST paste
+
+1. Add config values in `backend/app/config.py`:
+   - `bridge_attachment_dir`,
+   - `bridge_attachment_agent_root`,
+   - `bridge_attachment_max_bytes`,
+   - `bridge_attachment_retention_days`.
+2. Add `BridgeSessionAttachment` SQLAlchemy model.
+3. Add Pydantic schemas:
+   - `BridgeAttachmentResponse`
+   - `BridgeAttachmentPasteRequest`
+   - `BridgeAttachmentPasteResponse`
+4. Add attachment service:
+   - validate target exists via `discover_agent_sessions`,
+   - validate image,
+   - compute sha256,
+   - save file atomically,
+   - create DB row,
+   - generate prompt text.
+5. Add REST endpoints under `backend/app/api/v1/agent_bridge/router.py`.
+6. Add terminal-token validation and request same-origin checking for REST attachment endpoints.
+7. Add `tmux send-keys` injection helper with the existing Enter delay/error handling pattern.
+8. Add backend tests.
+
+### Phase 2 — Frontend paste/drop UX
+
+1. Add API client methods in `frontend/src/features/cc-bridge/api.ts`.
+2. Add `BridgeAttachment` types.
+3. Add paste/drop handling in `TerminalView`.
+4. Add `ImageAttachmentDialog`.
+5. Respect read-only mode.
+6. Add error/toast states.
+7. Run targeted lint and build.
+
+### Phase 3 — Agentic interface
+
+1. Add MCP tool(s) for server-side file attachment and paste.
+2. Add docs to the MCP tool docstrings.
+3. Add shim tests.
+
+### Phase 4 — Cleanup and polish
+
+1. Add retention cleanup task.
+2. Add list/delete UI if needed.
+3. Add provider-template customization if real-world CLI testing shows better prompts.
+
+---
+
+## 12. Test Plan
+
+### Backend unit/integration tests
+
+- Upload valid PNG returns `agent_path` and persisted metadata.
+- Upload rejects unsupported MIME type.
+- Upload rejects oversized file.
+- Upload sanitizes original filename.
+- Upload rejects unknown/dead tmux target.
+- Upload/list/paste/delete reject missing, expired, reused, or invalid terminal tokens.
+- Paste endpoint uses `tmux send-keys -l`.
+- Paste strips newlines from final prompt text.
+- `submit=true` waits `TMUX_ENTER_DELAY_SECONDS` and then sends Enter.
+- Docker path mapping produces correct `agent_path`.
+- Delete refuses paths outside attachment root.
+- Cleanup removes expired rows/files.
+
+### Frontend tests / validation
+
+- Pasting text still behaves as normal terminal paste.
+- Pasting image opens attachment dialog.
+- Dropping image opens attachment dialog.
+- Dropping non-image shows error.
+- Read-only terminal does not call the paste endpoint unless the user explicitly switches to interactive mode.
+- `Paste reference` injects prompt without Enter.
+- `Paste and submit` injects prompt with Enter.
+
+### Manual E2E
+
+1. Launch a Claude Code session through Agent Bridge.
+2. Attach interactively.
+3. Paste a PNG screenshot.
+4. Confirm `Paste reference`.
+5. Verify prompt appears in terminal and image path exists.
+6. Press Enter manually and confirm Claude can inspect the image.
+7. Repeat with `Paste and submit`.
+8. Repeat against remote Deck accessed through browser.
+9. Repeat with an Agent Team session to ensure session card theme changes do not affect paste behavior.
+
+---
+
+## 13. Open Questions for Reviewer
+
+Resolved decisions:
+
+- Upload before confirmation. This is the only way to preview the exact `agent_path` and `prompt_text`; abandoned uploads are handled by retention cleanup.
+- Default attachment root is `~/.claude-registry/bridge-attachments`.
+
+Remaining questions:
+
+1. Should `submit=true` be hidden behind a setting?
+2. Should attachment retention default to `24 hours` instead of `7 days`?
+3. Should MVP include multiple images in one prompt?
+4. Should we expose a per-provider editable prompt template in config?
+5. Should Agent Bridge have a visible attachment history panel, or is API/list enough for now?
+
+---
+
+## 14. Recommended MVP Decision
+
+Implement **single-image paste/drop → upload to Deck host → preview dialog → paste generated file-path prompt**.
+
+Do not implement terminal image rendering or base64 terminal injection. Those paths are more fragile and less aligned with what the agent CLIs need.
+
+The critical backend invariant is:
+
+> If Deck returns an `agent_path`, the tmux agent process should be able to read it.
+
+If that invariant cannot be satisfied for a deployment, the API should fail loudly with configuration guidance rather than pasting a broken path.

--- a/frontend/src/features/cc-bridge/ImageAttachmentDialog.tsx
+++ b/frontend/src/features/cc-bridge/ImageAttachmentDialog.tsx
@@ -1,0 +1,125 @@
+import { AlertTriangle, Image as ImageIcon, Loader2 } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import type { BridgeAttachment } from './types'
+
+interface ImageAttachmentDialogProps {
+  open: boolean
+  fileName: string
+  fileSize: number
+  previewUrl: string
+  targetLabel: string
+  uploading: boolean
+  pasting: boolean
+  readOnly: boolean
+  error: string | null
+  attachment: BridgeAttachment | null
+  onOpenChange: (open: boolean) => void
+  onPaste: (submit: boolean) => void
+  onSwitchInteractive: () => void
+}
+
+function formatBytes(value: number): string {
+  if (value < 1024) return `${value} B`
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KB`
+  return `${(value / (1024 * 1024)).toFixed(1)} MB`
+}
+
+export function ImageAttachmentDialog({
+  open,
+  fileName,
+  fileSize,
+  previewUrl,
+  targetLabel,
+  uploading,
+  pasting,
+  readOnly,
+  error,
+  attachment,
+  onOpenChange,
+  onPaste,
+  onSwitchInteractive,
+}: ImageAttachmentDialogProps) {
+  const canPaste = Boolean(attachment) && !uploading && !pasting && !readOnly
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ImageIcon className="h-5 w-5" />
+            Attach image to session
+          </DialogTitle>
+          <DialogDescription>
+            Uploads the image to this Claude Deck host and pastes a file-path prompt into {targetLabel}.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 md:grid-cols-[180px_1fr]">
+          <div className="overflow-hidden rounded-md border bg-muted">
+            <img src={previewUrl} alt="" className="h-40 w-full object-contain" />
+          </div>
+          <div className="min-w-0 space-y-3 text-sm">
+            <div>
+              <p className="font-medium truncate" title={fileName}>{fileName}</p>
+              <p className="text-muted-foreground">{formatBytes(fileSize)}</p>
+            </div>
+
+            {uploading && (
+              <div className="flex items-center gap-2 text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Uploading image...
+              </div>
+            )}
+
+            {error && (
+              <div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-destructive">
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                <p>{error}</p>
+              </div>
+            )}
+
+            {attachment && (
+              <div>
+                <p className="mb-1 text-xs uppercase text-muted-foreground">Prompt to paste</p>
+                <p className="max-h-28 overflow-y-auto rounded-md border bg-muted/40 p-2 font-mono text-xs">
+                  {attachment.prompt_text}
+                </p>
+              </div>
+            )}
+
+            {readOnly && !error && (
+              <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-amber-300">
+                This terminal is read-only. Switch to interactive mode before pasting into tmux.
+              </div>
+            )}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={pasting}>
+            Cancel
+          </Button>
+          {readOnly && (
+            <Button variant="outline" onClick={onSwitchInteractive} disabled={uploading || pasting}>
+              Switch to interactive
+            </Button>
+          )}
+          <Button variant="outline" onClick={() => onPaste(false)} disabled={!canPaste}>
+            {pasting ? 'Pasting...' : 'Paste reference'}
+          </Button>
+          <Button onClick={() => onPaste(true)} disabled={!canPaste}>
+            {pasting ? 'Pasting...' : 'Paste and submit'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/features/cc-bridge/TerminalView.tsx
+++ b/frontend/src/features/cc-bridge/TerminalView.tsx
@@ -148,7 +148,7 @@ export function TerminalView({ target, fullscreen, onToggleFullscreen, onClose, 
     const attachment = imageAttachment.attachment
     setImageAttachment((current) => current ? { ...current, pasting: true, error: null } : current)
     try {
-      await pasteBridgeAttachment(target, attachment.id, { submit })
+      await pasteBridgeAttachment(target, attachment.id, { submit, require_interactive_relay: true })
       toast.success(submit ? 'Image prompt pasted and submitted' : 'Image prompt pasted')
       closeImageAttachment()
     } catch (error) {

--- a/frontend/src/features/cc-bridge/TerminalView.tsx
+++ b/frontend/src/features/cc-bridge/TerminalView.tsx
@@ -1,11 +1,14 @@
-import { useMemo, useRef, useEffect } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Monitor, Maximize2, Minimize2, X } from 'lucide-react'
+import { toast } from 'sonner'
 import { useTerminal } from './useTerminal'
+import { ImageAttachmentDialog } from './ImageAttachmentDialog'
+import { pasteBridgeAttachment, uploadBridgeAttachment } from './api'
 import { Button } from '@/components/ui/button'
 import { getTeamSlotColorClasses, getTeamSlotTerminalTheme } from '@/lib/agentTeamColors'
 import { getInstanceAccentClasses } from '@/lib/instanceAccent'
 import { cn } from '@/lib/utils'
-import type { CCSession } from './types'
+import type { BridgeAttachment, CCSession } from './types'
 import type { InstanceIdentity } from '@/types/status'
 
 interface TerminalViewProps {
@@ -17,9 +20,44 @@ interface TerminalViewProps {
   session?: CCSession | null
 }
 
+interface ImageAttachmentState {
+  fileName: string
+  fileSize: number
+  previewUrl: string
+  attachment: BridgeAttachment | null
+  uploading: boolean
+  pasting: boolean
+  error: string | null
+}
+
+function firstImageFile(files: FileList | File[] | null | undefined): File | null {
+  if (!files) return null
+  return Array.from(files).find((file) => file.type.startsWith('image/')) ?? null
+}
+
+function hasDraggedImage(dataTransfer: DataTransfer): boolean {
+  const items = Array.from(dataTransfer.items)
+  if (items.length > 0) {
+    return items.some((item) => item.kind === 'file' && item.type.startsWith('image/'))
+  }
+  return Boolean(firstImageFile(dataTransfer.files))
+}
+
+function imageFromClipboard(event: React.ClipboardEvent<HTMLDivElement>): File | null {
+  const items = Array.from(event.clipboardData.items)
+  for (const item of items) {
+    if (item.kind === 'file' && item.type.startsWith('image/')) {
+      return item.getAsFile()
+    }
+  }
+  return null
+}
+
 export function TerminalView({ target, fullscreen, onToggleFullscreen, onClose, instance, session }: TerminalViewProps) {
   const wrapperRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
+  const [draggingImage, setDraggingImage] = useState(false)
+  const [imageAttachment, setImageAttachment] = useState<ImageAttachmentState | null>(null)
   const slotColor = session?.team_slot_color
   const terminalTheme = useMemo(() => getTeamSlotTerminalTheme(slotColor), [slotColor])
   const { connected, readOnly, setReadOnly, attach, detach } = useTerminal(containerRef, wrapperRef, terminalTheme)
@@ -36,9 +74,104 @@ export function TerminalView({ target, fullscreen, onToggleFullscreen, onClose, 
     }
   }, [target, attach, detach])
 
+  useEffect(() => {
+    const previewUrl = imageAttachment?.previewUrl
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl)
+    }
+  }, [imageAttachment?.previewUrl])
+
+  const closeImageAttachment = useCallback(() => {
+    setImageAttachment(null)
+  }, [])
+
+  const attachImageFile = useCallback(async (file: File) => {
+    if (!target) return
+    const previewUrl = URL.createObjectURL(file)
+    setImageAttachment({
+      fileName: file.name || 'clipboard-image.png',
+      fileSize: file.size,
+      previewUrl,
+      attachment: null,
+      uploading: true,
+      pasting: false,
+      error: null,
+    })
+
+    try {
+      const attachment = await uploadBridgeAttachment(target, file)
+      setImageAttachment((current) => current?.previewUrl === previewUrl
+        ? { ...current, attachment, uploading: false }
+        : current)
+    } catch (error) {
+      setImageAttachment((current) => current?.previewUrl === previewUrl
+        ? {
+          ...current,
+          uploading: false,
+          error: error instanceof Error ? error.message : 'Failed to upload image',
+        }
+        : current)
+    }
+  }, [target])
+
+  const handlePaste = useCallback((event: React.ClipboardEvent<HTMLDivElement>) => {
+    if (!target) return
+    const file = imageFromClipboard(event)
+    if (!file) return
+    event.preventDefault()
+    void attachImageFile(file)
+  }, [attachImageFile, target])
+
+  const handleDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    if (!target || !hasDraggedImage(event.dataTransfer)) return
+    event.preventDefault()
+    setDraggingImage(true)
+  }, [target])
+
+  const handleDragLeave = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    const related = event.relatedTarget
+    if (related instanceof Node && event.currentTarget.contains(related)) return
+    setDraggingImage(false)
+  }, [])
+
+  const handleDrop = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    if (!target) return
+    const file = firstImageFile(event.dataTransfer.files)
+    if (!file) return
+    event.preventDefault()
+    setDraggingImage(false)
+    void attachImageFile(file)
+  }, [attachImageFile, target])
+
+  const handleAttachmentPaste = useCallback(async (submit: boolean) => {
+    if (!target || !imageAttachment?.attachment || readOnly) return
+    const attachment = imageAttachment.attachment
+    setImageAttachment((current) => current ? { ...current, pasting: true, error: null } : current)
+    try {
+      await pasteBridgeAttachment(target, attachment.id, { submit })
+      toast.success(submit ? 'Image prompt pasted and submitted' : 'Image prompt pasted')
+      closeImageAttachment()
+    } catch (error) {
+      setImageAttachment((current) => current
+        ? {
+          ...current,
+          pasting: false,
+          error: error instanceof Error ? error.message : 'Failed to paste image prompt',
+        }
+        : current)
+    }
+  }, [closeImageAttachment, imageAttachment?.attachment, readOnly, target])
+
   return (
     <div className="flex flex-col h-full">
-      <div ref={wrapperRef} className={cn('relative flex-1 overflow-hidden', colorClasses.terminalWrapper)}>
+      <div
+        ref={wrapperRef}
+        className={cn('relative flex-1 overflow-hidden', colorClasses.terminalWrapper)}
+        onPaste={handlePaste}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
         {!target && (
           <div className="absolute inset-0 flex flex-col items-center justify-center text-muted-foreground bg-background">
             <Monitor className="h-12 w-12 mb-3" />
@@ -52,6 +185,11 @@ export function TerminalView({ target, fullscreen, onToggleFullscreen, onClose, 
             !target && 'invisible'
           )}
         />
+        {draggingImage && (
+          <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center border-2 border-dashed border-primary bg-background/80 text-sm font-medium text-foreground">
+            Drop image to attach to this session
+          </div>
+        )}
       </div>
 
       {target && (
@@ -116,6 +254,27 @@ export function TerminalView({ target, fullscreen, onToggleFullscreen, onClose, 
             )}
           </div>
         </div>
+      )}
+      {imageAttachment && (
+        <ImageAttachmentDialog
+          open
+          fileName={imageAttachment.fileName}
+          fileSize={imageAttachment.fileSize}
+          previewUrl={imageAttachment.previewUrl}
+          targetLabel={sessionLabel || target || 'this session'}
+          uploading={imageAttachment.uploading}
+          pasting={imageAttachment.pasting}
+          readOnly={readOnly}
+          error={imageAttachment.error}
+          attachment={imageAttachment.attachment}
+          onOpenChange={(open) => {
+            if (!open) closeImageAttachment()
+          }}
+          onPaste={(submit) => {
+            void handleAttachmentPaste(submit)
+          }}
+          onSwitchInteractive={() => setReadOnly(false)}
+        />
       )}
     </div>
   )

--- a/frontend/src/features/cc-bridge/api.ts
+++ b/frontend/src/features/cc-bridge/api.ts
@@ -1,6 +1,12 @@
-import { apiClient, buildEndpoint } from '@/lib/api'
+import { apiClient, buildEndpoint, type ApiError } from '@/lib/api'
+import { API_BASE_URL } from '@/lib/constants'
 import type { AgentProviderId } from '@/types/providers'
 import type {
+  BridgeAttachment,
+  BridgeAttachmentDeleteResponse,
+  BridgeAttachmentListResponse,
+  BridgeAttachmentPasteRequest,
+  BridgeAttachmentPasteResponse,
   CCSessionsResponse,
   CCPreviewResponse,
   CCTokenResponse,
@@ -11,6 +17,41 @@ import type {
 } from './types'
 
 const BASE = 'agent-bridge'
+
+function apiErrorMessage(error: ApiError, fallback = 'An error occurred'): string {
+  if (error.message) return error.message
+  if (typeof error.detail === 'string') return error.detail
+  if (Array.isArray(error.detail)) {
+    const messages = error.detail.map((item) => item.msg).filter(Boolean)
+    if (messages.length > 0) return messages.join(', ')
+  }
+  if (error.detail && typeof error.detail === 'object' && 'msg' in error.detail && error.detail.msg) {
+    return error.detail.msg
+  }
+  return fallback
+}
+
+async function attachmentRequest<T>(
+  endpoint: string,
+  options: RequestInit = {}
+): Promise<T> {
+  const { token } = await fetchTerminalToken()
+  const headers = new Headers(options.headers)
+  headers.set('X-Claude-Deck-Terminal-Token', token)
+  const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+    ...options,
+    headers,
+  })
+
+  if (!response.ok) {
+    const error: ApiError = await response.json().catch(() => ({
+      message: `HTTP ${response.status}: ${response.statusText}`,
+    }))
+    throw new Error(apiErrorMessage(error))
+  }
+
+  return response.json()
+}
 
 export async function fetchCCSessions(provider?: AgentProviderId): Promise<CCSessionsResponse> {
   return apiClient<CCSessionsResponse>(buildEndpoint(BASE + '/sessions', { provider }))
@@ -46,4 +87,53 @@ export async function killSession(target: string, cleanupWorktree: boolean = fal
   return apiClient<KillSessionResponse>(`${BASE}/sessions/${encodeURIComponent(target)}${params}`, {
     method: 'DELETE',
   })
+}
+
+export async function uploadBridgeAttachment(
+  target: string,
+  file: File
+): Promise<BridgeAttachment> {
+  const form = new FormData()
+  form.append('file', file)
+  form.append('created_by', 'deck-ui')
+  return attachmentRequest<BridgeAttachment>(
+    `${BASE}/sessions/${encodeURIComponent(target)}/attachments`,
+    {
+      method: 'POST',
+      body: form,
+    }
+  )
+}
+
+export async function listBridgeAttachments(target: string): Promise<BridgeAttachmentListResponse> {
+  return attachmentRequest<BridgeAttachmentListResponse>(
+    `${BASE}/sessions/${encodeURIComponent(target)}/attachments`
+  )
+}
+
+export async function pasteBridgeAttachment(
+  target: string,
+  attachmentId: number,
+  request: BridgeAttachmentPasteRequest
+): Promise<BridgeAttachmentPasteResponse> {
+  return attachmentRequest<BridgeAttachmentPasteResponse>(
+    `${BASE}/sessions/${encodeURIComponent(target)}/attachments/${attachmentId}/paste`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(request),
+    }
+  )
+}
+
+export async function deleteBridgeAttachment(
+  target: string,
+  attachmentId: number
+): Promise<BridgeAttachmentDeleteResponse> {
+  return attachmentRequest<BridgeAttachmentDeleteResponse>(
+    `${BASE}/sessions/${encodeURIComponent(target)}/attachments/${attachmentId}`,
+    { method: 'DELETE' }
+  )
 }

--- a/frontend/src/features/cc-bridge/types.ts
+++ b/frontend/src/features/cc-bridge/types.ts
@@ -102,6 +102,7 @@ export interface BridgeAttachmentPasteRequest {
   submit?: boolean
   prefix?: string
   suffix?: string
+  require_interactive_relay?: boolean
 }
 
 export interface BridgeAttachmentPasteResponse {

--- a/frontend/src/features/cc-bridge/types.ts
+++ b/frontend/src/features/cc-bridge/types.ts
@@ -78,6 +78,44 @@ export interface KillSessionResponse {
   error?: string
 }
 
+export interface BridgeAttachment {
+  id: number
+  target: string
+  session_name?: string | null
+  provider?: string | null
+  original_filename?: string | null
+  mime_type: string
+  size_bytes: number
+  sha256: string
+  agent_path: string
+  prompt_text: string
+  created_by?: string | null
+  created_at: string
+  expires_at?: string | null
+}
+
+export interface BridgeAttachmentListResponse {
+  attachments: BridgeAttachment[]
+}
+
+export interface BridgeAttachmentPasteRequest {
+  submit?: boolean
+  prefix?: string
+  suffix?: string
+}
+
+export interface BridgeAttachmentPasteResponse {
+  pasted: boolean
+  submitted: boolean
+  target: string
+}
+
+export interface BridgeAttachmentDeleteResponse {
+  deleted: boolean
+  target: string
+  attachment_id: number
+}
+
 export interface CodexLaunchModelOption {
   value: string
   label: string


### PR DESCRIPTION
## Summary
- Adds Agent Bridge image attachment storage, validation, metadata, retention cleanup, and paste/submit APIs.
- Adds UI paste/drop image flow with upload-before-confirm behavior and read-only safeguards.
- Exposes MCP tools for agentic image attachment upload/list/paste workflows.
- Documents REST API, config, MCP usage, and commits the reviewed design spec.

## Validation
- `PYTHONPATH=backend backend/venv/bin/python -m pytest backend/tests/test_agent_bridge_attachments.py backend/tests/agent_mail/test_mcp_shim.py`
- `npm --prefix frontend run build`
- `cd frontend && npm exec -- eslint src/features/cc-bridge/api.ts src/features/cc-bridge/types.ts src/features/cc-bridge/TerminalView.tsx src/features/cc-bridge/ImageAttachmentDialog.tsx`
- Broader Agent Bridge-related suite: 53 passed, 1 existing failure in `backend/tests/test_multi_provider_smoke.py::test_agent_bridge_session_filter_smoke` because it calls async `list_sessions` synchronously.

Closes #252
