### PR TITLE
feat(dispatch): implement autonomous GitHub dispatch Phase A

### DIFF
--- a/backend/app/api/v1/agent_teams.py
+++ b/backend/app/api/v1/agent_teams.py
@@ -1,11 +1,14 @@
 """Agent Team Preset endpoints."""
 from __future__ import annotations
 
+from datetime import datetime
+
 from fastapi import APIRouter, Depends, HTTPException, Response
 from fastapi.encoders import jsonable_encoder
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
+from app.models.database import GithubWorkItem, TeamGithubScope
 from app.models.schemas import (
     AgentTeamCreateFromBridgeRequest,
     AgentTeamCreateFromMailRequest,
@@ -19,7 +22,9 @@ from app.models.schemas import (
     AgentTeamSlotCreate,
     AgentTeamSlotReorderRequest,
     AgentTeamSlotUpdate,
+    DispatchStatusReport,
 )
+from app.services.github_dispatch_service import github_dispatch_service
 from app.services.agent_team_service import PlanConflictError, agent_team_service
 from app.services.providers.base import ProviderLaunchError
 
@@ -33,6 +38,51 @@ def _bad_request(exc: ValueError) -> HTTPException:
             detail={"message": str(exc), "block_code": exc.block_code},
         )
     return HTTPException(status_code=400, detail=str(exc))
+
+
+@router.post("/dispatch-status")
+async def report_dispatch_status(
+    report: DispatchStatusReport,
+    db: AsyncSession = Depends(get_db),
+):
+    item = await db.get(GithubWorkItem, report.work_item_id)
+    if item is None:
+        raise HTTPException(status_code=404, detail="work item not found")
+    scope = await db.get(TeamGithubScope, item.scope_id)
+
+    if report.status in ("triaging", "revision_requested"):
+        await github_dispatch_service.record_approval_round(db, item, scope)
+    elif report.status == "handoff_initiated":
+        if report.reassign_to_slot_id is None:
+            raise HTTPException(status_code=400, detail="reassign_to_slot_id required")
+        await github_dispatch_service.initiate_handoff(db, item, report.reassign_to_slot_id)
+    elif report.status == "handoff_accepted":
+        if report.reporting_slot_id is None:
+            raise HTTPException(status_code=400, detail="reporting_slot_id required")
+        try:
+            await github_dispatch_service.accept_handoff(db, item, report.reporting_slot_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+    elif report.status == "blocked":
+        item.dispatch_status = "escalated"
+        item.escalation_reason = "agent_blocked"
+        item.updated_at = datetime.utcnow()
+        await db.commit()
+    elif report.status in ("pr_opened", "in_progress"):
+        if report.pr_number is not None:
+            item.pr_number = report.pr_number
+            item.updated_at = datetime.utcnow()
+            await db.commit()
+    else:
+        raise HTTPException(status_code=400, detail=f"unknown status {report.status}")
+
+    await db.refresh(item)
+    return {
+        "work_item_id": item.id,
+        "dispatch_status": item.dispatch_status,
+        "escalation_reason": item.escalation_reason,
+        "handoff_state": item.handoff_state,
+    }
 
 
 @router.get("/presets", response_model=AgentTeamPresetListResponse)

--- a/backend/app/api/v1/agent_teams.py
+++ b/backend/app/api/v1/agent_teams.py
@@ -50,7 +50,12 @@ async def report_dispatch_status(
         raise HTTPException(status_code=404, detail="work item not found")
     scope = await db.get(TeamGithubScope, item.scope_id)
 
-    if report.status in ("triaging", "revision_requested"):
+    if report.status == "triaging":
+        if report.note is not None:
+            item.status_note = report.note
+            item.updated_at = datetime.utcnow()
+            await db.commit()
+    elif report.status == "revision_requested":
         await github_dispatch_service.record_approval_round(db, item, scope)
     elif report.status == "handoff_initiated":
         if report.reassign_to_slot_id is None:
@@ -65,7 +70,8 @@ async def report_dispatch_status(
             raise HTTPException(status_code=409, detail=str(exc)) from exc
     elif report.status == "blocked":
         item.dispatch_status = "escalated"
-        item.escalation_reason = "agent_blocked"
+        item.escalation_reason = "plan_blocked"
+        item.status_note = report.note
         item.updated_at = datetime.utcnow()
         await db.commit()
     elif report.status in ("pr_opened", "in_progress"):

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -35,6 +35,9 @@ class Settings(BaseSettings):
     bridge_attachment_retention_days: int = 7
     bridge_attachment_max_per_session_per_day: int = 100
 
+    # GitHub integration (autonomous dispatch)
+    github_token: str = ""
+
     # Server settings
     host: str = "0.0.0.0"
     port: int = 8000

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -369,6 +369,17 @@ async def _run_sqlite_compat_migrations(conn) -> None:
         )
     if slot_columns and "ui_color" not in slot_columns:
         await conn.execute(text("ALTER TABLE agent_team_slots ADD COLUMN ui_color VARCHAR"))
+    if slot_columns and "area_labels" not in slot_columns:
+        await conn.execute(text("ALTER TABLE agent_team_slots ADD COLUMN area_labels JSON"))
+    if slot_columns and "expertise" not in slot_columns:
+        await conn.execute(text("ALTER TABLE agent_team_slots ADD COLUMN expertise VARCHAR"))
+
+    result = await conn.execute(text("PRAGMA table_info(agent_team_presets)"))
+    preset_columns = {row[1] for row in result.fetchall()}
+    if preset_columns and "autonomy_enabled" not in preset_columns:
+        await conn.execute(
+            text("ALTER TABLE agent_team_presets ADD COLUMN autonomy_enabled BOOLEAN DEFAULT 0 NOT NULL")
+        )
 
     result = await conn.execute(text("PRAGMA table_info(agent_team_launch_items)"))
     launch_item_columns = {row[1] for row in result.fetchall()}

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -381,6 +381,11 @@ async def _run_sqlite_compat_migrations(conn) -> None:
             text("ALTER TABLE agent_team_presets ADD COLUMN autonomy_enabled BOOLEAN DEFAULT 0 NOT NULL")
         )
 
+    result = await conn.execute(text("PRAGMA table_info(github_work_items)"))
+    work_item_columns = {row[1] for row in result.fetchall()}
+    if work_item_columns and "status_note" not in work_item_columns:
+        await conn.execute(text("ALTER TABLE github_work_items ADD COLUMN status_note VARCHAR"))
+
     result = await conn.execute(text("PRAGMA table_info(agent_team_launch_items)"))
     launch_item_columns = {row[1] for row in result.fetchall()}
     if launch_item_columns and "message" not in launch_item_columns:

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -131,6 +131,7 @@ class AgentTeamPreset(Base):
     created_by: Mapped[str | None] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    autonomy_enabled: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
 
 
 class AgentTeamSlot(Base):
@@ -154,6 +155,8 @@ class AgentTeamSlot(Base):
     bootstrap_prompt: Mapped[str | None] = mapped_column(String, nullable=True)
     launch_mode: Mapped[str] = mapped_column(String, default="plain", nullable=False)
     launch_options: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    area_labels: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    expertise: Mapped[str | None] = mapped_column(String, nullable=True)
     enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
@@ -198,6 +201,71 @@ class AgentTeamLaunchItem(Base):
     block_code: Mapped[str | None] = mapped_column(String, nullable=True)
     error: Mapped[str | None] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+
+class TeamGithubScope(Base):
+    """A GitHub repo an Agent Team watches for labeled issues."""
+
+    __tablename__ = "team_github_scopes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    preset_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("agent_team_presets.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    repo_owner: Mapped[str] = mapped_column(String, nullable=False)
+    repo_name: Mapped[str] = mapped_column(String, nullable=False)
+    repo_path: Mapped[str] = mapped_column(String, nullable=False)
+    dispatch_label: Mapped[str] = mapped_column(String, default="claude-deck-ready", nullable=False)
+    design_label: Mapped[str] = mapped_column(String, default="claude-deck-design", nullable=False)
+    merge_policy: Mapped[str] = mapped_column(String, default="human", nullable=False)
+    max_approval_rounds: Mapped[int] = mapped_column(Integer, default=3, nullable=False)
+    enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    last_polled_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("preset_id", "repo_owner", "repo_name", name="uix_preset_repo_scope"),
+    )
+
+
+class GithubWorkItem(Base):
+    """A labeled GitHub issue the dispatch pipeline is tracking."""
+
+    __tablename__ = "github_work_items"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    scope_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("team_github_scopes.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    issue_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    issue_title: Mapped[str] = mapped_column(String, nullable=False)
+    issue_url: Mapped[str] = mapped_column(String, nullable=False)
+    github_updated_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    issue_type: Mapped[str] = mapped_column(String, default="code", nullable=False)
+    dispatch_status: Mapped[str] = mapped_column(String, default="pending", nullable=False)
+    pending_reason: Mapped[str | None] = mapped_column(String, nullable=True)
+    launch_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("agent_team_launches.id", ondelete="SET NULL"), nullable=True
+    )
+    owner_slot_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("agent_team_slots.id", ondelete="SET NULL"), nullable=True
+    )
+    routing_method: Mapped[str | None] = mapped_column(String, nullable=True)
+    handoff_state: Mapped[str | None] = mapped_column(String, nullable=True)
+    handoff_target_slot_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("agent_team_slots.id", ondelete="SET NULL"), nullable=True
+    )
+    approval_round_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    pr_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    retry_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    escalation_reason: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("scope_id", "issue_number", name="uix_scope_issue"),
+    )
 
 
 class BridgeSessionAttachment(Base):

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -260,6 +260,7 @@ class GithubWorkItem(Base):
     pr_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
     retry_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     escalation_reason: Mapped[str | None] = mapped_column(String, nullable=True)
