### PR TITLE
Add Agent Bridge team filter

### DIFF
--- a/docs/features/agent-bridge.md
+++ b/docs/features/agent-bridge.md
@@ -1,10 +1,10 @@
 # Agent Bridge
 
-Agent Bridge discovers and manages local agent CLIs running inside tmux. It supports mixed Claude Code, Codex CLI, and GitHub Copilot CLI sessions in the same view.
+Agent Bridge discovers and manages local agent CLIs running inside tmux. It supports mixed Claude Code, Codex CLI, GitHub Copilot CLI, and OpenCode CLI sessions in the same view.
 
 ## Overview
 
-The bridge performs a provider-aware tmux discovery pass and classifies each matching pane as `claude-code`, `codex-cli`, or `copilot-cli`. The UI can show all sessions together or filter to one provider.
+The bridge performs a provider-aware tmux discovery pass and classifies each matching pane as `claude-code`, `codex-cli`, `copilot-cli`, or `opencode-cli`. The UI can show all sessions together or filter to one provider.
 
 Session cards include:
 
@@ -18,10 +18,13 @@ The terminal grid is shared across providers. Read-only and interactive modes wo
 
 Provider filters are explicit:
 
-- **All** — mixed Claude Code, Codex, and Copilot sessions
+- **All** — mixed Claude Code, Codex, Copilot, and OpenCode sessions
 - **Claude Code** — Claude Code panes only
 - **Codex** — Codex panes only
 - **Copilot** — GitHub Copilot CLI panes only
+- **OpenCode** — OpenCode CLI panes only
+
+When Agent Team sessions are running, Agent Bridge also shows a team filter row. Team filters compose with provider filters, so selecting a team and a provider shows only matching session cards. Selecting a specific team also detaches any open terminal panes that do not belong to that team; it does not auto-attach that team's sessions or kill any tmux sessions. New sessions launched from Agent Bridge remain standalone and are not attached while a specific team filter is active.
 
 ## New Sessions
 

