### PR TITLE
Add Claude Sonnet 5 model support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Docs**: Refreshed release, Config, and Dashboard docs to describe the 2.0.1 stabilization fixes.
 
 ### Fixed
-- **Usage costs**: Claude Code usage dashboards now calculate costs for current Claude model aliases such as Opus 4.6/4.7/4.8, Sonnet 4.6, Haiku 4.5, and Fable 5 instead of showing `$0.00` with non-zero token usage.
+- **Usage costs**: Claude Code usage dashboards now calculate costs for current Claude model aliases such as Sonnet 5, Fable 5, Opus 4.6/4.7/4.8, Sonnet 4.6, and Haiku 4.5 instead of showing `$0.00` with non-zero token usage.
 - **Usage cache**: Usage cache keys now include the pricing table version, avoiding stale zero-cost aggregates after pricing support changes.
 - **Config defaults**: Corrected stale UI defaults/descriptions for auto-updates, sandbox auto-allow, thinking summaries, plan auto-mode, and turn duration.
 

--- a/backend/app/services/context_service.py
+++ b/backend/app/services/context_service.py
@@ -28,6 +28,9 @@ from app.utils.path_utils import get_claude_projects_dir, get_project_display_na
 # Model context window limits (input tokens). Keys are normalized
 # substrings — `_normalize_model` strips dated suffixes before lookup.
 MODEL_CONTEXT_LIMITS: dict[str, int] = {
+    # Claude 5.x
+    "claude-sonnet-5": 1_000_000,
+    "claude-fable-5": 200_000,
     # Claude 4.7 — 1M window
     "claude-opus-4-7": 1_000_000,
     # Claude 4.6
@@ -81,10 +84,11 @@ def get_context_limit(model: str) -> int:
     # Exact match first
     if normalized in MODEL_CONTEXT_LIMITS:
         return MODEL_CONTEXT_LIMITS[normalized]
-    # Longest-prefix match so claude-opus-4-7 picks the 4-7 entry over 4 entry
+    # Longest match so claude-opus-4-7 picks the 4-7 entry over 4,
+    # including provider-prefixed model IDs such as Bedrock names.
     best: tuple[int, int] = (-1, DEFAULT_CONTEXT_LIMIT)
     for key, limit in MODEL_CONTEXT_LIMITS.items():
-        if normalized.startswith(key) and len(key) > best[0]:
+        if (normalized.startswith(key) or key in normalized) and len(key) > best[0]:
             best = (len(key), limit)
     return best[1]
 

--- a/backend/app/services/pricing_service.py
+++ b/backend/app/services/pricing_service.py
@@ -11,7 +11,7 @@ class PricingService:
     """Service for model pricing and cost calculation."""
 
     # Bump when MODEL_PRICING changes so cached usage aggregates are recalculated.
-    PRICING_VERSION = "2026-06-20"
+    PRICING_VERSION = "2026-07-02"
 
     # Default token threshold for tiered pricing (200k tokens)
     TIERED_THRESHOLD = 200_000
@@ -19,6 +19,13 @@ class PricingService:
     # Model pricing data (costs per token)
     # Based on LiteLLM pricing data
     MODEL_PRICING = {
+        # Claude Sonnet 5 (June 2026)
+        "claude-sonnet-5": {
+            "input": 3.00 / 1_000_000,
+            "output": 15.00 / 1_000_000,
+            "cache_creation": 3.75 / 1_000_000,
+            "cache_read": 0.30 / 1_000_000,
+        },
         # Claude Fable 5 (June 2026)
         "claude-fable-5": {
             "input": 10.00 / 1_000_000,

--- a/backend/tests/test_context_service.py
+++ b/backend/tests/test_context_service.py
@@ -1,0 +1,12 @@
+from app.services.context_service import get_context_limit
+
+
+def test_current_model_context_limits():
+    assert get_context_limit("claude-sonnet-5") == 1_000_000
+    assert get_context_limit("anthropic.claude-sonnet-5-20260620-v1:0") == 1_000_000
+    assert get_context_limit("claude-fable-5") == 200_000
+
+
+def test_existing_long_context_aliases_still_match():
+    assert get_context_limit("claude-sonnet-4-6") == 1_000_000
+    assert get_context_limit("claude-opus-4-7") == 1_000_000

--- a/backend/tests/test_usage_service.py
+++ b/backend/tests/test_usage_service.py
@@ -89,6 +89,15 @@ class TestPricingService:
 
     def test_current_claude_code_alias_pricing(self):
         """Test current Claude Code model aliases have non-zero pricing."""
+        sonnet_5_cost = self.pricing.calculate_cost(
+            input_tokens=1000,
+            output_tokens=500,
+            cache_creation_tokens=200,
+            cache_read_tokens=1000,
+            model="claude-sonnet-5",
+        )
+        assert sonnet_5_cost == pytest.approx(0.01155, rel=1e-3)
+
         sonnet_cost = self.pricing.calculate_cost(
             input_tokens=1000,
             output_tokens=500,
@@ -116,7 +125,7 @@ class TestPricingService:
 
     def test_current_alias_matching_with_provider_style_name(self):
         """Test provider-prefixed current aliases resolve."""
-        pricing = self.pricing.get_model_pricing("anthropic.claude-sonnet-4-6-v1:0")
+        pricing = self.pricing.get_model_pricing("anthropic.claude-sonnet-5-20260620-v1:0")
         assert pricing is not None
         assert pricing["input"] == pytest.approx(3.00 / 1_000_000)
 
@@ -125,6 +134,7 @@ class TestPricingService:
         models = self.pricing.get_supported_models()
         assert len(models) > 0
         assert "claude-sonnet-4-20250514" in models
+        assert "claude-sonnet-5" in models
         assert "claude-sonnet-4-6" in models
         assert "claude-opus-4-7" in models
         assert "claude-fable-5" in models

--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -29,7 +29,7 @@ POST /api/v1/agents?project_path={path}
   "description": "Code review specialist",
   "tools": ["Read", "Grep", "Glob"],
   "disallowed_tools": ["Write", "Bash"],
-  "model": "claude-sonnet-4-6",
+  "model": "claude-sonnet-5",
   "permission_mode": "default",
   "skills": ["code-review"],
   "memory": "user",

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -76,7 +76,7 @@ PUT /api/v1/config/settings
 ```json
 {
   "scope": "user",
-  "settings": { "model": "claude-sonnet-4-6" },
+  "settings": { "model": "claude-sonnet-5" },
   "project_path": "/path/to/project"
 }
 ```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,7 +33,7 @@ All notable changes to Claude Deck are documented here. The format follows [Keep
 
 ### Fixed
 
-- Claude Code usage dashboards now calculate costs for current model aliases such as Opus 4.6/4.7/4.8, Sonnet 4.6, Haiku 4.5, and Fable 5 instead of showing `$0.00` with non-zero token usage.
+- Claude Code usage dashboards now calculate costs for current model aliases such as Sonnet 5, Fable 5, Opus 4.6/4.7/4.8, Sonnet 4.6, and Haiku 4.5 instead of showing `$0.00` with non-zero token usage.
 - Usage cache keys now include the pricing table version, preventing stale zero-cost aggregates after pricing support changes.
 - Several settings defaults and descriptions were corrected to match current Claude Code behavior.
 

--- a/docs/features/agents-skills.md
+++ b/docs/features/agents-skills.md
@@ -30,7 +30,7 @@ description: Code review specialist
 tools: Read, Grep, Glob
 disallowed-tools: Write, Bash
 permission-mode: default
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 skills: code-review, testing
 memory: user
 ---

--- a/frontend/src/features/config/settings/cards/AutoModeCard.tsx
+++ b/frontend/src/features/config/settings/cards/AutoModeCard.tsx
@@ -12,7 +12,7 @@ export function AutoModeCard({ getSetting, updateSetting, scope }: SettingsCardP
       <CardHeader>
         <CardTitle>Auto Mode</CardTitle>
         <CardDescription>
-          Configure the AI safety classifier for auto mode (requires Team/Enterprise + Sonnet 4.6+/Opus 4.6+)
+          Configure the AI safety classifier for auto mode (requires Team/Enterprise and a supported current Claude model)
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">

--- a/frontend/src/features/config/settings/cards/GeneralCard.tsx
+++ b/frontend/src/features/config/settings/cards/GeneralCard.tsx
@@ -38,7 +38,7 @@ export function GeneralCard({ getSetting, updateSetting }: SettingsCardProps) {
           <ListEditor
             value={getSetting<string[]>('fallbackModel', [])}
             onChange={(v) => updateSetting('fallbackModel', v)}
-            placeholder="e.g., claude-sonnet-4-6 or default"
+            placeholder="e.g., claude-sonnet-5 or claude-fable-5"
           />
         </div>
 
@@ -61,7 +61,7 @@ export function GeneralCard({ getSetting, updateSetting }: SettingsCardProps) {
         <SelectSetting
           id="effortLevel"
           label="Effort Level"
-          description="Persist the effort level across sessions. Supported on Opus 4.6+ and Sonnet 4.6. Note: Opus 4.8 defaults to high."
+          description="Persist the effort level across sessions. Supported on current Sonnet, Opus, and Fable models where Claude Code exposes effort controls."
           value={getSetting<string>('effortLevel', '')}
           onValueChange={(v) => updateSetting('effortLevel', v)}
           placeholder="Select effort level"
@@ -90,7 +90,7 @@ export function GeneralCard({ getSetting, updateSetting }: SettingsCardProps) {
           <ListEditor
             value={getSetting<string[]>('availableModels', [])}
             onChange={(v) => updateSetting('availableModels', v)}
-            placeholder="e.g., claude-sonnet-4-6"
+            placeholder="e.g., claude-sonnet-5"
           />
         </div>
 

--- a/frontend/src/features/config/settings/constants.ts
+++ b/frontend/src/features/config/settings/constants.ts
@@ -1,4 +1,5 @@
 export const MODEL_OPTIONS = [
+  { value: 'claude-sonnet-5', label: 'Claude Sonnet 5' },
   { value: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
   { value: 'claude-opus-4-7', label: 'Claude Opus 4.7' },
   { value: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
@@ -59,6 +60,7 @@ export const HOOK_MODEL_OPTIONS = [
   { value: 'fast-model', label: 'Fast Model (default)' },
   { value: 'haiku', label: 'Haiku' },
   { value: 'sonnet', label: 'Sonnet' },
+  { value: 'fable', label: 'Fable' },
   { value: 'opus', label: 'Opus' },
 ]
 

--- a/frontend/src/types/agents.ts
+++ b/frontend/src/types/agents.ts
@@ -206,6 +206,7 @@ export const AGENT_TOOLS = [
 export const AGENT_MODELS = [
   { value: "sonnet", label: "Claude Sonnet", description: "Fast and capable" },
   { value: "opus", label: "Claude Opus", description: "Most capable" },
+  { value: "fable", label: "Claude Fable", description: "Creative and capable" },
   { value: "haiku", label: "Claude Haiku", description: "Fastest, lightweight" },
 ] as const;
 

--- a/frontend/src/types/hooks.ts
+++ b/frontend/src/types/hooks.ts
@@ -271,6 +271,7 @@ export const HOOK_EVENTS: HookEventMetadata[] = [
 export const AGENT_MODELS = [
   { value: "haiku", label: "Haiku (Fast)" },
   { value: "sonnet", label: "Sonnet (Balanced)" },
+  { value: "fable", label: "Fable (Creative)" },
   { value: "opus", label: "Opus (Powerful)" },
 ];
 


### PR DESCRIPTION
## Summary
- Adds `claude-sonnet-5` to the Claude Code settings model picker.
- Adds Fable alias options to subagent/hook model selectors where the UI uses strict alias lists.
- Adds Sonnet 5 pricing, bumps the pricing cache version, and adds explicit Sonnet 5/Fable 5 context limits.
- Updates current-model examples in docs and changelogs.

Closes #269

## Validation
- `backend/.venv/bin/python -m pytest tests/test_usage_service.py tests/test_context_service.py`
- `npm exec -- eslint src/features/config/settings/constants.ts src/features/config/settings/cards/GeneralCard.tsx src/features/config/settings/cards/AutoModeCard.tsx src/types/agents.ts src/types/hooks.ts`
- `npm run build`
- `npm --prefix ../docs run build`
- `git diff --check`

Note: frontend/docs builds still emit the existing large-chunk warning.