+    status_note: Mapped[str | None] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
 

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -2181,6 +2181,15 @@ class AgentTeamLaunchRequest(BaseModel):
     repo_path_override: Optional[str] = None
 
 
+class DispatchStatusReport(BaseModel):
+    work_item_id: int
+    status: str
+    pr_number: Optional[int] = None
+    reassign_to_slot_id: Optional[int] = None
+    note: Optional[str] = None
+    reporting_slot_id: Optional[int] = None
+
+
 class AgentTeamLaunchResultItem(BaseModel):
     slot_id: int
     slot_name: str

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -2178,6 +2178,7 @@ class AgentTeamLaunchRequest(BaseModel):
     include_disabled: bool = False
     confirm_plan_hash: Optional[str] = None
     skip_plan_confirmation: bool = False
+    repo_path_override: Optional[str] = None
 
 
 class AgentTeamLaunchResultItem(BaseModel):

--- a/backend/app/services/agent_team_service.py
+++ b/backend/app/services/agent_team_service.py
@@ -496,7 +496,9 @@ class AgentTeamService:
         results: list[AgentTeamLaunchResultItem] = []
         for item in plan.items:
             slot = slot_by_id[item.slot_id]
-            result_item = await self._execute_plan_item(db, launch.id, preset, slot, item)
+            result_item = await self._execute_plan_item(
+                db, launch.id, preset, slot, item, request.repo_path_override
+            )
             results.append(result_item)
 
         failed = sum(1 for item in results if item.status == "failed")
@@ -523,6 +525,7 @@ class AgentTeamService:
         preset: AgentTeamPreset,
         slot: AgentTeamSlot,
         plan_item: AgentTeamLaunchPlanItem,
+        repo_path_override: str | None = None,
     ) -> AgentTeamLaunchResultItem:
         if plan_item.action == "reuse":
             agent_mail_member_id = await self._attach_team_context_to_existing_session(
@@ -577,7 +580,9 @@ class AgentTeamService:
             return result
 
         try:
-            options = self._spawn_options_for_slot(slot, self._bootstrap_prompt(preset, slot))
+            options = self._spawn_options_for_slot(
+                slot, self._bootstrap_prompt(preset, slot), repo_path_override
+            )
             spawned = spawn_session(
                 slot.provider,
                 options,
@@ -596,7 +601,7 @@ class AgentTeamService:
                 action="spawn",
                 status="pending_registration",
                 provider=slot.provider,
-                repo_path=slot.repo_path,
+                repo_path=repo_path_override or slot.repo_path,
                 session_name=spawned.get("session_name"),
                 tmux_target=spawned.get("tmux_target"),
                 message="Session spawned; waiting for Agent Mail registration",
@@ -609,7 +614,7 @@ class AgentTeamService:
                 action="spawn",
                 status="failed",
                 provider=slot.provider,
-                repo_path=slot.repo_path,
+                repo_path=repo_path_override or slot.repo_path,
                 error=str(exc),
                 warnings=plan_item.warnings,
             )
@@ -1034,7 +1039,9 @@ class AgentTeamService:
         except Exception as exc:
             return str(exc)
 
-    def _spawn_options_for_slot(self, slot: AgentTeamSlot, prompt: str | None) -> SpawnCommandOptions:
+    def _spawn_options_for_slot(
+        self, slot: AgentTeamSlot, prompt: str | None, repo_path_override: str | None = None
+    ) -> SpawnCommandOptions:
         raw_options = dict(slot.launch_options or {})
         raw_prompt = self._clean_optional(raw_options.pop("prompt", None))
         if prompt and raw_prompt:
@@ -1043,7 +1050,7 @@ class AgentTeamService:
             prompt = raw_prompt
 
         values: dict[str, Any] = {
-            "directory": slot.repo_path,
+            "directory": repo_path_override or slot.repo_path,
             "mode": slot.launch_mode or "plain",
             "prompt": prompt,
         }

--- a/backend/app/services/github_client.py
+++ b/backend/app/services/github_client.py
@@ -43,6 +43,16 @@ class GithubClient:
     async def get_open_issues_by_number(
         self, owner: str, repo: str, numbers: list[int]
     ) -> dict[int, dict]:
+        issues = await self.get_issues_by_number(owner, repo, numbers)
+        return {
+            number: issue
+            for number, issue in issues.items()
+            if issue.get("state") == "open" and "pull_request" not in issue
+        }
+
+    async def get_issues_by_number(
+        self, owner: str, repo: str, numbers: list[int]
+    ) -> dict[int, dict]:
         if not numbers:
             return {}
         client = self._client()
@@ -57,7 +67,7 @@ class GithubClient:
                     continue
                 resp.raise_for_status()
                 issue = resp.json()
-                if issue.get("state") == "open" and "pull_request" not in issue:
+                if "pull_request" not in issue:
                     result[number] = issue
             return result
         finally:

--- a/backend/app/services/github_client.py
+++ b/backend/app/services/github_client.py
@@ -1,0 +1,82 @@
+"""Read-only GitHub REST client for autonomous dispatch."""
+from __future__ import annotations
+
+import httpx
+
+from app.config import settings
+
+_GITHUB_API = "https://api.github.com"
+
+
+class GithubClient:
+    """Thin async wrapper over the read-only GitHub calls dispatch needs."""
+
+    def __init__(self, http: httpx.AsyncClient | None = None, token: str | None = None):
+        self._http = http
+        self._token = token if token is not None else settings.github_token
+
+    def _client(self) -> httpx.AsyncClient:
+        if self._http is not None:
+            return self._http
+        return httpx.AsyncClient(base_url=_GITHUB_API, timeout=30.0)
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Accept": "application/vnd.github+json"}
+        if self._token:
+            headers["Authorization"] = f"Bearer {self._token}"
+        return headers
+
+    async def list_issues_with_label(self, owner: str, repo: str, label: str) -> list[dict]:
+        client = self._client()
+        try:
+            resp = await client.get(
+                f"/repos/{owner}/{repo}/issues",
+                params={"labels": label, "state": "open", "per_page": 100},
+                headers=self._headers(),
+            )
+            resp.raise_for_status()
+            return [issue for issue in resp.json() if "pull_request" not in issue]
+        finally:
+            if self._http is None:
+                await client.aclose()
+
+    async def get_open_issues_by_number(
+        self, owner: str, repo: str, numbers: list[int]
+    ) -> dict[int, dict]:
+        if not numbers:
+            return {}
+        client = self._client()
+        result: dict[int, dict] = {}
+        try:
+            for number in numbers:
+                resp = await client.get(
+                    f"/repos/{owner}/{repo}/issues/{number}",
+                    headers=self._headers(),
+                )
+                if resp.status_code == 404:
+                    continue
+                resp.raise_for_status()
+                issue = resp.json()
+                if issue.get("state") == "open" and "pull_request" not in issue:
+                    result[number] = issue
+            return result
+        finally:
+            if self._http is None:
+                await client.aclose()
+
+    async def list_repo_labels(self, owner: str, repo: str) -> list[str]:
+        client = self._client()
+        try:
+            resp = await client.get(
+                f"/repos/{owner}/{repo}/labels",
+                params={"per_page": 100},
+                headers=self._headers(),
+            )
+            resp.raise_for_status()
+            return [label["name"] for label in resp.json()]
+        finally:
+            if self._http is None:
+                await client.aclose()
+
+
+github_client = GithubClient()

--- a/backend/app/services/github_dispatch_service.py
+++ b/backend/app/services/github_dispatch_service.py
@@ -154,5 +154,50 @@ class GithubDispatchService:
         item.updated_at = datetime.utcnow()
         await db.commit()
 
+    async def monitor_dispatched(
+        self,
+        db: AsyncSession,
+        scope: TeamGithubScope,
+        preset_slots: list[AgentTeamSlot],
+        wake_state_by_slot: dict[int, str] | None = None,
+    ) -> None:
+        enabled = sorted(
+            [slot for slot in preset_slots if slot.enabled],
+            key=lambda slot: slot.position,
+        )
+        if not enabled:
+            return
+        leader = enabled[0]
+
+        if wake_state_by_slot is None:
+            from app.services.agent_mail_service import agent_mail_service
+
+            members = await agent_mail_service.list_team(db)
+            wake_state_by_slot = {
+                member.team_slot_id: member.wake_state
+                for member in members
+                if member.team_slot_id is not None
+            }
+        leader_wake = wake_state_by_slot.get(leader.id, "offline")
+
+        dispatched = (
+            await db.execute(
+                select(GithubWorkItem).where(
+                    GithubWorkItem.scope_id == scope.id,
+                    GithubWorkItem.dispatch_status == "dispatched",
+                    GithubWorkItem.pr_number.is_(None),
+                )
+            )
+        ).scalars().all()
+
+        for item in dispatched:
+            if leader_wake == "offline":
+                item.dispatch_status = "escalated"
+                item.escalation_reason = "leader_offline"
+                item.updated_at = datetime.utcnow()
+            # Leader reachable but idle nudge/escalation is intentionally deferred;
+            # it needs agent-mail last-activity plumbing beyond Phase A's backend core.
+        await db.commit()
+
 
 github_dispatch_service = GithubDispatchService()

--- a/backend/app/services/github_dispatch_service.py
+++ b/backend/app/services/github_dispatch_service.py
@@ -1,10 +1,14 @@
 """Routing and dispatch lifecycle for autonomous GitHub dispatch."""
 from __future__ import annotations
 
+from datetime import datetime
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.database import AgentTeamSlot, GithubWorkItem
+from app.models.database import AgentTeamSlot, GithubWorkItem, TeamGithubScope
+from app.models.schemas import AgentTeamLaunchRequest
+from app.services.agent_team_service import agent_team_service
 
 _BUSY_STATUSES = ("dispatched", "verifying")
 
@@ -59,6 +63,96 @@ class GithubDispatchService:
             )
         ).first()
         return pending_handoff is not None