--- a/docs/superpowers/specs/2026-06-30-agent-bridge-team-lane-fullscreen-design.md
+++ b/docs/superpowers/specs/2026-06-30-agent-bridge-team-lane-fullscreen-design.md
@@ -1,0 +1,151 @@
+# Agent Bridge Team-Lane Fullscreen — Design Spec
+
+**Status:** Draft for review (no implementation committed)
+**Date:** 2026-06-30
+**Scope:** Add a fullscreen "team lanes" layout to Agent Bridge that displays all live sessions of the currently-selected team side by side as vertical, full-height lanes (left-to-right), up to 4 lanes.
+**Depends on:** #257 (Agent Bridge team filtering) — provides the selected-team concept and slot-ordering plumbing this feature builds on.
+
+---
+
+## 1. Problem & Motivation
+
+Agent Bridge currently supports fullscreen for a **single** terminal panel (`fullscreenTarget` in `CCBridgePage.tsx`). When working with an Agent Team, a user wants to watch **all members at once** — e.g. a team of Architect, Lead Dev, and QA Engineer — each occupying a full-height vertical lane across the screen.
+
+Today there is no way to see more than one agent at full size. The single-panel fullscreen forces the user to flip between members one at a time, which defeats the purpose of observing a team working in parallel.
+
+The desired outcome: with a team selected, one click enters a fullscreen layout where each team member is shown in its own vertical lane, dividing the horizontal space evenly, supporting up to 4 lanes.
+
+---
+
+## 2. Current Architecture (as-is)
+
+In `frontend/src/features/cc-bridge/CCBridgePage.tsx`:
+
+- `activeTargets: string[]` — terminals attached in the grid (capped at `MAX_GRID_PANES = 4`).
+- `fullscreenTarget: string | null` — single-panel fullscreen state.
+- `gridCols` — only ever `grid-cols-1` or `grid-cols-2`.
+- Fullscreen container uses `fixed inset-0 z-50 bg-background`.
+- An existing `useEffect` listens for `Escape` to exit fullscreen.
+
+Each terminal is a `TerminalView` backed by `useTerminal`, which already:
+
+- loads `FitAddon` and calls `fitAddon.fit()` on mount and on a `ResizeObserver`,
+- sends a `resize` control frame to the backend pty relay when dimensions change.
+
+So **terminals automatically refit when their container resizes** — no manual sizing logic is needed for new layouts.
+
+Sessions carry team metadata (from `_enrich_team_sessions` in `backend/app/api/v1/agent_bridge/router.py`), already typed on `AgentSession` in `frontend/src/features/cc-bridge/types.ts`:
+
+- `team_preset_id: number | null`
+- `team_preset_name: string | null`
+- `team_slot_id`, `team_slot_name`, `team_slot_role`, `team_slot_color`
+
+**This is a frontend-only feature.** No backend or schema changes.
+
+---
+
+## 3. Behavior & Trigger
+
+- **Trigger:** a "Team lanes" action in the Agent Bridge header, enabled **only when a specific team is selected** in the team filter (#257). When "All teams" is selected, the action is disabled.
+- **Lane contents:** derived from discovery — all live sessions whose `team_preset_id` matches the selected team, **ordered by slot role** (`team_slot` ordering), **capped at 4**.
+- **No pre-attaching required:** entering lane mode attaches the team's sessions on the fly.
+- **Overflow (>4 live members):** show the first 4 by slot order plus a clear "+N not shown" indicator. No paging in MVP.
+- **Underflow:** lane count equals the actual live-member count (3 members → 3 lanes); lanes divide the width evenly.
+- **Exit:** `Esc` (reusing the existing Escape handler) returns to the normal grid.
+- **Coexistence:** mutually exclusive with single-panel fullscreen — entering one exits the other.
+
+---
+
+## 4. State & Layout Mechanics
+
+### 4.1 Layout state
+
+Replace the implicit two-flag fullscreen state with an explicit union, since the three layouts are mutually exclusive:
+
+```ts
+type LayoutMode =
+  | { kind: 'grid' }
+  | { kind: 'single'; target: string }
+  | { kind: 'lanes' }
+```
+
+(Equivalent to today's `fullscreenTarget` plus a new lanes state. Implementation may keep `fullscreenTarget` and add a `teamLanesActive` boolean instead, as long as the mutual exclusion is enforced. The union is preferred for clarity.)
+
+### 4.2 Derived lane targets
+
+Lane targets are **derived, not stored**, so they react to discovery refreshes automatically:
+
+```ts
+const laneTargets = useMemo(() => {
+  if (layoutMode.kind !== 'lanes' || teamFilter === 'all') return []
+  return sessions
+    .filter((s) => s.team_preset_id === teamFilter)
+    .sort(bySlotOrder)            // stable order by slot role / slot id
+    .slice(0, MAX_GRID_PANES)
+    .map((s) => s.tmux_target)
+}, [layoutMode, teamFilter, sessions])
+```
+
+`bySlotOrder` sorts by a stable slot ordering (slot id, or a role rank derived from `team_slot_role`) so the left-to-right arrangement is meaningful and stable across refreshes.
+
+### 4.3 Layout rendering
+
+- Reuse the existing fullscreen container (`fixed inset-0 z-50 bg-background`).
+- Render N lanes as full-height columns. Lane count drives columns: 1→1, 2→2, 3→3, 4→4. This is a **distinct layout path** from the existing `gridCols` (which only does 1/2). Use `flex` with `flex-1` per lane, or an explicit `grid-cols-N` mapping.
+- Each lane renders a `TerminalView` for one lane target.
+
+### 4.4 Sizing
+
+No manual terminal sizing — each lane's `TerminalView` refits via the existing `ResizeObserver` + `FitAddon` + `resize` control frame when the lanes mount/resize.
+
+### 4.5 Attach semantics
+
+Lane mode is **ephemeral**: it shows the team's sessions regardless of what was in `activeTargets`, and it does **not** mutate `activeTargets`. Exiting lane mode (`Esc`) restores the previous grid untouched.
+
+---
+
+## 5. Edge Cases & Interactions
+
+- **Read-only / interactive:** each lane is a normal `TerminalView`; the per-terminal read-only/interactive toggle and focus highlight (`focusedTarget`) work per lane, unchanged.
+- **Member dies mid-lanes:** discovery refresh drops it from `laneTargets` → its lane disappears, remaining lanes re-divide the width. If the count reaches 0 (whole team gone), **auto-exit** to the grid.
+- **Team filter changes while in lanes:** **exit lane mode** back to the grid. The user re-triggers lanes deliberately for the new team. (Avoids a surprising full re-layout on a filter click.)
+- **"All teams" selected:** the Team-lanes action is disabled.
+- **Overflow (>4):** first 4 by slot order; "+N not shown" indicator in the lane bar.
+- **Single-fullscreen button inside a lane:** hidden in MVP (promote-to-single is a deferred enhancement).
+- **Spawn / kill from lane mode:** out of scope; if a session is killed elsewhere, the die-mid-lanes path covers it.
+
+---
+
+## 6. Components
+
+Frontend-only:
+
+- **`CCBridgePage.tsx`** — `LayoutMode` union state; derived `laneTargets` (filter by team → sort by slot order → slice 4); lane render path; "Team lanes" trigger button (enabled only for a specific team); Esc/exit handler reuse; auto-exit effects (team gone, filter changed); disable rules.
+- **`TerminalView.tsx`** — minor: hide the per-panel maximize button when in lane mode (small prop signal, e.g. `inLanes`).
+- **`TeamLanesView` (optional)** — extract the lane render path into a subcomponent if `CCBridgePage` grows too heavy; decide during implementation, otherwise inline.
+- **No `types.ts` change** (team fields already present); **no backend change**.
+
+---
+
+## 7. Test Plan
+
+Manual (until a frontend test harness exists):
+
+1. 3-member team → click Team lanes → 3 full-height lanes left-to-right in slot-role order, each attached.
+2. 5-member team → 4 lanes + "+1 not shown".
+3. Kill one member → its lane drops, others re-divide; kill all → auto-exit to grid.
+4. `Esc` exits to the prior grid with previous `activeTargets` intact (ephemeral attach didn't disturb them).
+5. Switch team filter while in lanes → exits lane mode.
+6. "All teams" selected → Team-lanes action disabled.
+7. Per-lane read-only/interactive toggle works independently.
+
+---
+
+## 8. Non-Goals
+
+- Promote-a-lane to single fullscreen (and back). Deferred enhancement.
+- Horizontal (stacked) lane orientation — lanes are vertical only.
+- More than 4 members with paging.
+- Spawning or killing sessions from lane mode.
+- Persisting lane mode across reloads.
+- Team-color theming of lanes/pills.

--- a/frontend/src/features/cc-bridge/CCBridgePage.tsx
+++ b/frontend/src/features/cc-bridge/CCBridgePage.tsx
@@ -14,6 +14,13 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 
 const MAX_GRID_PANES = 4
 type ProviderFilter = 'all' | AgentProviderId
+type TeamFilter = 'all' | number
+
+interface TeamFilterOption {
+  id: number
+  name: string
+  count: number
+}
 
 const PROVIDER_FILTERS: { value: ProviderFilter; label: string }[] = [
   { value: 'all', label: 'All agents' },
@@ -31,6 +38,7 @@ function addTarget(prev: string[], target: string): string[] {
 
 export function CCBridgePage() {
   const [providerFilter, setProviderFilter] = useState<ProviderFilter>('all')
+  const [teamFilter, setTeamFilter] = useState<TeamFilter>('all')
   const { providers, selectedProviderId } = useProviderContext()
   const status = useSystemStatus()
   const instance = status?.instance ?? null
@@ -42,18 +50,45 @@ export function CCBridgePage() {
   const [killSession, setKillSession] = useState<CCSession | null>(null)
 
   const isFullscreen = fullscreenTarget !== null
-  const visibleSessions = providerFilter === 'all'
-    ? sessions
-    : sessions.filter((session) => session.provider === providerFilter)
   const sessionsByTarget = useMemo(
     () => new Map(sessions.map((session) => [session.tmux_target, session])),
     [sessions]
   )
 
-  const providersById = providers.reduce<Partial<Record<AgentProviderId, AgentProviderStatus>>>((acc, provider) => {
+  const providersById = useMemo(() => providers.reduce<Partial<Record<AgentProviderId, AgentProviderStatus>>>((acc, provider) => {
     acc[provider.id] = provider
     return acc
-  }, {})
+  }, {}), [providers])
+
+  const teamOptions = useMemo<TeamFilterOption[]>(() => {
+    const teams = new Map<number, TeamFilterOption>()
+    for (const session of sessions) {
+      if (typeof session.team_preset_id !== 'number') continue
+      const current = teams.get(session.team_preset_id)
+      if (current) {
+        current.count += 1
+      } else {
+        teams.set(session.team_preset_id, {
+          id: session.team_preset_id,
+          name: session.team_preset_name ?? `Team ${session.team_preset_id}`,
+          count: 1,
+        })
+      }
+    }
+    return [...teams.values()].sort((a, b) => a.name.localeCompare(b.name))
+  }, [sessions])
+
+  const teamFilterAvailable = teamFilter === 'all' || teamOptions.some((team) => team.id === teamFilter)
+  const effectiveTeamFilter = teamFilterAvailable ? teamFilter : 'all'
+
+  const visibleSessions = useMemo(() => sessions.filter((session) => (
+    (providerFilter === 'all' || session.provider === providerFilter)
+    && (effectiveTeamFilter === 'all' || session.team_preset_id === effectiveTeamFilter)
+  )), [effectiveTeamFilter, providerFilter, sessions])
+
+  const selectedTeamLabel = effectiveTeamFilter === 'all'
+    ? null
+    : teamOptions.find((team) => team.id === effectiveTeamFilter)?.name ?? `Team ${effectiveTeamFilter}`
 
   const canProviderSpawn = (provider: AgentProviderStatus | undefined) => (
     Boolean(provider?.installed)
@@ -87,6 +122,23 @@ export function CCBridgePage() {
   const initialDialogProvider = providerFilter === 'all' ? selectedProviderId : providerFilter
 
   useEffect(() => {
+    if (teamFilterAvailable) return
+    const resetId = window.setTimeout(() => setTeamFilter('all'), 0)
+    return () => window.clearTimeout(resetId)
+  }, [teamFilterAvailable])
+
+  const applyTeamFilter = useCallback((nextTeamFilter: TeamFilter) => {
+    setTeamFilter(nextTeamFilter)
+    if (nextTeamFilter === 'all') return
+    const sessionInSelectedTeam = (target: string) => (
+      sessionsByTarget.get(target)?.team_preset_id === nextTeamFilter
+    )
+    setActiveTargets((prev) => prev.filter(sessionInSelectedTeam))
+    setFullscreenTarget((cur) => (cur && !sessionInSelectedTeam(cur) ? null : cur))
+    setFocusedTarget((cur) => (cur && !sessionInSelectedTeam(cur) ? null : cur))
+  }, [sessionsByTarget])
+
+  useEffect(() => {
     if (!isFullscreen) return
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') setFullscreenTarget(null)
@@ -109,6 +161,7 @@ export function CCBridgePage() {
 
   const handleSpawned = (tmuxTarget: string) => {
     refresh()
+    if (effectiveTeamFilter !== 'all') return
     setActiveTargets((prev) => addTarget(prev, tmuxTarget))
   }
 
@@ -157,6 +210,42 @@ export function CCBridgePage() {
               ))}
             </div>
           </div>
+          {teamOptions.length > 0 && (
+            <div className="px-4 pb-3">
+              <div className="flex items-center gap-2 min-w-0">
+                <span className="text-xs font-medium text-muted-foreground shrink-0">Teams</span>
+                <div className="flex rounded-md bg-background border p-0.5 shrink-0 max-w-full overflow-x-auto">
+                  <button
+                    type="button"
+                    className={cn(
+                      'px-2.5 py-1 text-xs rounded-sm transition-colors whitespace-nowrap',
+                      effectiveTeamFilter === 'all'
+                        ? 'bg-primary text-primary-foreground'
+                        : 'text-muted-foreground hover:text-foreground'
+                    )}
+                    onClick={() => applyTeamFilter('all')}
+                  >
+                    All teams <span className="opacity-70">({sessions.length})</span>
+                  </button>
+                  {teamOptions.map((team) => (
+                    <button
+                      key={team.id}
+                      type="button"
+                      className={cn(
+                        'px-2.5 py-1 text-xs rounded-sm transition-colors whitespace-nowrap',
+                        effectiveTeamFilter === team.id
+                          ? 'bg-primary text-primary-foreground'
+                          : 'text-muted-foreground hover:text-foreground'
+                      )}
+                      onClick={() => applyTeamFilter(team.id)}
+                    >
+                      {team.name} <span className="opacity-70">({team.count})</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
           {agentCliWarning && (
             <div className="px-4 pb-3">
               <Alert variant="destructive" className="py-3">
@@ -184,6 +273,7 @@ export function CCBridgePage() {
               onNewSession={() => setNewSessionOpen(true)}
               onKillSession={setKillSession}
               providerFilter={providerFilter}
+              teamLabel={selectedTeamLabel}
               canCreateSession={canCreateSession}
               createDisabledReason={canCreateSession ? null : createDisabledReason}
               instance={instance}

--- a/frontend/src/features/cc-bridge/SessionList.tsx
+++ b/frontend/src/features/cc-bridge/SessionList.tsx
@@ -18,6 +18,7 @@ interface SessionListProps {
   onNewSession: () => void
   onKillSession: (session: CCSession) => void
   providerFilter: ProviderFilter
+  teamLabel?: string | null
   canCreateSession: boolean
   createDisabledReason: string | null
   instance?: InstanceIdentity | null
@@ -33,6 +34,7 @@ export function SessionList({
   onNewSession,
   onKillSession,
   providerFilter,
+  teamLabel,
   canCreateSession,
   createDisabledReason,
   instance,
@@ -46,10 +48,19 @@ export function SessionList({
         : providerFilter === 'opencode-cli'
           ? 'OpenCode'
           : 'Claude Code'
+  const emptyTitle = teamLabel
+    ? providerFilter === 'all'
+      ? `No sessions in ${teamLabel}`
+      : `No ${emptyName} sessions in ${teamLabel}`
+    : `No ${emptyName} sessions found`
   const emptyHint = createDisabledReason
-    ?? (providerFilter === 'all'
+    ?? (teamLabel
+      ? `Use Agent Teams to launch more sessions for ${teamLabel}. New Agent Bridge sessions are standalone and stay hidden while this team filter is active.`
+      : providerFilter === 'all'
       ? 'Launch or start a supported CLI in tmux.'
       : `Launch ${emptyName} from Agent Bridge or start it in tmux.`)
+  const newSessionTitle = createDisabledReason
+    ?? (teamLabel ? `New standalone session (hidden until All teams is selected)` : 'New session')
 
   return (
     <div className="flex flex-col h-full">
@@ -64,7 +75,7 @@ export function SessionList({
             className="h-7 w-7"
             onClick={onNewSession}
             disabled={!canCreateSession}
-            title={createDisabledReason ?? 'New session'}
+            title={newSessionTitle}
           >
             <Plus className="h-3.5 w-3.5" />
           </Button>
@@ -88,7 +99,7 @@ export function SessionList({
         {!loading && !error && sessions.length === 0 && (
           <div className="flex flex-col items-center justify-center py-8 text-muted-foreground">
             <MonitorX className="h-8 w-8 mb-2" />
-            <p className="text-sm">No {emptyName} sessions found</p>
+            <p className="text-sm">{emptyTitle}</p>
             <p className="text-xs mt-1 text-center px-3">{emptyHint}</p>
           </div>
         )}


### PR DESCRIPTION
## Summary
- Adds a live Agent Team filter row to Agent Bridge when team-backed sessions exist.
- Composes team filtering with the existing provider filter for the session-card list.
- Enforces strict team isolation on team selection by detaching open panes outside the selected team without killing tmux sessions or auto-attaching new panes.
- Updates empty-state copy and new-session tooltip to clarify that direct new sessions are standalone.
- Documents Agent Bridge team filtering and OpenCode support.

## Validation
- `npm --prefix frontend run build`
- `cd frontend && npm exec -- eslint src/features/cc-bridge/CCBridgePage.tsx src/features/cc-bridge/SessionList.tsx`
- `npm --prefix docs run build`

Closes #257
