### PR TITLE
Make Agent Bridge keyboard shortcuts discoverable

### DIFF
--- a/docs/features/agent-bridge.md
+++ b/docs/features/agent-bridge.md
@@ -30,6 +30,8 @@ With a specific team selected, the **Team lanes** action opens a fullscreen vert
 
 ## Keyboard Controls
 
+Each terminal bar includes a keyboard shortcut chip. Click it to open the in-app shortcut reference; the dialog is available in the normal grid, single fullscreen, and team-lanes layouts.
+
 When a bridge terminal is focused, press `Ctrl+Space` to arm the Agent Bridge leader. The hint overlay lists the available follow-up keys:
 
 - `←` / `→` — focus the previous or next displayed pane, wrapping in on-screen order.

--- a/docs/superpowers/specs/2026-07-01-agent-bridge-shortcuts-discoverability-design.md
+++ b/docs/superpowers/specs/2026-07-01-agent-bridge-shortcuts-discoverability-design.md
@@ -1,0 +1,103 @@
+# Agent Bridge Keyboard Shortcuts Discoverability — Design Spec
+
+**Status:** Draft for review (no implementation committed)
+**Date:** 2026-07-01
+**Scope:** Make the Agent Bridge keyboard shortcuts (#261 / PR #262) discoverable through an always-visible in-app affordance plus a full shortcuts dialog, instead of only appearing transiently after pressing `Ctrl+Space`.
+**Depends on:** #261 / PR #262 (leader shortcuts + `LeaderHintOverlay`), merged to master.
+
+---
+
+## 1. Problem & Motivation
+
+The `Ctrl+Space` leader shortcuts (prev/next pane, jump 1-4, toggle mode) are only surfaced by `LeaderHintOverlay`, which appears **after** the user already presses `Ctrl+Space`. Nothing in the UI tells a user the shortcuts exist, so the feature is effectively hidden — a user who doesn't already know the prefix will never discover it.
+
+Additional constraint: the Agent Bridge **header is hidden in fullscreen and team-lanes layouts** (`{!isFullscreen && ...}` in `CCBridgePage.tsx`) — which are exactly the modes where the shortcuts are most useful. So a header-only affordance would be invisible when it matters most.
+
+---
+
+## 2. Current State (as-is)
+
+- `frontend/src/features/cc-bridge/LeaderHintOverlay.tsx` — a transient top-right chip listing the follow-up keys as a **hardcoded string**; rendered by `CCBridgePage` only while a terminal reports leader-armed.
+- `frontend/src/features/cc-bridge/TerminalView.tsx` — each pane has a **bottom bar** already showing the Read-only/Interactive toggle, connection status, and session label. This bar is part of every pane, so it is present in **all** layouts (grid, single fullscreen, lanes).
+- UI primitives available: shadcn `dialog` and `alert-dialog` exist. **No `popover` or `tooltip`** primitive is present.
+
+---
+
+## 3. Design
+
+### 3.1 Shared shortcut definitions (single source of truth)
+
+Extract the shortcut list into one module, e.g. `frontend/src/features/cc-bridge/leaderShortcuts.ts`:
+
+```ts
+export interface LeaderShortcut {
+  keys: string        // e.g. '←/→', '1-4', 'r', 'Esc'
+  label: string       // e.g. 'Previous / next pane'
+}
+
+export const LEADER_PREFIX_LABEL = 'Ctrl+Space'
+
+export const LEADER_SHORTCUTS: LeaderShortcut[] = [
+  { keys: '←/→', label: 'Previous / next displayed pane' },
+  { keys: '1-4', label: 'Jump to displayed pane' },
+  { keys: 'r',   label: 'Toggle read-only / interactive' },
+  { keys: 'Esc', label: 'Cancel the leader' },
+]
+```
+
+Both `LeaderHintOverlay` and the new dialog render from this array so they cannot drift.
+
+### 3.2 Terminal-bar hint (always-visible affordance)
+
+Add a small, low-emphasis `<button>` to the `TerminalView` bottom bar (near the mode toggle / status), labeled with an icon + prefix, e.g. `⌨ Ctrl+Space`.
+
+- Present in every layout because the bar is part of each pane.
+- **Responsive:** icon-first chip; on narrow panes (4-up grid / lanes) it may collapse to just the icon, with the full text available via `title` and the dialog.
+- `onClick` calls `e.stopPropagation()` so it does not steal/alter pane focus; opens the dialog.
+- A real `<button>` — keyboard reachable, focusable.
+
+### 3.3 Shortcuts dialog
+
+Clicking the hint opens a shadcn `Dialog` titled "Keyboard shortcuts":
+
+- Renders `LEADER_PREFIX_LABEL` as the leader prefix, then each `LEADER_SHORTCUTS` entry as `keys` + `label`.
+- Renders above fullscreen / lanes (dialog portal), so it works in every layout.
+- `Esc` / backdrop / close button dismisses it.
+- Open state is **local to `TerminalView`** (each pane owns its own dialog) — no new global state in `CCBridgePage`.
+
+### 3.4 Refactor `LeaderHintOverlay`
+
+Replace its hardcoded string with a render over `LEADER_SHORTCUTS` + `LEADER_PREFIX_LABEL`, keeping the transient overlay and the dialog in sync.
+
+---
+
+## 4. Components / Files
+
+Frontend only. No backend change.
+
+- `frontend/src/features/cc-bridge/leaderShortcuts.ts` — **new**; shared definitions.
+- `frontend/src/features/cc-bridge/TerminalView.tsx` — bottom-bar hint button + local dialog state + `Dialog` render.
+- `frontend/src/features/cc-bridge/LeaderHintOverlay.tsx` — consume the shared list.
+- `docs/features/agent-bridge.md` — note the in-app affordance (bar hint + dialog).
+
+---
+
+## 5. Test Plan (manual; no FE test harness)
+
+1. The `⌨ Ctrl+Space` hint is visible in the terminal bar in grid, single fullscreen, and team-lanes layouts.
+2. Clicking the hint opens the shortcuts dialog listing prefix + all follow-up keys with descriptions.
+3. Clicking the hint does not change which pane is focused (`stopPropagation`).
+4. `Esc` / backdrop / close button dismisses the dialog.
+5. Dialog opens correctly above fullscreen and lanes layouts.
+6. On a narrow pane (4-up grid), the hint collapses gracefully (icon-only) and the dialog still lists everything.
+7. The transient `LeaderHintOverlay` (after pressing `Ctrl+Space`) and the dialog show the same shortcut set (shared source).
+8. Hint button is keyboard-reachable and activates on Enter/Space.
+
+---
+
+## 6. Non-Goals
+
+- Configurable / remappable keybindings (still a future enhancement).
+- A global, app-wide shortcuts reference beyond Agent Bridge.
+- Showing the hint outside Agent Bridge terminals.
+- Adding a new `popover`/`tooltip` primitive (dialog reuse only).

--- a/frontend/src/features/cc-bridge/LeaderHintOverlay.tsx
+++ b/frontend/src/features/cc-bridge/LeaderHintOverlay.tsx
@@ -1,8 +1,12 @@
+import { LEADER_PREFIX_LABEL, LEADER_SHORTCUTS } from './leaderShortcuts'
+
 export function LeaderHintOverlay() {
   return (
     <div className="pointer-events-none fixed right-4 top-4 z-[60] rounded-md border bg-background/95 px-3 py-2 text-xs text-foreground shadow-lg backdrop-blur">
-      <span className="font-medium">Leader:</span>{' '}
-      <span className="text-muted-foreground">← prev · → next · 1-4 jump · r toggle mode · Esc cancel</span>
+      <span className="font-medium">Leader {LEADER_PREFIX_LABEL}:</span>{' '}
+      <span className="text-muted-foreground">
+        {LEADER_SHORTCUTS.map((shortcut) => `${shortcut.keys} ${shortcut.label}`).join(' · ')}
+      </span>
     </div>
   )
 }

--- a/frontend/src/features/cc-bridge/TerminalView.tsx
+++ b/frontend/src/features/cc-bridge/TerminalView.tsx
@@ -1,13 +1,21 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Monitor, Maximize2, Minimize2, X } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent } from 'react'
+import { Keyboard, Monitor, Maximize2, Minimize2, X } from 'lucide-react'
 import { toast } from 'sonner'
 import { useTerminal } from './useTerminal'
 import { ImageAttachmentDialog } from './ImageAttachmentDialog'
 import { pasteBridgeAttachment, uploadBridgeAttachment } from './api'
 import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import { getTeamSlotColorClasses, getTeamSlotTerminalTheme } from '@/lib/agentTeamColors'
 import { getInstanceAccentClasses } from '@/lib/instanceAccent'
 import { cn } from '@/lib/utils'