+
+    async def dispatch_pending(
+        self,
+        db: AsyncSession,
+        scope: TeamGithubScope,
+        preset_slots: list[AgentTeamSlot],
+        client=None,
+        classify=None,
+        launcher=None,
+        issue_labels_by_number: dict[int, list[str]] | None = None,
+    ) -> None:
+        from app.services.github_client import github_client as _default_client
+
+        client = client or _default_client
+        launcher = launcher or agent_team_service.launch
+        issue_labels_by_number = issue_labels_by_number or {}
+        repo_labels = await client.list_repo_labels(scope.repo_owner, scope.repo_name)
+
+        pending = (
+            await db.execute(
+                select(GithubWorkItem).where(
+                    GithubWorkItem.scope_id == scope.id,
+                    GithubWorkItem.dispatch_status == "pending",
+                )
+            )
+        ).scalars().all()
+
+        for item in pending:
+            issue_labels = issue_labels_by_number.get(item.issue_number, [])
+            owner_slot_id, method = await self.route_item(
+                db, item, preset_slots, repo_labels, issue_labels, classify=classify
+            )
+            if owner_slot_id is None:
+                item.dispatch_status = "escalated"
+                item.escalation_reason = "plan_blocked"
+                continue
+            if await self.slot_is_busy(db, owner_slot_id):
+                item.owner_slot_id = owner_slot_id
+                item.routing_method = method
+                item.pending_reason = "queued_slot_busy"
+                continue
+            result = await launcher(
+                db,
+                scope.preset_id,
+                AgentTeamLaunchRequest(
+                    slot_ids=[owner_slot_id],
+                    skip_plan_confirmation=True,
+                    repo_path_override=scope.repo_path,
+                ),
+            )
+            item.owner_slot_id = owner_slot_id
+            item.routing_method = method
+            item.launch_id = getattr(result, "launch_id", None)
+            item.dispatch_status = "dispatched"
+            item.pending_reason = None
+            item.updated_at = datetime.utcnow()
+        await db.commit()
+
+    async def record_approval_round(
+        self, db: AsyncSession, item: GithubWorkItem, scope: TeamGithubScope
+    ) -> None:
+        item.approval_round_count += 1
+        if item.approval_round_count >= scope.max_approval_rounds:
+            item.dispatch_status = "escalated"
+            item.escalation_reason = "approval_rounds_exhausted"
+        item.updated_at = datetime.utcnow()
+        await db.commit()
+
+    async def initiate_handoff(
+        self, db: AsyncSession, item: GithubWorkItem, target_slot_id: int
+    ) -> None:
+        item.handoff_state = "pending"
+        item.handoff_target_slot_id = target_slot_id
+        item.updated_at = datetime.utcnow()
+        await db.commit()
+
+    async def accept_handoff(
+        self, db: AsyncSession, item: GithubWorkItem, accepting_slot_id: int
+    ) -> None:
+        if item.handoff_target_slot_id != accepting_slot_id:
+            raise ValueError(
+                f"slot {accepting_slot_id} cannot accept a handoff targeted at "
+                f"{item.handoff_target_slot_id}"
+            )
+        item.owner_slot_id = accepting_slot_id
+        item.handoff_state = "accepted"
+        item.handoff_target_slot_id = None
+        item.routing_method = "reassigned"
+        item.updated_at = datetime.utcnow()
+        await db.commit()
 
 
 github_dispatch_service = GithubDispatchService()

--- a/backend/app/services/github_dispatch_service.py
+++ b/backend/app/services/github_dispatch_service.py
@@ -19,7 +19,6 @@ class GithubDispatchService:
         db: AsyncSession,
         item: GithubWorkItem,
         preset_slots: list[AgentTeamSlot],
-        repo_labels: list[str],
         issue_labels: list[str],
         classify=None,
     ) -> tuple[int | None, str]:
@@ -74,12 +73,9 @@ class GithubDispatchService:
         launcher=None,
         issue_labels_by_number: dict[int, list[str]] | None = None,
     ) -> None:
-        from app.services.github_client import github_client as _default_client
-
-        client = client or _default_client
         launcher = launcher or agent_team_service.launch
         issue_labels_by_number = issue_labels_by_number or {}
