### PR TITLE
Add Agent Bridge team lanes

### DIFF
--- a/backend/app/api/v1/agent_bridge/router.py
+++ b/backend/app/api/v1/agent_bridge/router.py
@@ -105,6 +105,7 @@ async def _enrich_team_sessions(
                 team_preset_id=slot.preset_id,
                 team_preset_name=preset.name if preset is not None else updated.get("team_preset_name"),
                 team_slot_name=slot.display_name,
+                team_slot_position=slot.position,
                 team_slot_role=slot.role,
                 team_slot_charter=slot.charter,
                 team_slot_color=slot.ui_color,

--- a/backend/tests/agent_teams/test_agent_bridge_session_metadata.py
+++ b/backend/tests/agent_teams/test_agent_bridge_session_metadata.py
@@ -44,6 +44,7 @@ async def test_agent_bridge_sessions_enrich_team_role_from_db(db, tmp_path):
     assert sessions[0]["team_preset_id"] == preset.id
     assert sessions[0]["team_preset_name"] == "SnazzyEmail"
     assert sessions[0]["team_slot_name"] == "Architect"
+    assert sessions[0]["team_slot_position"] == 0
     assert sessions[0]["team_slot_role"] == "architect"
     assert sessions[0]["team_slot_charter"] == "Own architecture"
     assert sessions[0]["team_slot_color"] == "purple"

--- a/docs/api/agent-bridge.md
+++ b/docs/api/agent-bridge.md
@@ -1,6 +1,6 @@
 # Agent Bridge API
 
-Provider-aware live terminal monitoring for Claude Code, Codex CLI, and GitHub Copilot CLI tmux sessions.
+Provider-aware live terminal monitoring for Claude Code, Codex CLI, GitHub Copilot CLI, and OpenCode CLI tmux sessions.
 
 ## Endpoints
 
@@ -10,7 +10,7 @@ Provider-aware live terminal monitoring for Claude Code, Codex CLI, and GitHub C
 GET /api/v1/agent-bridge/sessions?provider={provider_id}
 ```
 
-`provider` is optional. Supported values are `claude-code`, `codex-cli`, and `copilot-cli`.
+`provider` is optional. Supported values are `claude-code`, `codex-cli`, `copilot-cli`, and `opencode-cli`.
 
 ```json
 {
@@ -29,6 +29,7 @@ GET /api/v1/agent-bridge/sessions?provider={provider_id}
       "team_preset_name": "Release validation",
       "team_slot_id": 20,
       "team_slot_name": "Reviewer",
+      "team_slot_position": 2,
       "team_slot_role": "planner-reviewer",
       "team_slot_charter": "Review the plan and implementation against release goals.",
       "team_slot_color": "purple"

--- a/docs/features/agent-bridge.md
+++ b/docs/features/agent-bridge.md
@@ -26,6 +26,8 @@ Provider filters are explicit:
 
 When Agent Team sessions are running, Agent Bridge also shows a team filter row. Team filters compose with provider filters, so selecting a team and a provider shows only matching session cards. Selecting a specific team also detaches any open terminal panes that do not belong to that team; it does not auto-attach that team's sessions or kill any tmux sessions. New sessions launched from Agent Bridge remain standalone and are not attached while a specific team filter is active.
 
+With a specific team selected, the **Team lanes** action opens a fullscreen vertical-lane layout for that team. Lane mode shows up to four live team sessions side by side, ordered by configured team slot position, without changing the normal grid attachments. Press `Esc` or the exit button to return to the previous grid; if more than four members are live, Agent Bridge shows how many are not displayed.
+
 ## New Sessions
 
 The new session dialog starts with a provider choice.

--- a/frontend/src/features/cc-bridge/CCBridgePage.tsx
+++ b/frontend/src/features/cc-bridge/CCBridgePage.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils'
 import { useCCSessions } from './useCCSessions'
 import { SessionList } from './SessionList'
 import { TerminalView } from './TerminalView'
+import { TeamLanesView } from './TeamLanesView'
 import { NewSessionDialog } from './NewSessionDialog'
 import { KillSessionDialog } from './KillSessionDialog'
 import type { CCSession } from './types'
@@ -15,6 +16,10 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 const MAX_GRID_PANES = 4
 type ProviderFilter = 'all' | AgentProviderId
 type TeamFilter = 'all' | number
+type LayoutMode =
+  | { kind: 'grid' }
+  | { kind: 'single'; target: string }
+  | { kind: 'lanes'; teamId: number }
 
 interface TeamFilterOption {
   id: number
@@ -36,6 +41,21 @@ function addTarget(prev: string[], target: string): string[] {
   return [...prev, target]
 }
 
+function slotOrderValue(session: CCSession): number {
+  if (typeof session.team_slot_position === 'number') return session.team_slot_position
+  return typeof session.team_slot_id === 'number' ? session.team_slot_id : Number.MAX_SAFE_INTEGER
+}
+
+function compareTeamLaneSessions(a: CCSession, b: CCSession): number {
+  const slotOrder = slotOrderValue(a) - slotOrderValue(b)
+  if (slotOrder !== 0) return slotOrder
+  const roleOrder = (a.team_slot_role ?? '').localeCompare(b.team_slot_role ?? '')
+  if (roleOrder !== 0) return roleOrder
+  const nameOrder = (a.team_slot_name ?? '').localeCompare(b.team_slot_name ?? '')
+  if (nameOrder !== 0) return nameOrder
+  return a.tmux_target.localeCompare(b.tmux_target)
+}
+
 export function CCBridgePage() {
   const [providerFilter, setProviderFilter] = useState<ProviderFilter>('all')
   const [teamFilter, setTeamFilter] = useState<TeamFilter>('all')
@@ -44,12 +64,13 @@ export function CCBridgePage() {
   const instance = status?.instance ?? null
   const { sessions, loading, error, refresh } = useCCSessions()
   const [activeTargets, setActiveTargets] = useState<string[]>([])
-  const [fullscreenTarget, setFullscreenTarget] = useState<string | null>(null)
+  const [layoutMode, setLayoutMode] = useState<LayoutMode>({ kind: 'grid' })
   const [focusedTarget, setFocusedTarget] = useState<string | null>(null)
   const [newSessionOpen, setNewSessionOpen] = useState(false)
   const [killSession, setKillSession] = useState<CCSession | null>(null)
 
-  const isFullscreen = fullscreenTarget !== null
+  const isFullscreen = layoutMode.kind !== 'grid'
+  const laneTeamId = layoutMode.kind === 'lanes' ? layoutMode.teamId : null
   const sessionsByTarget = useMemo(
     () => new Map(sessions.map((session) => [session.tmux_target, session])),
     [sessions]
@@ -90,6 +111,21 @@ export function CCBridgePage() {
     ? null
     : teamOptions.find((team) => team.id === effectiveTeamFilter)?.name ?? `Team ${effectiveTeamFilter}`
 
+  const laneTeamLabel = laneTeamId === null
+    ? null
+    : teamOptions.find((team) => team.id === laneTeamId)?.name ?? `Team ${laneTeamId}`
+
+  const teamLanes = useMemo(() => {
+    if (laneTeamId === null) return { sessions: [], overflowCount: 0 }
+    const teamSessions = sessions
+      .filter((session) => session.team_preset_id === laneTeamId)
+      .sort(compareTeamLaneSessions)
+    return {
+      sessions: teamSessions.slice(0, MAX_GRID_PANES),
+      overflowCount: Math.max(0, teamSessions.length - MAX_GRID_PANES),
+    }
+  }, [laneTeamId, sessions])
+
   const canProviderSpawn = (provider: AgentProviderStatus | undefined) => (
     Boolean(provider?.installed)
     && provider?.capability_details?.spawn?.state !== 'unsupported'
@@ -129,34 +165,61 @@ export function CCBridgePage() {
 
   const applyTeamFilter = useCallback((nextTeamFilter: TeamFilter) => {
     setTeamFilter(nextTeamFilter)
-    if (nextTeamFilter === 'all') return
+    if (nextTeamFilter === 'all') {
+      setLayoutMode((cur) => (cur.kind === 'lanes' ? { kind: 'grid' } : cur))
+      return
+    }
     const sessionInSelectedTeam = (target: string) => (
       sessionsByTarget.get(target)?.team_preset_id === nextTeamFilter
     )
     setActiveTargets((prev) => prev.filter(sessionInSelectedTeam))
-    setFullscreenTarget((cur) => (cur && !sessionInSelectedTeam(cur) ? null : cur))
+    setLayoutMode((cur) => {
+      if (cur.kind === 'lanes' && cur.teamId !== nextTeamFilter) return { kind: 'grid' }
+      if (cur.kind === 'single' && !sessionInSelectedTeam(cur.target)) return { kind: 'grid' }
+      return cur
+    })
     setFocusedTarget((cur) => (cur && !sessionInSelectedTeam(cur) ? null : cur))
   }, [sessionsByTarget])
+
+  const openTeamLanes = useCallback(() => {
+    if (effectiveTeamFilter === 'all') return
+    setLayoutMode({ kind: 'lanes', teamId: effectiveTeamFilter })
+    setFocusedTarget(null)
+  }, [effectiveTeamFilter])
+
+  const exitFullscreen = useCallback(() => {
+    setLayoutMode({ kind: 'grid' })
+  }, [])
 
   useEffect(() => {
     if (!isFullscreen) return
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setFullscreenTarget(null)
+      if (e.key === 'Escape') exitFullscreen()
     }
     document.addEventListener('keydown', handleKey)
     return () => document.removeEventListener('keydown', handleKey)
-  }, [isFullscreen])
+  }, [exitFullscreen, isFullscreen])
+
+  const shouldExitEmptyLanes = layoutMode.kind === 'lanes' && teamLanes.sessions.length === 0
+
+  useEffect(() => {
+    if (!shouldExitEmptyLanes) return
+    const exitId = window.setTimeout(() => {
+      setLayoutMode((cur) => (cur.kind === 'lanes' ? { kind: 'grid' } : cur))
+    }, 0)
+    return () => window.clearTimeout(exitId)
+  }, [shouldExitEmptyLanes])
 
   const toggleTarget = useCallback((target: string) => {
     setActiveTargets((prev) =>
       prev.includes(target) ? prev.filter((t) => t !== target) : addTarget(prev, target)
     )
-    setFullscreenTarget((cur) => (cur === target ? null : cur))
+    setLayoutMode((cur) => (cur.kind === 'single' && cur.target === target ? { kind: 'grid' } : cur))
   }, [])
 
   const removeTarget = useCallback((target: string) => {
     setActiveTargets((prev) => prev.filter((t) => t !== target))
-    setFullscreenTarget((cur) => (cur === target ? null : cur))
+    setLayoutMode((cur) => (cur.kind === 'single' && cur.target === target ? { kind: 'grid' } : cur))
   }, [])
 
   const handleSpawned = (tmuxTarget: string) => {
@@ -243,6 +306,20 @@ export function CCBridgePage() {
                     </button>
                   ))}
                 </div>
+                <button
+                  type="button"
+                  className={cn(
+                    'px-2.5 py-1 text-xs rounded-md border transition-colors whitespace-nowrap shrink-0',
+                    effectiveTeamFilter === 'all'
+                      ? 'bg-muted text-muted-foreground cursor-not-allowed opacity-60'
+                      : 'bg-background text-foreground hover:bg-muted'
+                  )}
+                  disabled={effectiveTeamFilter === 'all'}
+                  onClick={openTeamLanes}
+                  title={selectedTeamLabel ? `Show ${selectedTeamLabel} in fullscreen lanes` : 'Select a team to open team lanes'}
+                >
+                  Team lanes
+                </button>
               </div>
             </div>
           )}
@@ -282,7 +359,17 @@ export function CCBridgePage() {
         )}
 
         <div className="flex-1 min-w-0 relative">
-          {activeTargets.length === 0 ? (
+          {layoutMode.kind === 'lanes' ? (
+            <TeamLanesView
+              sessions={teamLanes.sessions}
+              overflowCount={teamLanes.overflowCount}
+              teamLabel={laneTeamLabel}
+              focusedTarget={focusedTarget}
+              onFocusTarget={setFocusedTarget}
+              onExit={exitFullscreen}
+              instance={instance}
+            />
+          ) : activeTargets.length === 0 ? (
             <div className="absolute inset-0 flex flex-col items-center justify-center text-muted-foreground bg-background">
               <Monitor className="h-12 w-12 mb-3" />
               <p className="text-sm">Select a session to attach</p>
@@ -293,7 +380,7 @@ export function CCBridgePage() {
               isFullscreen ? 'grid-cols-1' : gridCols
             )}>
               {activeTargets.map((target) => {
-                const isThisFullscreen = fullscreenTarget === target
+                const isThisFullscreen = layoutMode.kind === 'single' && layoutMode.target === target
                 const hidden = isFullscreen && !isThisFullscreen
                 const session = sessionsByTarget.get(target) ?? null
                 return (
@@ -317,7 +404,7 @@ export function CCBridgePage() {
                         target={target}
                         fullscreen={isThisFullscreen}
                         onToggleFullscreen={() =>
-                          setFullscreenTarget(isThisFullscreen ? null : target)
+                          setLayoutMode(isThisFullscreen ? { kind: 'grid' } : { kind: 'single', target })
                         }
                         onClose={() => removeTarget(target)}
                         instance={instance}

--- a/frontend/src/features/cc-bridge/TeamLanesView.tsx
+++ b/frontend/src/features/cc-bridge/TeamLanesView.tsx
@@ -1,0 +1,92 @@
+import { Monitor, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { TerminalView } from './TerminalView'
+import type { CCSession } from './types'
+import type { InstanceIdentity } from '@/types/status'
+
+interface TeamLanesViewProps {
+  sessions: CCSession[]
+  overflowCount: number
+  teamLabel?: string | null
+  focusedTarget: string | null
+  onFocusTarget: (target: string) => void
+  onExit: () => void
+  instance?: InstanceIdentity | null
+}
+
+function laneLabel(session: CCSession): string {
+  return session.team_slot_name || session.session_name || session.tmux_target
+}
+
+export function TeamLanesView({
+  sessions,
+  overflowCount,
+  teamLabel,
+  focusedTarget,
+  onFocusTarget,
+  onExit,
+  instance,
+}: TeamLanesViewProps) {
+  return (
+    <div className="absolute inset-0 flex flex-col bg-background">
+      <div className="flex h-10 shrink-0 items-center justify-between gap-3 border-b bg-muted/30 px-3">
+        <div className="flex min-w-0 items-baseline gap-2">
+          <span className="text-sm font-semibold">Team lanes</span>
+          <span className="truncate text-xs text-muted-foreground">
+            {teamLabel ?? 'Selected team'} · {sessions.length} shown
+            {overflowCount > 0 ? ` · +${overflowCount} not shown` : ''}
+          </span>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <span className="text-xs text-muted-foreground">Esc exits</span>
+          <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onExit} title="Exit team lanes">
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </div>
+
+      {sessions.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center text-muted-foreground">
+          <Monitor className="mb-3 h-12 w-12" />
+          <p className="text-sm">No live team sessions</p>
+        </div>
+      ) : (
+        <div className="flex min-h-0 flex-1 overflow-hidden">
+          {sessions.map((session) => (
+            <div
+              key={session.pane_id}
+              className={cn(
+                'relative flex min-w-0 flex-1 flex-col overflow-hidden border-r last:border-r-0',
+                focusedTarget === session.tmux_target ? 'bg-primary/60' : 'bg-border/30'
+              )}
+              onMouseDown={() => onFocusTarget(session.tmux_target)}
+              onFocusCapture={() => onFocusTarget(session.tmux_target)}
+            >
+              <div className="flex h-8 shrink-0 items-center gap-2 border-b bg-background px-2">
+                <span className="truncate text-xs font-medium" title={laneLabel(session)}>
+                  {laneLabel(session)}
+                </span>
+                {session.team_slot_role && (
+                  <span className="shrink-0 truncate text-[11px] text-muted-foreground" title={session.team_slot_role}>
+                    {session.team_slot_role}
+                  </span>
+                )}
+              </div>
+              <div className="relative min-h-0 flex-1">
+                <div className="absolute inset-[2px] rounded-sm">
+                  <TerminalView
+                    target={session.tmux_target}
+                    inLanes
+                    instance={instance}
+                    session={session}
+                  />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/cc-bridge/TerminalView.tsx
+++ b/frontend/src/features/cc-bridge/TerminalView.tsx
@@ -14,6 +14,7 @@ import type { InstanceIdentity } from '@/types/status'
 interface TerminalViewProps {
   target: string | null
   fullscreen?: boolean
+  inLanes?: boolean
   onToggleFullscreen?: () => void
   onClose?: () => void
   instance?: InstanceIdentity | null
@@ -53,7 +54,7 @@ function imageFromClipboard(event: React.ClipboardEvent<HTMLDivElement>): File |
   return null
 }
 
-export function TerminalView({ target, fullscreen, onToggleFullscreen, onClose, instance, session }: TerminalViewProps) {
+export function TerminalView({ target, fullscreen, inLanes, onToggleFullscreen, onClose, instance, session }: TerminalViewProps) {
   const wrapperRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const [draggingImage, setDraggingImage] = useState(false)
@@ -233,7 +234,7 @@ export function TerminalView({ target, fullscreen, onToggleFullscreen, onClose, 
             </span>
           </div>
           <div className="flex items-center gap-2 shrink-0">
-            {onToggleFullscreen && (
+            {onToggleFullscreen && !inLanes && (
               <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onToggleFullscreen} title={fullscreen ? 'Exit fullscreen' : 'Fullscreen'}>
                 {fullscreen ? <Minimize2 className="h-3.5 w-3.5" /> : <Maximize2 className="h-3.5 w-3.5" />}
               </Button>

--- a/frontend/src/features/cc-bridge/types.ts
+++ b/frontend/src/features/cc-bridge/types.ts
@@ -14,6 +14,7 @@ export interface AgentSession {
   team_preset_name?: string | null
   team_slot_id?: number | null
   team_slot_name?: string | null
+  team_slot_position?: number | null
   team_slot_role?: string | null
   team_slot_charter?: string | null
   team_slot_color?: string | null


### PR DESCRIPTION
Closes #258.

## Summary
- Adds explicit Agent Bridge layout modes for grid, single fullscreen, and team-lane fullscreen.
- Adds a Team lanes action enabled only when a specific team is selected.
- Renders up to four live sessions from the selected team as fullscreen vertical lanes.
- Orders lanes by persisted team slot position, falling back to slot id / role / slot name / tmux target for stability.
- Keeps lane mode ephemeral: it does not mutate normal grid attachments and exits back to the prior grid.
- Hides per-panel maximize controls in lane mode and documents the feature.

## Behavior
- `Esc` or the lane header exit button returns to grid mode.
- If all lane sessions disappear, lane mode auto-exits.
- If more than four team sessions are live, the lane header shows `+N not shown`.
- Switching team filters exits lane mode through the existing filter handler.

## Validation
- `npm --prefix frontend run build`
- `cd frontend && npm exec -- eslint src/features/cc-bridge/CCBridgePage.tsx src/features/cc-bridge/TerminalView.tsx src/features/cc-bridge/TeamLanesView.tsx`
- `npm --prefix docs run build`
- `cd backend && PYTHONPATH=. .venv/bin/python -m pytest tests/agent_teams/test_agent_bridge_session_metadata.py`
- `git diff --check`