+import { LEADER_PREFIX_LABEL, LEADER_SHORTCUTS } from './leaderShortcuts'
 import type { BridgeAttachment, CCSession, LeaderNavigationDirection } from './types'
 import type { InstanceIdentity } from '@/types/status'
 
@@ -72,6 +80,7 @@ export function TerminalView({
   const wrapperRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const [draggingImage, setDraggingImage] = useState(false)
+  const [shortcutsOpen, setShortcutsOpen] = useState(false)
   const [imageAttachment, setImageAttachment] = useState<ImageAttachmentState | null>(null)
   const slotColor = session?.team_slot_color
   const terminalTheme = useMemo(() => getTeamSlotTerminalTheme(slotColor), [slotColor])
@@ -108,6 +117,15 @@ export function TerminalView({
 
   const closeImageAttachment = useCallback(() => {
     setImageAttachment(null)
+  }, [])
+
+  const stopShortcutButtonPropagation = useCallback((event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation()
+  }, [])
+
+  const openShortcuts = useCallback((event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation()
+    setShortcutsOpen(true)
   }, [])
 
   const attachImageFile = useCallback(async (file: File) => {
@@ -250,6 +268,17 @@ export function TerminalView({
             )}>
               {connected ? 'Connected' : 'Disconnected'}
             </span>
+            <button
+              type="button"
+              className="inline-flex h-6 shrink-0 items-center gap-1 rounded border bg-muted/40 px-1.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1"
+              aria-label="Keyboard shortcuts"
+              title={`Keyboard shortcuts (${LEADER_PREFIX_LABEL})`}
+              onMouseDown={stopShortcutButtonPropagation}
+              onClick={openShortcuts}
+            >
+              <Keyboard className="h-3.5 w-3.5" />
+              <span className="hidden lg:inline">{LEADER_PREFIX_LABEL}</span>
+            </button>
             <span
               className="text-xs text-muted-foreground truncate"
               title={instance ? `${modeLabel} on ${instance.name} (${instance.hostname}) · ${target}` : target}
@@ -301,6 +330,26 @@ export function TerminalView({
           onSwitchInteractive={() => setReadOnly(false)}
         />
       )}
+      <Dialog open={shortcutsOpen} onOpenChange={setShortcutsOpen}>
+        <DialogContent className="sm:max-w-[440px]">
+          <DialogHeader>
+            <DialogTitle>Keyboard shortcuts</DialogTitle>
+            <DialogDescription>
+              Press <kbd className="rounded border bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground">{LEADER_PREFIX_LABEL}</kbd> while a bridge terminal is focused, then press a follow-up key.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            {LEADER_SHORTCUTS.map((shortcut) => (
+              <div key={shortcut.keys} className="flex items-center justify-between gap-4 rounded-md border bg-muted/20 px-3 py-2">
+                <kbd className="shrink-0 rounded border bg-background px-2 py-1 font-mono text-xs text-foreground">
+                  {shortcut.keys}
+                </kbd>
+                <span className="text-sm text-muted-foreground">{shortcut.label}</span>
+              </div>
+            ))}
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/frontend/src/features/cc-bridge/leaderShortcuts.ts
+++ b/frontend/src/features/cc-bridge/leaderShortcuts.ts
@@ -1,0 +1,13 @@
+export interface LeaderShortcut {
+  keys: string
+  label: string
+}
+
+export const LEADER_PREFIX_LABEL = 'Ctrl+Space'
+
+export const LEADER_SHORTCUTS: LeaderShortcut[] = [
+  { keys: '←/→', label: 'Previous / next displayed pane' },
+  { keys: '1-4', label: 'Jump to displayed pane' },
+  { keys: 'r', label: 'Toggle read-only / interactive' },
+  { keys: 'Esc', label: 'Cancel the leader' },
+]


### PR DESCRIPTION
Closes #263.

## Summary
- Adds a shared Agent Bridge leader shortcut definition module.
- Refactors the transient leader overlay to render from the shared shortcut list.
- Adds a persistent keyboard-shortcuts chip in each terminal bar so shortcuts are discoverable in grid, single fullscreen, and team lanes.
- Adds a local terminal shortcuts dialog listing the leader prefix and follow-up keys.
- Documents the in-app shortcut affordance.

## Behavior
- The terminal bar shows a keyboard chip; the prefix text appears on normal desktop widths and collapses to icon-only on smaller layouts.
- Clicking the chip stops propagation and opens the dialog without changing pane focus state.
- Dialog uses the existing shadcn `Dialog` primitive and renders above fullscreen/lane layouts.
- Overlay and dialog share the same shortcut source.

## Validation
- `npm --prefix frontend run build`
- `cd frontend && npm exec -- eslint src/features/cc-bridge/TerminalView.tsx src/features/cc-bridge/LeaderHintOverlay.tsx src/features/cc-bridge/leaderShortcuts.ts`
- `npm --prefix docs run build`
- `git diff --check`