-        repo_labels = await client.list_repo_labels(scope.repo_owner, scope.repo_name)
+        slots_dispatched_this_batch: set[int] = set()
 
         pending = (
             await db.execute(
@@ -93,33 +89,61 @@ class GithubDispatchService:
         for item in pending:
             issue_labels = issue_labels_by_number.get(item.issue_number, [])
             owner_slot_id, method = await self.route_item(
-                db, item, preset_slots, repo_labels, issue_labels, classify=classify
+                db, item, preset_slots, issue_labels, classify=classify
             )
             if owner_slot_id is None:
                 item.dispatch_status = "escalated"
                 item.escalation_reason = "plan_blocked"
+                item.updated_at = datetime.utcnow()
+                await db.commit()
                 continue
-            if await self.slot_is_busy(db, owner_slot_id):
+            if owner_slot_id in slots_dispatched_this_batch or await self.slot_is_busy(
+                db, owner_slot_id
+            ):
                 item.owner_slot_id = owner_slot_id
                 item.routing_method = method
                 item.pending_reason = "queued_slot_busy"
+                item.updated_at = datetime.utcnow()
+                await db.commit()
                 continue
-            result = await launcher(
-                db,
-                scope.preset_id,
-                AgentTeamLaunchRequest(
-                    slot_ids=[owner_slot_id],
-                    skip_plan_confirmation=True,
-                    repo_path_override=scope.repo_path,
-                ),
-            )
+            try:
+                result = await launcher(
+                    db,
+                    scope.preset_id,
+                    AgentTeamLaunchRequest(
+                        slot_ids=[owner_slot_id],
+                        reuse_existing=False,
+                        skip_plan_confirmation=True,
+                        repo_path_override=scope.repo_path,
+                    ),
+                )
+            except ValueError:
+                item.owner_slot_id = owner_slot_id
+                item.routing_method = method
+                item.dispatch_status = "escalated"
+                item.escalation_reason = "plan_blocked"
+                item.pending_reason = None
+                item.updated_at = datetime.utcnow()
+                await db.commit()
+                continue
             item.owner_slot_id = owner_slot_id
             item.routing_method = method
             item.launch_id = getattr(result, "launch_id", None)
-            item.dispatch_status = "dispatched"
+            launch_item = next(iter(getattr(result, "items", []) or []), None)
+            launch_status = getattr(launch_item, "status", None)
+            if launch_status in {
+                "failed",
+                "blocked",
+                "blocked_provider_unavailable",
+                "blocked_agent_mail_not_configured",
+            }:
+                item.dispatch_status = "failed"
+            else:
+                item.dispatch_status = "dispatched"
+                slots_dispatched_this_batch.add(owner_slot_id)
             item.pending_reason = None
             item.updated_at = datetime.utcnow()
-        await db.commit()
+            await db.commit()
 
     async def record_approval_round(
         self, db: AsyncSession, item: GithubWorkItem, scope: TeamGithubScope
@@ -178,7 +202,7 @@ class GithubDispatchService:
                 for member in members
                 if member.team_slot_id is not None
             }
-        leader_wake = wake_state_by_slot.get(leader.id, "offline")
+        leader_wake = wake_state_by_slot.get(leader.id)
 
         dispatched = (
             await db.execute(

--- a/backend/app/services/github_dispatch_service.py
+++ b/backend/app/services/github_dispatch_service.py
@@ -1,0 +1,64 @@
+"""Routing and dispatch lifecycle for autonomous GitHub dispatch."""
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.database import AgentTeamSlot, GithubWorkItem
+
+_BUSY_STATUSES = ("dispatched", "verifying")
+
+
+class GithubDispatchService:
+    async def route_item(
+        self,
+        db: AsyncSession,
+        item: GithubWorkItem,
+        preset_slots: list[AgentTeamSlot],
+        repo_labels: list[str],
+        issue_labels: list[str],
+        classify=None,
+    ) -> tuple[int | None, str]:
+        enabled = [slot for slot in preset_slots if slot.enabled]
+        enabled.sort(key=lambda slot: slot.position)
+        if not enabled:
+            return None, "leader_fallback"
+
+        issue_label_set = set(issue_labels)
+        for slot in enabled:
+            slot_areas = set(slot.area_labels or [])
+            if slot_areas & issue_label_set:
+                return slot.id, "label"
+
+        classifiable = [slot for slot in enabled if slot.expertise]
+        if classifiable and classify is not None:
+            chosen = await classify(item, classifiable)
+            if chosen is not None:
+                return chosen, "classified"
+
+        return enabled[0].id, "leader_fallback"
+
+    async def slot_is_busy(self, db: AsyncSession, slot_id: int) -> bool:
+        active = (
+            await db.execute(
+                select(GithubWorkItem.id).where(
+                    GithubWorkItem.owner_slot_id == slot_id,
+                    GithubWorkItem.dispatch_status.in_(_BUSY_STATUSES),
+                )
+            )
+        ).first()
+        if active is not None:
+            return True
+        pending_handoff = (
+            await db.execute(
+                select(GithubWorkItem.id).where(
+                    GithubWorkItem.handoff_state == "pending",
+                    (GithubWorkItem.owner_slot_id == slot_id)
+                    | (GithubWorkItem.handoff_target_slot_id == slot_id),
+                )
+            )
+        ).first()
+        return pending_handoff is not None
+
+
+github_dispatch_service = GithubDispatchService()

--- a/backend/app/services/github_watcher_service.py
+++ b/backend/app/services/github_watcher_service.py
@@ -1,0 +1,103 @@
+"""Polling watcher for autonomous GitHub dispatch."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.database import GithubWorkItem, TeamGithubScope
+from app.services.github_client import GithubClient, github_client
+
+_ACTIVE_STATUSES = ("dispatched", "verifying", "awaiting_human_review")
+_RECOVERABLE_STATUSES = ("failed", "escalated")
+
+
+def _parse_gh_ts(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).replace(tzinfo=None)
+
+
+class GithubWatcherService:
+    async def poll_scope(
+        self, db: AsyncSession, scope: TeamGithubScope, client: GithubClient | None = None
+    ) -> None:
+        client = client or github_client
+        labeled = await client.list_issues_with_label(
+            scope.repo_owner, scope.repo_name, scope.dispatch_label
+        )
+        for issue in labeled:
+            await self._upsert_item(db, scope, issue)
+        await self._recheck_active_items(db, scope, client)
+        scope.last_polled_at = datetime.utcnow()
+        await db.commit()
+
+    async def _upsert_item(self, db: AsyncSession, scope: TeamGithubScope, issue: dict) -> None:
+        label_names = {label["name"] for label in issue.get("labels", [])}
+        issue_type = "design" if scope.design_label in label_names else "code"
+        github_updated_at = _parse_gh_ts(issue["updated_at"])
+        existing = (
+            await db.execute(
+                select(GithubWorkItem).where(
+                    GithubWorkItem.scope_id == scope.id,
+                    GithubWorkItem.issue_number == issue["number"],
+                )
+            )
+        ).scalar_one_or_none()
+
+        if existing is None:
+            db.add(
+                GithubWorkItem(
+                    scope_id=scope.id,
+                    issue_number=issue["number"],
+                    issue_title=issue["title"],
+                    issue_url=issue["html_url"],
+                    github_updated_at=github_updated_at,
+                    issue_type=issue_type,
+                    dispatch_status="pending",
+                )
+            )
+            return
+
+        if (
+            existing.dispatch_status in _RECOVERABLE_STATUSES
+            and github_updated_at > existing.github_updated_at
+        ):
+            existing.dispatch_status = "pending"
+            existing.escalation_reason = None
+            existing.pending_reason = None
+            existing.retry_count = 0
+            existing.approval_round_count = 0
+        if existing.dispatch_status == "pending":
+            existing.issue_type = issue_type
+        existing.github_updated_at = github_updated_at
+        existing.issue_title = issue["title"]
+        existing.updated_at = datetime.utcnow()
+
+    async def _recheck_active_items(
+        self, db: AsyncSession, scope: TeamGithubScope, client: GithubClient
+    ) -> None:
+        active = (
+            await db.execute(
+                select(GithubWorkItem).where(
+                    GithubWorkItem.scope_id == scope.id,
+                    GithubWorkItem.dispatch_status.in_(_ACTIVE_STATUSES),
+                )
+            )
+        ).scalars().all()
+        if not active:
+            return
+        current = await client.get_open_issues_by_number(
+            scope.repo_owner, scope.repo_name, [item.issue_number for item in active]
+        )
+        for item in active:
+            issue = current.get(item.issue_number)
+            still_labeled = issue is not None and any(
+                label["name"] == scope.dispatch_label for label in issue.get("labels", [])
+            )
+            if not still_labeled:
+                item.dispatch_status = "escalated"
+                item.escalation_reason = "dispatch_label_removed"
+                item.updated_at = datetime.utcnow()
+
+
+github_watcher_service = GithubWatcherService()

--- a/backend/app/services/github_watcher_service.py
+++ b/backend/app/services/github_watcher_service.py
@@ -86,11 +86,18 @@ class GithubWatcherService:
         ).scalars().all()
         if not active:
             return
-        current = await client.get_open_issues_by_number(
-            scope.repo_owner, scope.repo_name, [item.issue_number for item in active]
+        current = await client.get_issues_by_number(
+            scope.repo_owner,
+            scope.repo_name,
+            [item.issue_number for item in active],
         )
         for item in active:
             issue = current.get(item.issue_number)
+            if issue is not None and issue.get("state") == "closed":
+                item.dispatch_status = "completed"
+                item.escalation_reason = None
+                item.updated_at = datetime.utcnow()
+                continue
             still_labeled = issue is not None and any(
                 label["name"] == scope.dispatch_label for label in issue.get("labels", [])
             )

--- a/backend/mcp_shim/agent_mail_server.py
+++ b/backend/mcp_shim/agent_mail_server.py
@@ -110,6 +110,10 @@ def _bridge_request(method: str, path: str, **kwargs) -> dict:
     return _deck_request(method, "agent-bridge", path, **kwargs)
 
 
+def _dispatch_request(method: str, path: str, **kwargs) -> dict:
+    return _deck_request(method, "agent-teams", path, **kwargs)
+
+
 def _bridge_request_with_token(method: str, path: str, **kwargs) -> dict:
     token_result = _bridge_request("GET", "/token")
     if not token_result["ok"]:
@@ -592,6 +596,34 @@ def deck_launch_team(
     if not result["ok"]:
         return result
     return {"ok": True, "launch": result["data"]}
+
+
+@mcp.tool()
+def deck_report_dispatch_status(
+    work_item_id: int,
+    status: str,
+    pr_number: Optional[int] = None,
+    reassign_to_slot_id: Optional[int] = None,
+    note: Optional[str] = None,
+) -> dict:
+    """Report progress on a Claude-Deck-dispatched GitHub issue back to the brain.
+
+    status is one of: triaging, revision_requested, in_progress, pr_opened,
+    handoff_initiated (with reassign_to_slot_id), handoff_accepted, blocked.
+    Called by the owner slot the brain dispatched the issue to. Include
+    work_item_id from your bootstrap prompt.
+    """
+    identity = _ensure_registered()
+    member = identity.get("data", {}).get("member", {}) if identity.get("ok") else {}
+    payload = {
+        "work_item_id": work_item_id,
+        "status": status,
+        "pr_number": pr_number,
+        "reassign_to_slot_id": reassign_to_slot_id,
+        "note": note,
+        "reporting_slot_id": member.get("team_slot_id"),
+    }
+    return _dispatch_request("POST", "/dispatch-status", json=payload)
 
 
 if __name__ == "__main__":

--- a/backend/tests/agent_mail/test_dispatch_status_tool.py
+++ b/backend/tests/agent_mail/test_dispatch_status_tool.py
@@ -60,7 +60,7 @@ async def _seed_item(maker, **overrides):
 
 
 @pytest.mark.asyncio
-async def test_triaging_increments_and_caps(client_and_db):
+async def test_triaging_does_not_increment_approval_rounds(client_and_db):
     ac, maker = client_and_db
     item_id = await _seed_item(maker, approval_round_count=1)
     resp = await ac.post(
@@ -70,8 +70,40 @@ async def test_triaging_increments_and_caps(client_and_db):
     assert resp.status_code == 200
     async with maker() as db:
         item = await db.get(GithubWorkItem, item_id)
+        assert item.dispatch_status == "dispatched"
+        assert item.approval_round_count == 1
+        assert item.escalation_reason is None
+
+
+@pytest.mark.asyncio
+async def test_revision_requested_increments_and_caps(client_and_db):
+    ac, maker = client_and_db
+    item_id = await _seed_item(maker, approval_round_count=1)
+    resp = await ac.post(
+        "/api/v1/agent-teams/dispatch-status",
+        json={"work_item_id": item_id, "status": "revision_requested"},
+    )
+    assert resp.status_code == 200
+    async with maker() as db:
+        item = await db.get(GithubWorkItem, item_id)
         assert item.dispatch_status == "escalated"
         assert item.escalation_reason == "approval_rounds_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_blocked_uses_spec_reason_and_persists_note(client_and_db):
+    ac, maker = client_and_db
+    item_id = await _seed_item(maker)
+    resp = await ac.post(
+        "/api/v1/agent-teams/dispatch-status",
+        json={"work_item_id": item_id, "status": "blocked", "note": "missing credentials"},
+    )
+    assert resp.status_code == 200
+    async with maker() as db:
+        item = await db.get(GithubWorkItem, item_id)
+        assert item.dispatch_status == "escalated"
+        assert item.escalation_reason == "plan_blocked"
+        assert item.status_note == "missing credentials"
 
 
 def test_shim_exposes_dispatch_status_tool():

--- a/backend/tests/agent_mail/test_dispatch_status_tool.py
+++ b/backend/tests/agent_mail/test_dispatch_status_tool.py
@@ -1,0 +1,113 @@
+"""Tests for the dispatch-status REST endpoint backing the MCP tool."""
+from datetime import datetime
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.database import Base, get_db
+from app.main import app
+from app.models.database import AgentTeamPreset, GithubWorkItem, TeamGithubScope
+
+
+@pytest_asyncio.fixture
+async def client_and_db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def _get_db():
+        async with maker() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = _get_db
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac, maker
+    app.dependency_overrides.clear()
+    await engine.dispose()
+
+
+async def _seed_item(maker, **overrides):
+    async with maker() as db:
+        preset = AgentTeamPreset(name="T", description="", created_by="t")
+        db.add(preset)
+        await db.flush()
+        scope = TeamGithubScope(
+            preset_id=preset.id,
+            repo_owner="o",
+            repo_name="r",
+            repo_path="/tmp/r",
+            max_approval_rounds=2,
+        )
+        db.add(scope)
+        await db.flush()
+        item = GithubWorkItem(
+            scope_id=scope.id,
+            issue_number=1,
+            issue_title="x",
+            issue_url="u",
+            github_updated_at=datetime.utcnow(),
+            dispatch_status="dispatched",
+            **overrides,
+        )
+        db.add(item)
+        await db.commit()
+        await db.refresh(item)
+        return item.id
+
+
+@pytest.mark.asyncio
+async def test_triaging_increments_and_caps(client_and_db):
+    ac, maker = client_and_db
+    item_id = await _seed_item(maker, approval_round_count=1)
+    resp = await ac.post(
+        "/api/v1/agent-teams/dispatch-status",
+        json={"work_item_id": item_id, "status": "triaging"},
+    )
+    assert resp.status_code == 200
+    async with maker() as db:
+        item = await db.get(GithubWorkItem, item_id)
+        assert item.dispatch_status == "escalated"
+        assert item.escalation_reason == "approval_rounds_exhausted"
+
+
+def test_shim_exposes_dispatch_status_tool():
+    import importlib
+
+    shim = importlib.import_module("mcp_shim.agent_mail_server")
+    assert hasattr(shim, "deck_report_dispatch_status")
+    assert hasattr(shim, "_dispatch_request")
+
+
+def test_shim_dispatch_status_reports_team_slot(monkeypatch):
+    import importlib
+
+    shim = importlib.import_module("mcp_shim.agent_mail_server")
+    requests = []
+
+    monkeypatch.setattr(
+        shim,
+        "_ensure_registered",
+        lambda: {"ok": True, "data": {"member": {"id": 1, "team_slot_id": 7}}},
+    )
+
+    def fake_dispatch_request(method, path, **kwargs):
+        requests.append((method, path, kwargs))
+        return {"ok": True, "data": {"work_item_id": 123}}
+
+    monkeypatch.setattr(shim, "_dispatch_request", fake_dispatch_request)
+
+    result = shim.deck_report_dispatch_status(
+        123,
+        "pr_opened",
+        pr_number=456,
+        note="opened",
+    )
+
+    assert result["ok"] is True
+    assert requests[0][0:2] == ("POST", "/dispatch-status")
+    assert requests[0][2]["json"]["reporting_slot_id"] == 7
+    assert requests[0][2]["json"]["pr_number"] == 456

--- a/backend/tests/agent_teams/test_github_dispatch_service.py
+++ b/backend/tests/agent_teams/test_github_dispatch_service.py
@@ -67,6 +67,14 @@ async def _team(db):
     return preset, [architect, backend], scope
 
 
+class _LabelsClient:
+    def __init__(self, labels):
+        self._labels = labels
+
+    async def list_repo_labels(self, owner, repo):
+        return list(self._labels)
+
+
 def _item(scope_id, number, labels):
     return (
         GithubWorkItem(
@@ -215,3 +223,145 @@ async def test_slot_busy_during_pending_handoff_on_both_sides(db):
     await db.commit()
     assert await github_dispatch_service.slot_is_busy(db, architect.id) is True
     assert await github_dispatch_service.slot_is_busy(db, backend.id) is True
+
+
+@pytest.mark.asyncio
+async def test_dispatch_pending_launches_and_marks_dispatched(db):
+    preset, slots, scope = await _team(db)
+    backend = next(slot for slot in slots if slot.display_name == "Backend SME")
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=20,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="pending",
+    )
+    db.add(item)
+    await db.commit()
+
+    launched = {}
+
+    class _Result:
+        launch_id = 99
+
+    async def fake_launcher(db_, preset_id, request):
+        launched["preset_id"] = preset_id
+        launched["override"] = request.repo_path_override
+        return _Result()
+
+    await github_dispatch_service.dispatch_pending(
+        db,
+        scope,
+        slots,
+        client=_LabelsClient(["area:backend"]),
+        classify=None,
+        launcher=fake_launcher,
+        issue_labels_by_number={20: ["area:backend"]},
+    )
+    await db.refresh(item)
+    assert item.dispatch_status == "dispatched"
+    assert item.owner_slot_id == backend.id
+    assert item.routing_method == "label"
+    assert item.launch_id == 99
+    assert item.pending_reason is None
+    assert launched["override"] == scope.repo_path
+
+
+@pytest.mark.asyncio
+async def test_dispatch_pending_queues_when_slot_busy(db):
+    preset, slots, scope = await _team(db)
+    backend = next(slot for slot in slots if slot.display_name == "Backend SME")
+    db.add(
+        GithubWorkItem(
+            scope_id=scope.id,
+            issue_number=21,
+            issue_title="x",
+            issue_url="u",
+            github_updated_at=datetime.utcnow(),
+            dispatch_status="dispatched",
+            owner_slot_id=backend.id,
+        )
+    )
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=22,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="pending",
+    )
+    db.add(item)
+    await db.commit()
+
+    async def fake_launcher(db_, preset_id, request):
+        raise AssertionError("should not launch a busy slot")
+
+    await github_dispatch_service.dispatch_pending(
+        db,
+        scope,
+        slots,
+        client=_LabelsClient(["area:backend"]),
+        launcher=fake_launcher,
+        issue_labels_by_number={22: ["area:backend"]},
+    )
+    await db.refresh(item)
+    assert item.dispatch_status == "pending"
+    assert item.pending_reason == "queued_slot_busy"
+
+
+@pytest.mark.asyncio
+async def test_approval_round_cap_escalates(db):
+    preset, slots, scope = await _team(db)
+    scope.max_approval_rounds = 2
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=30,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="dispatched",
+        approval_round_count=0,
+    )
+    db.add(item)
+    await db.commit()
+    await github_dispatch_service.record_approval_round(db, item, scope)
+    await db.refresh(item)
+    assert item.dispatch_status == "dispatched"
+    await github_dispatch_service.record_approval_round(db, item, scope)
+    await db.refresh(item)
+    assert item.dispatch_status == "escalated"
+    assert item.escalation_reason == "approval_rounds_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_two_phase_handoff(db):
+    preset, slots, scope = await _team(db)
+    architect, backend = slots[0], slots[1]
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=40,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="dispatched",
+        owner_slot_id=architect.id,
+    )
+    db.add(item)
+    await db.commit()
+
+    await github_dispatch_service.initiate_handoff(db, item, backend.id)
+    await db.refresh(item)
+    assert item.handoff_state == "pending"
+    assert item.handoff_target_slot_id == backend.id
+    assert item.owner_slot_id == architect.id
+
+    with pytest.raises(ValueError):
+        await github_dispatch_service.accept_handoff(db, item, architect.id)
+
+    await github_dispatch_service.accept_handoff(db, item, backend.id)
+    await db.refresh(item)
+    assert item.owner_slot_id == backend.id
+    assert item.handoff_state == "accepted"
+    assert item.handoff_target_slot_id is None
+    assert item.routing_method == "reassigned"

--- a/backend/tests/agent_teams/test_github_dispatch_service.py
+++ b/backend/tests/agent_teams/test_github_dispatch_service.py
@@ -365,3 +365,55 @@ async def test_two_phase_handoff(db):
     assert item.handoff_state == "accepted"
     assert item.handoff_target_slot_id is None
     assert item.routing_method == "reassigned"
+
+
+@pytest.mark.asyncio
+async def test_monitor_escalates_when_leader_offline(db):
+    preset, slots, scope = await _team(db)
+    architect = slots[0]
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=50,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="dispatched",
+        owner_slot_id=slots[1].id,
+    )
+    db.add(item)
+    await db.commit()
+
+    await github_dispatch_service.monitor_dispatched(
+        db,
+        scope,
+        preset_slots=slots,
+        wake_state_by_slot={architect.id: "offline", slots[1].id: "wakeable"},
+    )
+    await db.refresh(item)
+    assert item.dispatch_status == "escalated"
+    assert item.escalation_reason == "leader_offline"
+
+
+@pytest.mark.asyncio
+async def test_monitor_leaves_item_when_leader_reachable(db):
+    preset, slots, scope = await _team(db)
+    architect = slots[0]
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=51,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="dispatched",
+        owner_slot_id=slots[1].id,
+    )
+    db.add(item)
+    await db.commit()
+    await github_dispatch_service.monitor_dispatched(
+        db,
+        scope,
+        preset_slots=slots,
+        wake_state_by_slot={architect.id: "wakeable", slots[1].id: "wakeable"},
+    )
+    await db.refresh(item)
+    assert item.dispatch_status == "dispatched"

--- a/backend/tests/agent_teams/test_github_dispatch_service.py
+++ b/backend/tests/agent_teams/test_github_dispatch_service.py
@@ -1,0 +1,217 @@
+"""Dispatch routing + concurrency tests."""
+from datetime import datetime
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+import app.models.database  # noqa: F401
+from app.database import Base
+from app.models.database import (
+    AgentTeamPreset,
+    AgentTeamSlot,
+    GithubWorkItem,
+    TeamGithubScope,
+)
+from app.services.github_dispatch_service import github_dispatch_service
+
+
+@pytest_asyncio.fixture
+async def db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _team(db):
+    preset = AgentTeamPreset(name="T", description="", created_by="t")
+    db.add(preset)
+    await db.flush()
+    architect = AgentTeamSlot(
+        preset_id=preset.id,
+        position=0,
+        display_name="Architect",
+        provider="codex-cli",
+        repo_id="r",
+        repo_path="/tmp/r",
+        repo_name="r",
+        launch_mode="plain",
+        launch_options={},
+        enabled=True,
+        area_labels=None,
+        expertise="cross-cutting",
+    )
+    backend = AgentTeamSlot(
+        preset_id=preset.id,
+        position=1,
+        display_name="Backend SME",
+        provider="codex-cli",
+        repo_id="r",
+        repo_path="/tmp/r",
+        repo_name="r",
+        launch_mode="plain",
+        launch_options={},
+        enabled=True,
+        area_labels=["area:backend"],
+        expertise="backend",
+    )
+    db.add_all([architect, backend])
+    await db.flush()
+    scope = TeamGithubScope(preset_id=preset.id, repo_owner="o", repo_name="r", repo_path="/tmp/r")
+    db.add(scope)
+    await db.commit()
+    return preset, [architect, backend], scope
+
+
+def _item(scope_id, number, labels):
+    return (
+        GithubWorkItem(
+            scope_id=scope_id,
+            issue_number=number,
+            issue_title="x",
+            issue_url="u",
+            github_updated_at=datetime.utcnow(),
+            dispatch_status="pending",
+        ),
+        [{"name": name} for name in labels],
+    )
+
+
+@pytest.mark.asyncio
+async def test_route_by_label_match(db):
+    preset, slots, scope = await _team(db)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=1,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+    )
+    db.add(item)
+    await db.commit()
+    owner_id, method = await github_dispatch_service.route_item(
+        db,
+        item,
+        slots,
+        repo_labels=["area:backend"],
+        issue_labels=["area:backend"],
+    )
+    backend = next(slot for slot in slots if slot.display_name == "Backend SME")
+    assert owner_id == backend.id
+    assert method == "label"
+
+
+@pytest.mark.asyncio
+async def test_route_classification_fallback(db):
+    preset, slots, scope = await _team(db)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=2,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+    )
+    db.add(item)
+    await db.commit()
+    backend = next(slot for slot in slots if slot.display_name == "Backend SME")
+
+    async def fake_classify(it, candidate_slots):
+        return backend.id
+
+    owner_id, method = await github_dispatch_service.route_item(
+        db,
+        item,
+        slots,
+        repo_labels=["area:backend"],
+        issue_labels=["no-area-label"],
+        classify=fake_classify,
+    )
+    assert owner_id == backend.id
+    assert method == "classified"
+
+
+@pytest.mark.asyncio
+async def test_route_leader_fallback_when_no_expertise(db):
+    preset, slots, scope = await _team(db)
+    for slot in slots:
+        slot.expertise = None
+    await db.commit()
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=3,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+    )
+    db.add(item)
+    await db.commit()
+    owner_id, method = await github_dispatch_service.route_item(
+        db, item, slots, repo_labels=[], issue_labels=["nothing"]
+    )
+    architect = next(slot for slot in slots if slot.display_name == "Architect")
+    assert owner_id == architect.id
+    assert method == "leader_fallback"
+
+
+@pytest.mark.asyncio
+async def test_slot_busy_when_dispatched_item_exists(db):
+    preset, slots, scope = await _team(db)
+    backend = next(slot for slot in slots if slot.display_name == "Backend SME")
+    db.add(
+        GithubWorkItem(
+            scope_id=scope.id,
+            issue_number=10,
+            issue_title="x",
+            issue_url="u",
+            github_updated_at=datetime.utcnow(),
+            dispatch_status="dispatched",
+            owner_slot_id=backend.id,
+        )
+    )
+    await db.commit()
+    assert await github_dispatch_service.slot_is_busy(db, backend.id) is True
+
+
+@pytest.mark.asyncio
+async def test_slot_free_when_only_awaiting_human_review(db):
+    preset, slots, scope = await _team(db)
+    backend = next(slot for slot in slots if slot.display_name == "Backend SME")
+    db.add(
+        GithubWorkItem(
+            scope_id=scope.id,
+            issue_number=11,
+            issue_title="x",
+            issue_url="u",
+            github_updated_at=datetime.utcnow(),
+            dispatch_status="awaiting_human_review",
+            owner_slot_id=backend.id,
+        )
+    )
+    await db.commit()
+    assert await github_dispatch_service.slot_is_busy(db, backend.id) is False
+
+
+@pytest.mark.asyncio
+async def test_slot_busy_during_pending_handoff_on_both_sides(db):
+    preset, slots, scope = await _team(db)
+    architect, backend = slots[0], slots[1]
+    db.add(
+        GithubWorkItem(
+            scope_id=scope.id,
+            issue_number=12,
+            issue_title="x",
+            issue_url="u",
+            github_updated_at=datetime.utcnow(),
+            dispatch_status="dispatched",
+            owner_slot_id=architect.id,
+            handoff_state="pending",
+            handoff_target_slot_id=backend.id,
+        )
+    )
+    await db.commit()
+    assert await github_dispatch_service.slot_is_busy(db, architect.id) is True
+    assert await github_dispatch_service.slot_is_busy(db, backend.id) is True

--- a/backend/tests/agent_teams/test_github_dispatch_service.py
+++ b/backend/tests/agent_teams/test_github_dispatch_service.py
@@ -105,7 +105,6 @@ async def test_route_by_label_match(db):
         db,
         item,
         slots,
-        repo_labels=["area:backend"],
         issue_labels=["area:backend"],
     )
     backend = next(slot for slot in slots if slot.display_name == "Backend SME")
@@ -134,7 +133,6 @@ async def test_route_classification_fallback(db):
         db,
         item,
         slots,
-        repo_labels=["area:backend"],
         issue_labels=["no-area-label"],
         classify=fake_classify,
     )
@@ -157,9 +155,7 @@ async def test_route_leader_fallback_when_no_expertise(db):
     )
     db.add(item)
     await db.commit()
-    owner_id, method = await github_dispatch_service.route_item(
-        db, item, slots, repo_labels=[], issue_labels=["nothing"]
-    )
+    owner_id, method = await github_dispatch_service.route_item(db, item, slots, ["nothing"])
     architect = next(slot for slot in slots if slot.display_name == "Architect")
     assert owner_id == architect.id
     assert method == "leader_fallback"
@@ -266,6 +262,176 @@ async def test_dispatch_pending_launches_and_marks_dispatched(db):
     assert item.launch_id == 99
     assert item.pending_reason is None
     assert launched["override"] == scope.repo_path
+
+
+@pytest.mark.asyncio
+async def test_dispatch_pending_disables_reuse_for_repo_override(db):
+    preset, slots, scope = await _team(db)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=23,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="pending",
+    )
+    db.add(item)
+    await db.commit()
+
+    launched = {}
+
+    class _Result:
+        launch_id = 100
+
+    async def fake_launcher(db_, preset_id, request):
+        launched["reuse_existing"] = request.reuse_existing
+        launched["override"] = request.repo_path_override
+        return _Result()
+
+    await github_dispatch_service.dispatch_pending(
+        db,
+        scope,
+        slots,
+        client=_LabelsClient([]),
+        launcher=fake_launcher,
+        issue_labels_by_number={23: []},
+    )
+
+    assert launched["reuse_existing"] is False
+    assert launched["override"] == scope.repo_path
+
+
+@pytest.mark.asyncio
+async def test_dispatch_pending_queues_same_batch_items_for_same_slot(db):
+    preset, slots, scope = await _team(db)
+    first = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=24,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="pending",
+    )
+    second = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=25,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="pending",
+    )
+    db.add_all([first, second])
+    await db.commit()
+    launches = []
+
+    class _Result:
+        launch_id = 101
+
+    async def fake_launcher(db_, preset_id, request):
+        launches.append(request.slot_ids[0])
+        return _Result()
+
+    await github_dispatch_service.dispatch_pending(
+        db,
+        scope,
+        slots,
+        client=_LabelsClient(["area:backend"]),
+        launcher=fake_launcher,
+        issue_labels_by_number={24: ["area:backend"], 25: ["area:backend"]},
+    )
+    await db.refresh(first)
+    await db.refresh(second)
+    assert len(launches) == 1
+    assert first.dispatch_status == "dispatched"
+    assert second.dispatch_status == "pending"
+    assert second.pending_reason == "queued_slot_busy"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_pending_commits_success_before_later_plan_block(db):
+    preset, slots, scope = await _team(db)
+    first = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=26,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="pending",
+    )
+    second = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=27,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="pending",
+    )
+    db.add_all([first, second])
+    await db.commit()
+    calls = 0
+
+    class _Result:
+        launch_id = 102
+
+    async def fake_launcher(db_, preset_id, request):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise ValueError("plan is blocked")
+        return _Result()
+
+    await github_dispatch_service.dispatch_pending(
+        db,
+        scope,
+        slots,
+        client=_LabelsClient(["area:backend"]),
+        launcher=fake_launcher,
+        issue_labels_by_number={26: [], 27: ["area:backend"]},
+    )
+    await db.refresh(first)
+    await db.refresh(second)
+    assert first.dispatch_status == "dispatched"
+    assert second.dispatch_status == "escalated"
+    assert second.escalation_reason == "plan_blocked"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_pending_marks_failed_launch_result_failed(db):
+    preset, slots, scope = await _team(db)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=28,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="pending",
+    )
+    db.add(item)
+    await db.commit()
+
+    class _Item:
+        status = "failed"
+        error = "spawn failed"
+
+    class _Result:
+        launch_id = 103
+        status = "completed_with_errors"
+        items = [_Item()]
+
+    async def fake_launcher(db_, preset_id, request):
+        return _Result()
+
+    await github_dispatch_service.dispatch_pending(
+        db,
+        scope,
+        slots,
+        client=_LabelsClient([]),
+        launcher=fake_launcher,
+        issue_labels_by_number={28: []},
+    )
+    await db.refresh(item)
+    assert item.dispatch_status == "failed"
+    assert item.launch_id == 103
 
 
 @pytest.mark.asyncio
@@ -414,6 +580,30 @@ async def test_monitor_leaves_item_when_leader_reachable(db):
         scope,
         preset_slots=slots,
         wake_state_by_slot={architect.id: "wakeable", slots[1].id: "wakeable"},
+    )
+    await db.refresh(item)
+    assert item.dispatch_status == "dispatched"
+
+
+@pytest.mark.asyncio
+async def test_monitor_leaves_item_when_leader_not_registered_yet(db):
+    preset, slots, scope = await _team(db)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=52,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="dispatched",
+        owner_slot_id=slots[1].id,
+    )
+    db.add(item)
+    await db.commit()
+    await github_dispatch_service.monitor_dispatched(
+        db,
+        scope,
+        preset_slots=slots,
+        wake_state_by_slot={slots[1].id: "wakeable"},
     )
     await db.refresh(item)
     assert item.dispatch_status == "dispatched"

--- a/backend/tests/agent_teams/test_github_scope_models.py
+++ b/backend/tests/agent_teams/test_github_scope_models.py
@@ -1,0 +1,125 @@
+"""Schema tests for the autonomous GitHub dispatch tables."""
+import pytest
+import pytest_asyncio
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+import app.models.database  # noqa: F401
+from app.database import Base, _run_sqlite_compat_migrations
+from app.models.database import (
+    AgentTeamPreset,
+    AgentTeamSlot,
+    TeamGithubScope,
+    GithubWorkItem,
+)
+
+
+@pytest_asyncio.fixture
+async def db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_team_github_scope_round_trips(db):
+    preset = AgentTeamPreset(name="SnazzyEmail", description="", created_by="test")
+    db.add(preset)
+    await db.flush()
+    scope = TeamGithubScope(
+        preset_id=preset.id,
+        repo_owner="adrirubio",
+        repo_name="snazzyemail",
+        repo_path="/tmp/snazzyemail",
+    )
+    db.add(scope)
+    await db.commit()
+    await db.refresh(scope)
+    assert scope.dispatch_label == "claude-deck-ready"
+    assert scope.design_label == "claude-deck-design"
+    assert scope.merge_policy == "human"
+    assert scope.max_approval_rounds == 3
+    assert scope.enabled is True
+
+
+@pytest.mark.asyncio
+async def test_github_work_item_defaults(db):
+    preset = AgentTeamPreset(name="T", description="", created_by="test")
+    db.add(preset)
+    await db.flush()
+    scope = TeamGithubScope(
+        preset_id=preset.id, repo_owner="o", repo_name="r", repo_path="/tmp/r"
+    )
+    db.add(scope)
+    await db.flush()
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=42,
+        issue_title="bug",
+        issue_url="https://github.com/o/r/issues/42",
+        github_updated_at=__import__("datetime").datetime.utcnow(),
+    )
+    db.add(item)
+    await db.commit()
+    await db.refresh(item)
+    assert item.issue_type == "code"
+    assert item.dispatch_status == "pending"
+    assert item.pending_reason is None
+    assert item.approval_round_count == 0
+    assert item.retry_count == 0
+    assert item.handoff_state is None
+
+
+@pytest.mark.asyncio
+async def test_new_columns_on_existing_tables(db):
+    preset = AgentTeamPreset(name="T2", description="", created_by="test", autonomy_enabled=True)
+    db.add(preset)
+    await db.flush()
+    slot = AgentTeamSlot(
+        preset_id=preset.id, position=0, display_name="Backend SME",
+        provider="codex-cli", repo_id="r", repo_path="/tmp/r", repo_name="r",
+        launch_mode="plain", launch_options={}, enabled=True,
+        area_labels=["area:backend"], expertise="owns the backend",
+    )
+    db.add(slot)
+    await db.commit()
+    await db.refresh(slot)
+    await db.refresh(preset)
+    assert preset.autonomy_enabled is True
+    assert slot.area_labels == ["area:backend"]
+    assert slot.expertise == "owns the backend"
+
+
+@pytest.mark.asyncio
+async def test_compat_migration_adds_new_columns_to_legacy_db():
+    """Simulate a pre-existing db missing the new columns, then migrate."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        # Legacy agent_team_presets WITHOUT autonomy_enabled
+        await conn.execute(text(
+            "CREATE TABLE agent_team_presets (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "name VARCHAR NOT NULL, description VARCHAR, created_by VARCHAR, "
+            "created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL)"
+        ))
+        # Legacy agent_team_slots WITHOUT area_labels/expertise
+        await conn.execute(text(
+            "CREATE TABLE agent_team_slots (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "preset_id INTEGER NOT NULL, position INTEGER NOT NULL, display_name VARCHAR NOT NULL, "
+            "provider VARCHAR NOT NULL, repo_id VARCHAR NOT NULL, repo_path VARCHAR NOT NULL, "
+            "repo_name VARCHAR NOT NULL, role VARCHAR, charter VARCHAR, bootstrap_prompt VARCHAR, "
+            "ui_color VARCHAR, launch_mode VARCHAR NOT NULL, launch_options JSON, "
+            "enabled BOOLEAN NOT NULL, created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL)"
+        ))
+    async with engine.connect() as conn:
+        await _run_sqlite_compat_migrations(conn)
+    async with engine.connect() as conn:
+        preset_cols = {row[1] for row in (await conn.execute(text("PRAGMA table_info(agent_team_presets)"))).fetchall()}
+        slot_cols = {row[1] for row in (await conn.execute(text("PRAGMA table_info(agent_team_slots)"))).fetchall()}
+    assert "autonomy_enabled" in preset_cols
+    assert "area_labels" in slot_cols
+    assert "expertise" in slot_cols
+    await engine.dispose()

--- a/backend/tests/agent_teams/test_github_scope_models.py
+++ b/backend/tests/agent_teams/test_github_scope_models.py
@@ -72,6 +72,7 @@ async def test_github_work_item_defaults(db):
     assert item.approval_round_count == 0
     assert item.retry_count == 0
     assert item.handoff_state is None
+    assert item.status_note is None
 
 
 @pytest.mark.asyncio
@@ -114,12 +115,15 @@ async def test_compat_migration_adds_new_columns_to_legacy_db():
             "ui_color VARCHAR, launch_mode VARCHAR NOT NULL, launch_options JSON, "
             "enabled BOOLEAN NOT NULL, created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL)"
         ))
+        await conn.execute(text("CREATE TABLE github_work_items (id INTEGER PRIMARY KEY AUTOINCREMENT)"))
     async with engine.connect() as conn:
         await _run_sqlite_compat_migrations(conn)
     async with engine.connect() as conn:
         preset_cols = {row[1] for row in (await conn.execute(text("PRAGMA table_info(agent_team_presets)"))).fetchall()}
         slot_cols = {row[1] for row in (await conn.execute(text("PRAGMA table_info(agent_team_slots)"))).fetchall()}
+        work_item_cols = {row[1] for row in (await conn.execute(text("PRAGMA table_info(github_work_items)"))).fetchall()}
     assert "autonomy_enabled" in preset_cols
     assert "area_labels" in slot_cols
     assert "expertise" in slot_cols
+    assert "status_note" in work_item_cols
     await engine.dispose()

--- a/backend/tests/agent_teams/test_github_watcher_service.py
+++ b/backend/tests/agent_teams/test_github_watcher_service.py
@@ -75,6 +75,13 @@ class _FakeClient:
         return list(self._labeled)
 
     async def get_open_issues_by_number(self, owner, repo, numbers):
+        return {
+            number: self._by_number[number]
+            for number in numbers
+            if number in self._by_number and self._by_number[number].get("state", "open") == "open"
+        }
+
+    async def get_issues_by_number(self, owner, repo, numbers):
         return {number: self._by_number[number] for number in numbers if number in self._by_number}
 
     async def list_repo_labels(self, owner, repo):
@@ -100,6 +107,7 @@ def _issue(number, labels, updated="2026-07-04T00:00:00Z"):
         "title": f"issue {number}",
         "html_url": f"https://github.com/o/r/issues/{number}",
         "updated_at": updated,
+        "state": "open",
         "labels": [{"name": name} for name in labels],
     }
 
@@ -183,3 +191,25 @@ async def test_active_item_escalates_when_label_removed(db):
     await db.refresh(item)
     assert item.dispatch_status == "escalated"
     assert item.escalation_reason == "dispatch_label_removed"
+
+
+@pytest.mark.asyncio
+async def test_active_item_closed_does_not_escalate_as_label_removed(db):
+    scope = await _make_scope(db)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=8,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime(2026, 7, 1),
+        dispatch_status="dispatched",
+    )
+    db.add(item)
+    await db.commit()
+    closed = _issue(8, ["some-other-label"])
+    closed["state"] = "closed"
+    client = _FakeClient(labeled=[], by_number={8: closed})
+    await github_watcher_service.poll_scope(db, scope, client)
+    await db.refresh(item)
+    assert item.dispatch_status == "completed"
+    assert item.escalation_reason is None

--- a/backend/tests/agent_teams/test_github_watcher_service.py
+++ b/backend/tests/agent_teams/test_github_watcher_service.py
@@ -1,0 +1,46 @@
+"""GitHub client + watcher service tests."""
+import httpx
+import pytest
+
+from app.services.github_client import GithubClient
+
+
+class _RecordingTransport(httpx.AsyncBaseTransport):
+    def __init__(self, handler):
+        self.handler = handler
+        self.requests = []
+
+    async def handle_async_request(self, request):
+        self.requests.append(request)
+        return self.handler(request)
+
+
+@pytest.mark.asyncio
+async def test_list_issues_with_label_builds_request():
+    def handler(request):
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "number": 42,
+                    "title": "bug",
+                    "html_url": "u",
+                    "updated_at": "2026-07-04T00:00:00Z",
+                    "labels": [{"name": "claude-deck-ready"}],
+                }
+            ],
+        )
+
+    transport = _RecordingTransport(handler)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://api.github.com"
+    ) as http:
+        client = GithubClient(http=http, token="tok")
+        issues = await client.list_issues_with_label("o", "r", "claude-deck-ready")
+
+    req = transport.requests[0]
+    assert req.url.path == "/repos/o/r/issues"
+    assert req.url.params["labels"] == "claude-deck-ready"
+    assert req.url.params["state"] == "open"
+    assert req.headers["Authorization"] == "Bearer tok"
+    assert issues[0]["number"] == 42

--- a/backend/tests/agent_teams/test_github_watcher_service.py
+++ b/backend/tests/agent_teams/test_github_watcher_service.py
@@ -1,8 +1,17 @@
 """GitHub client + watcher service tests."""
+from datetime import datetime
+
 import httpx
 import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
+import app.models.database  # noqa: F401
+from app.database import Base
+from app.models.database import AgentTeamPreset, GithubWorkItem, TeamGithubScope
 from app.services.github_client import GithubClient
+from app.services.github_watcher_service import github_watcher_service
 
 
 class _RecordingTransport(httpx.AsyncBaseTransport):
@@ -44,3 +53,133 @@ async def test_list_issues_with_label_builds_request():
     assert req.url.params["state"] == "open"
     assert req.headers["Authorization"] == "Bearer tok"
     assert issues[0]["number"] == 42
+
+
+@pytest_asyncio.fixture
+async def db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+class _FakeClient:
+    def __init__(self, labeled=None, by_number=None):
+        self._labeled = labeled or []
+        self._by_number = by_number or {}
+
+    async def list_issues_with_label(self, owner, repo, label):
+        return list(self._labeled)
+
+    async def get_open_issues_by_number(self, owner, repo, numbers):
+        return {number: self._by_number[number] for number in numbers if number in self._by_number}
+
+    async def list_repo_labels(self, owner, repo):
+        return []
+
+
+async def _make_scope(db, **kw):
+    preset = AgentTeamPreset(name=kw.pop("preset_name", "T"), description="", created_by="t")
+    db.add(preset)
+    await db.flush()
+    scope = TeamGithubScope(
+        preset_id=preset.id, repo_owner="o", repo_name="r", repo_path="/tmp/r", **kw
+    )
+    db.add(scope)
+    await db.commit()
+    await db.refresh(scope)
+    return scope
+
+
+def _issue(number, labels, updated="2026-07-04T00:00:00Z"):
+    return {
+        "number": number,
+        "title": f"issue {number}",
+        "html_url": f"https://github.com/o/r/issues/{number}",
+        "updated_at": updated,
+        "labels": [{"name": name} for name in labels],
+    }
+
+
+@pytest.mark.asyncio
+async def test_poll_creates_pending_code_item(db):
+    scope = await _make_scope(db)
+    client = _FakeClient(labeled=[_issue(1, ["claude-deck-ready"])])
+    await github_watcher_service.poll_scope(db, scope, client)
+    items = (await db.execute(select(GithubWorkItem))).scalars().all()
+    assert len(items) == 1
+    assert items[0].issue_number == 1
+    assert items[0].issue_type == "code"
+    assert items[0].dispatch_status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_poll_detects_design_type(db):
+    scope = await _make_scope(db)
+    client = _FakeClient(labeled=[_issue(2, ["claude-deck-ready", "claude-deck-design"])])
+    await github_watcher_service.poll_scope(db, scope, client)
+    item = (await db.execute(select(GithubWorkItem))).scalars().one()
+    assert item.issue_type == "design"
+
+
+@pytest.mark.asyncio
+async def test_poll_is_idempotent(db):
+    scope = await _make_scope(db)
+    client = _FakeClient(labeled=[_issue(1, ["claude-deck-ready"])])
+    await github_watcher_service.poll_scope(db, scope, client)
+    await github_watcher_service.poll_scope(db, scope, client)
+    items = (await db.execute(select(GithubWorkItem))).scalars().all()
+    assert len(items) == 1
+
+
+@pytest.mark.asyncio
+async def test_escalated_item_recovers_on_updated_timestamp(db):
+    scope = await _make_scope(db)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=5,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime(2026, 7, 1),
+        dispatch_status="escalated",
+        escalation_reason="retry_count_exhausted",
+        retry_count=2,
+        approval_round_count=1,
+    )
+    db.add(item)
+    await db.commit()
+    client = _FakeClient(
+        labeled=[_issue(5, ["claude-deck-ready"], updated="2026-07-04T00:00:00Z")]
+    )
+    await github_watcher_service.poll_scope(db, scope, client)
+    await db.refresh(item)
+    assert item.dispatch_status == "pending"
+    assert item.escalation_reason is None
+    assert item.retry_count == 0
+    assert item.approval_round_count == 0
+
+
+@pytest.mark.asyncio
+async def test_active_item_escalates_when_label_removed(db):
+    scope = await _make_scope(db)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=7,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime(2026, 7, 1),
+        dispatch_status="dispatched",
+    )
+    db.add(item)
+    await db.commit()
+    client = _FakeClient(
+        labeled=[],
+        by_number={7: _issue(7, ["some-other-label"])},
+    )
+    await github_watcher_service.poll_scope(db, scope, client)
+    await db.refresh(item)
+    assert item.dispatch_status == "escalated"
+    assert item.escalation_reason == "dispatch_label_removed"

--- a/backend/tests/agent_teams/test_repo_path_override.py
+++ b/backend/tests/agent_teams/test_repo_path_override.py
@@ -1,0 +1,86 @@
+"""repo_path_override threads through the launch path to spawn options."""
+import pytest
+import pytest_asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+import app.models.database  # noqa: F401
+from app.database import Base
+from app.models.database import AgentTeamPreset, AgentTeamSlot
+from app.models.schemas import AgentTeamLaunchRequest
+from app.services.agent_team_service import agent_team_service
+
+
+@pytest_asyncio.fixture
+async def db(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_launch_request_accepts_repo_path_override():
+    req = AgentTeamLaunchRequest(repo_path_override="/tmp/other-repo", skip_plan_confirmation=True)
+    assert req.repo_path_override == "/tmp/other-repo"
+
+
+@pytest.mark.asyncio
+async def test_override_directory_used_in_spawn(db, tmp_path):
+    override_dir = tmp_path / "override-repo"
+    override_dir.mkdir()
+    slot_dir = tmp_path / "slot-repo"
+    slot_dir.mkdir()
+
+    preset = AgentTeamPreset(name="T", description="", created_by="t")
+    db.add(preset)
+    await db.flush()
+    slot = AgentTeamSlot(
+        preset_id=preset.id, position=0, display_name="Dev", provider="claude-code",
+        repo_id="r", repo_path=str(slot_dir), repo_name="slot-repo",
+        launch_mode="plain", launch_options={}, enabled=True,
+    )
+    db.add(slot)
+    await db.commit()
+
+    captured = {}
+
+    def fake_spawn(provider, options, extra_env=None):
+        captured["directory"] = options.directory
+        return {"session_name": "s", "tmux_target": "s:0.0"}
+
+    fake_provider = SimpleNamespace(
+        display_name="Claude Code",
+        get_status=lambda: {"installed": True},
+        build_spawn_command=lambda options: ["claude"],
+    )
+    fake_install_status = SimpleNamespace(
+        claude_code_mcp_installed=True,
+        claude_code_hooks_missing=[],
+    )
+
+    with (
+        patch("app.services.agent_team_service.get_provider", return_value=fake_provider),
+        patch(
+            "app.services.agent_team_service.agent_mail_install_service.get_install_status",
+            AsyncMock(return_value=fake_install_status),
+        ),
+        patch(
+            "app.services.agent_team_service.agent_mail_service.sync_observed_sessions",
+            AsyncMock(),
+        ),
+        patch.object(agent_team_service, "_discover_sessions", return_value=[]),
+        patch("app.services.agent_team_service.spawn_session", side_effect=fake_spawn),
+    ):
+        req = AgentTeamLaunchRequest(
+            skip_plan_confirmation=True,
+            repo_path_override=str(override_dir),
+        )
+        await agent_team_service.launch(db, preset.id, req)
+
+    assert captured["directory"] == str(override_dir)


### PR DESCRIPTION
## Summary

Part of #272.

Implements Autonomous GitHub Dispatch Phase A backend schema and core services:

- Adds `TeamGithubScope` and `GithubWorkItem` schema, additive compat migrations, and `GITHUB_TOKEN` setting.
- Threads `repo_path_override` through Agent Team launches.
- Adds injectable read-only GitHub client and watcher service for issue intake, type detection, recovery, and active label recheck.
- Adds dispatch routing, per-slot concurrency, launch execution, approval-round caps, two-phase handoff, and leader-offline monitoring.
- Adds `POST /api/v1/agent-teams/dispatch-status` plus MCP `deck_report_dispatch_status`.

## Scoped Deferred Items

- Spec §6 leader reachable-but-idle nudge/escalation is deferred; Phase A implements the wake-state `leader_offline` fast path only.
- `pr_opened` records `pr_number` but does not advance verification/merge status; full PR verification/merge is Phase B.
- Scheduler wiring that calls watcher/dispatch/monitor periodically remains out of Phase A scope.

## Review Follow-Up

Addressed PR review findings in `fix(dispatch): address Phase A PR review findings`:

- Prevents same-batch duplicate dispatch to one slot and commits each item independently.
- Disables Agent Team session reuse for GitHub dispatches using `repo_path_override`.
- Handles launch exceptions and failed launch result items without marking work as dispatched.
- Avoids leader-offline false escalation while a leader slot has not registered yet.
- Distinguishes closed GitHub issues from dispatch-label removal.
- Keeps `triaging` from consuming approval rounds; only `revision_requested` counts.
- Persists blocked-status notes in `GithubWorkItem.status_note` and uses canonical `plan_blocked`.
- Removes the unused dispatch-time repo-label fetch from routing.

Still intentionally deferred for a later notification/UI pass: Agent Mail escalation broadcasts and Deck activity-feed rows for every escalation site.

## Validation

- `cd backend && source venv/bin/activate && pytest tests/agent_teams/ tests/agent_mail/test_dispatch_status_tool.py tests/agent_mail/test_mcp_shim.py -q` — 99 passed.
- `cd backend && source venv/bin/activate && pytest tests/ -q` — 360 passed, 1 failed: `tests/test_multi_provider_smoke.py::test_agent_bridge_session_filter_smoke`.
  - This is outside the Phase A diff; `backend/app/api/v1/agent_bridge/router.py` and `backend/tests/test_multi_provider_smoke.py` are unchanged from `master`.
  - Root cause appears to be a pre-existing sync smoke test calling async `agent_bridge.router.list_sessions()` without awaiting it.



