### PR TITLE
Autonomous GitHub Dispatch Phase B

### DIFF
--- a/backend/app/api/v1/agent_teams.py
+++ b/backend/app/api/v1/agent_teams.py
@@ -75,7 +75,10 @@ async def report_dispatch_status(
     elif report.status == "pr_opened":
         if report.pr_number is None:
             raise HTTPException(status_code=400, detail="pr_number required")
-        await github_verification_service.report_pr_opened(db, item, scope, report.pr_number)
+        try:
+            await github_verification_service.report_pr_opened(db, item, scope, report.pr_number)
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
     elif report.status == "in_progress":
         if report.pr_number is not None:
             item.pr_number = report.pr_number

--- a/backend/app/api/v1/agent_teams.py
+++ b/backend/app/api/v1/agent_teams.py
@@ -25,6 +25,7 @@ from app.models.schemas import (
     DispatchStatusReport,
 )
 from app.services.github_dispatch_service import github_dispatch_service
+from app.services.github_verification_service import github_verification_service
 from app.services.agent_team_service import PlanConflictError, agent_team_service
 from app.services.providers.base import ProviderLaunchError
 
@@ -69,12 +70,13 @@ async def report_dispatch_status(
         except ValueError as exc:
             raise HTTPException(status_code=409, detail=str(exc)) from exc
     elif report.status == "blocked":
-        item.dispatch_status = "escalated"
-        item.escalation_reason = "plan_blocked"
-        item.status_note = report.note
-        item.updated_at = datetime.utcnow()
+        await github_dispatch_service.escalate(db, item, "plan_blocked", report.note)
         await db.commit()
-    elif report.status in ("pr_opened", "in_progress"):
+    elif report.status == "pr_opened":
+        if report.pr_number is None:
+            raise HTTPException(status_code=400, detail="pr_number required")
+        await github_verification_service.report_pr_opened(db, item, scope, report.pr_number)
+    elif report.status == "in_progress":
         if report.pr_number is not None:
             item.pr_number = report.pr_number
             item.updated_at = datetime.utcnow()

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -37,6 +37,7 @@ class Settings(BaseSettings):
 
     # GitHub integration (autonomous dispatch)
     github_token: str = ""
+    github_dispatch_interval_seconds: int = 60
 
     # Server settings
     host: str = "0.0.0.0"

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -38,6 +38,7 @@ class Settings(BaseSettings):
     # GitHub integration (autonomous dispatch)
     github_token: str = ""
     github_dispatch_interval_seconds: int = 60
+    github_check_signal_grace_seconds: int = 120
 
     # Server settings
     host: str = "0.0.0.0"

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -381,10 +381,27 @@ async def _run_sqlite_compat_migrations(conn) -> None:
             text("ALTER TABLE agent_team_presets ADD COLUMN autonomy_enabled BOOLEAN DEFAULT 0 NOT NULL")
         )
 
+    result = await conn.execute(text("PRAGMA table_info(team_github_scopes)"))
+    scope_columns = {row[1] for row in result.fetchall()}
+    if scope_columns and "max_concurrent_dispatched" not in scope_columns:
+        await conn.execute(
+            text("ALTER TABLE team_github_scopes ADD COLUMN max_concurrent_dispatched INTEGER DEFAULT 3 NOT NULL")
+        )
+    if scope_columns and "max_verification_retries" not in scope_columns:
+        await conn.execute(
+            text("ALTER TABLE team_github_scopes ADD COLUMN max_verification_retries INTEGER DEFAULT 2 NOT NULL")
+        )
+    if scope_columns and "max_auto_merges_per_day" not in scope_columns:
+        await conn.execute(
+            text("ALTER TABLE team_github_scopes ADD COLUMN max_auto_merges_per_day INTEGER DEFAULT 5 NOT NULL")
+        )
+
     result = await conn.execute(text("PRAGMA table_info(github_work_items)"))
     work_item_columns = {row[1] for row in result.fetchall()}
     if work_item_columns and "status_note" not in work_item_columns:
         await conn.execute(text("ALTER TABLE github_work_items ADD COLUMN status_note VARCHAR"))
+    if work_item_columns and "auto_merged_at" not in work_item_columns:
+        await conn.execute(text("ALTER TABLE github_work_items ADD COLUMN auto_merged_at DATETIME"))
 
     result = await conn.execute(text("PRAGMA table_info(agent_team_launch_items)"))
     launch_item_columns = {row[1] for row in result.fetchall()}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from app.api.v1.router import router as api_v1_router
 from app.config import settings
 from app.database import AsyncSessionLocal, init_db
 from app.services.agent_bridge.attachments import agent_bridge_attachment_service
+from app.services.github_dispatch_scheduler import github_dispatch_scheduler
 
 logger = logging.getLogger(__name__)
 
@@ -26,11 +27,16 @@ async def lifespan(app: FastAPI):
             await agent_bridge_attachment_service.cleanup_expired(db)
     except Exception:
         logger.exception("Failed to clean up expired Agent Bridge attachments")
+    try:
+        await github_dispatch_scheduler.start()
+    except Exception:
+        logger.exception("Failed to start autonomous GitHub dispatch scheduler")
     # Clean up any orphaned relay processes from previous runs
     from app.services.cc_bridge.pty_relay import close_all_relays, cleanup_orphaned_relays
     cleanup_orphaned_relays()
     yield
     # Shutdown: Cleanup
+    await github_dispatch_scheduler.shutdown()
     await close_all_relays()
 
 

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -219,6 +219,9 @@ class TeamGithubScope(Base):
     design_label: Mapped[str] = mapped_column(String, default="claude-deck-design", nullable=False)
     merge_policy: Mapped[str] = mapped_column(String, default="human", nullable=False)
     max_approval_rounds: Mapped[int] = mapped_column(Integer, default=3, nullable=False)
+    max_concurrent_dispatched: Mapped[int] = mapped_column(Integer, default=3, nullable=False)
+    max_verification_retries: Mapped[int] = mapped_column(Integer, default=2, nullable=False)
+    max_auto_merges_per_day: Mapped[int] = mapped_column(Integer, default=5, nullable=False)
     enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     last_polled_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
@@ -261,6 +264,7 @@ class GithubWorkItem(Base):
     retry_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     escalation_reason: Mapped[str | None] = mapped_column(String, nullable=True)
     status_note: Mapped[str | None] = mapped_column(String, nullable=True)
+    auto_merged_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
 

--- a/backend/app/services/agent_mail_service.py
+++ b/backend/app/services/agent_mail_service.py
@@ -862,6 +862,52 @@ class AgentMailService:
             await self.auto_nudge_members(db, recipients)
         return await self._message_response(db, message, for_member_id=None)
 
+    async def send_broadcast(
+        self,
+        db: AsyncSession,
+        *,
+        subject: str | None,
+        body_markdown: str,
+        payload: dict | None = None,
+        auto_nudge: bool = True,
+        sender_actor_id: int | None = None,
+    ) -> MailMessageResponse:
+        return await self.send_message(
+            db,
+            MailMessageCreate(
+                kind="broadcast",
+                subject=subject,
+                body_markdown=body_markdown,
+                payload=payload,
+            ),
+            auto_nudge=auto_nudge,
+            sender_actor_id=sender_actor_id,
+        )
+
+    async def send_direct_message(
+        self,
+        db: AsyncSession,
+        *,
+        recipient_member_id: int,
+        subject: str | None,
+        body_markdown: str,
+        payload: dict | None = None,
+        auto_nudge: bool = True,
+        sender_actor_id: int | None = None,
+    ) -> MailMessageResponse:
+        return await self.send_message(
+            db,
+            MailMessageCreate(
+                kind="message",
+                recipient_member_id=recipient_member_id,
+                subject=subject,
+                body_markdown=body_markdown,
+                payload=payload,
+            ),
+            auto_nudge=auto_nudge,
+            sender_actor_id=sender_actor_id,
+        )
+
     async def _sender_identity(
         self,
         db: AsyncSession,

--- a/backend/app/services/github_client.py
+++ b/backend/app/services/github_client.py
@@ -114,6 +114,19 @@ class GithubClient:
             if self._http is None:
                 await client.aclose()
 
+    async def get_combined_status_for_ref(self, owner: str, repo: str, ref: str) -> dict:
+        client = self._client()
+        try:
+            resp = await client.get(
+                f"/repos/{owner}/{repo}/commits/{ref}/status",
+                headers=self._headers(),
+            )
+            resp.raise_for_status()
+            return resp.json()
+        finally:
+            if self._http is None:
+                await client.aclose()
+
     async def mark_pull_ready_for_review(self, pull_node_id: str) -> dict:
         client = self._client()
         try:

--- a/backend/app/services/github_client.py
+++ b/backend/app/services/github_client.py
@@ -88,5 +88,72 @@ class GithubClient:
             if self._http is None:
                 await client.aclose()
 
+    async def get_pull(self, owner: str, repo: str, pr_number: int) -> dict:
+        client = self._client()
+        try:
+            resp = await client.get(
+                f"/repos/{owner}/{repo}/pulls/{pr_number}",
+                headers=self._headers(),
+            )
+            resp.raise_for_status()
+            return resp.json()
+        finally:
+            if self._http is None:
+                await client.aclose()
+
+    async def list_check_runs_for_ref(self, owner: str, repo: str, ref: str) -> list[dict]:
+        client = self._client()
+        try:
+            resp = await client.get(
+                f"/repos/{owner}/{repo}/commits/{ref}/check-runs",
+                headers=self._headers(),
+            )
+            resp.raise_for_status()
+            return resp.json().get("check_runs", [])
+        finally:
+            if self._http is None:
+                await client.aclose()
+
+    async def mark_pull_ready_for_review(self, pull_node_id: str) -> dict:
+        client = self._client()
+        try:
+            resp = await client.post(
+                "/graphql",
+                headers=self._headers(),
+                json={
+                    "query": (
+                        "mutation($pullRequestId: ID!) { "
+                        "markPullRequestReadyForReview(input: { pullRequestId: $pullRequestId }) { "
+                        "pullRequest { id } } }"
+                    ),
+                    "variables": {"pullRequestId": pull_node_id},
+                },
+            )
+            resp.raise_for_status()
+            body = resp.json()
+            if body.get("errors"):
+                raise httpx.HTTPStatusError(
+                    str(body["errors"]),
+                    request=resp.request,
+                    response=resp,
+                )
+            return body
+        finally:
+            if self._http is None:
+                await client.aclose()
+
+    async def merge_pull(self, owner: str, repo: str, pr_number: int) -> dict:
+        client = self._client()
+        try:
+            resp = await client.put(
+                f"/repos/{owner}/{repo}/pulls/{pr_number}/merge",
+                headers=self._headers(),
+            )
+            resp.raise_for_status()
+            return resp.json()
+        finally:
+            if self._http is None:
+                await client.aclose()
+
 
 github_client = GithubClient()

--- a/backend/app/services/github_dispatch_scheduler.py
+++ b/backend/app/services/github_dispatch_scheduler.py
@@ -1,0 +1,175 @@
+"""Hosted scheduler for autonomous GitHub dispatch."""
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.database import AsyncSessionLocal
+from app.models.database import AgentTeamPreset, AgentTeamSlot, GithubWorkItem, TeamGithubScope
+from app.services.github_client import GithubClient, github_client
+from app.services.github_dispatch_service import github_dispatch_service
+from app.services.github_verification_service import github_verification_service
+from app.services.github_watcher_service import github_watcher_service
+
+logger = logging.getLogger(__name__)
+
+_JOB_PREFIX = "github-dispatch:"
+
+
+class GithubDispatchScheduler:
+    def __init__(
+        self,
+        scheduler=None,
+        *,
+        interval_seconds: int | None = None,
+        watcher=github_watcher_service,
+        dispatch=github_dispatch_service,
+        verification=github_verification_service,
+    ) -> None:
+        self.scheduler = scheduler
+        self.interval_seconds = interval_seconds or settings.github_dispatch_interval_seconds
+        self.watcher = watcher
+        self.dispatch = dispatch
+        self.verification = verification
+
+    def _ensure_scheduler(self):
+        if self.scheduler is None:
+            from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+            self.scheduler = AsyncIOScheduler()
+        return self.scheduler
+
+    async def start(self) -> None:
+        scheduler = self._ensure_scheduler()
+        async with AsyncSessionLocal() as db:
+            await self.sync_jobs(db)
+        if not getattr(scheduler, "running", False):
+            scheduler.start()
+
+    async def shutdown(self) -> None:
+        if self.scheduler is not None and getattr(self.scheduler, "running", False):
+            self.scheduler.shutdown(wait=False)
+
+    async def sync_jobs(self, db: AsyncSession) -> None:
+        scheduler = self._ensure_scheduler()
+        rows = (
+            await db.execute(
+                select(TeamGithubScope.repo_owner, TeamGithubScope.repo_name)
+                .join(AgentTeamPreset, AgentTeamPreset.id == TeamGithubScope.preset_id)
+                .where(
+                    TeamGithubScope.enabled.is_(True),
+                    AgentTeamPreset.autonomy_enabled.is_(True),
+                )
+                .distinct()
+            )
+        ).all()
+        desired = {self._job_id(owner, repo): (owner, repo) for owner, repo in rows}
+        existing = {
+            job.id
+            for job in scheduler.get_jobs()
+            if getattr(job, "id", "").startswith(_JOB_PREFIX)
+        }
+        for stale_id in existing - set(desired):
+            scheduler.remove_job(stale_id)
+        for job_id, (owner, repo) in desired.items():
+            if job_id in existing:
+                continue
+            scheduler.add_job(
+                self.run_repo_job,
+                "interval",
+                seconds=self.interval_seconds,
+                id=job_id,
+                args=[owner, repo],
+                replace_existing=True,
+                max_instances=1,
+                coalesce=True,
+            )
+
+    async def run_repo_job(self, owner: str, repo: str) -> None:
+        try:
+            async with AsyncSessionLocal() as db:
+                await self.run_repo_once(db, owner, repo)
+                await self.sync_jobs(db)
+        except Exception:
+            logger.exception("Autonomous GitHub dispatch job failed for %s/%s", owner, repo)
+
+    async def run_repo_once(
+        self,
+        db: AsyncSession,
+        owner: str,
+        repo: str,
+        *,
+        client: GithubClient | None = None,
+        launcher=None,
+        classify=None,
+    ) -> None:
+        client = client or github_client
+        scopes = (
+            await db.execute(
+                select(TeamGithubScope)
+                .join(AgentTeamPreset, AgentTeamPreset.id == TeamGithubScope.preset_id)
+                .where(
+                    TeamGithubScope.repo_owner == owner,
+                    TeamGithubScope.repo_name == repo,
+                    TeamGithubScope.enabled.is_(True),
+                    AgentTeamPreset.autonomy_enabled.is_(True),
+                )
+                .order_by(TeamGithubScope.id)
+            )
+        ).scalars().all()
+        for scope in scopes:
+            await self.watcher.poll_scope(db, scope, client)
+            slots = (
+                await db.execute(
+                    select(AgentTeamSlot)
+                    .where(AgentTeamSlot.preset_id == scope.preset_id)
+                    .order_by(AgentTeamSlot.position, AgentTeamSlot.id)
+                )
+            ).scalars().all()
+            issue_labels_by_number = await self._issue_labels_by_number(db, scope, client)
+            await self.dispatch.dispatch_pending(
+                db,
+                scope,
+                slots,
+                client=client,
+                classify=classify,
+                launcher=launcher,
+                issue_labels_by_number=issue_labels_by_number,
+            )
+            await self.dispatch.monitor_dispatched(db, scope, slots)
+            await self.verification.process_scope(db, scope, client=client)
+
+    async def _issue_labels_by_number(
+        self,
+        db: AsyncSession,
+        scope: TeamGithubScope,
+        client: GithubClient,
+    ) -> dict[int, list[str]]:
+        pending_numbers = (
+            await db.execute(
+                select(GithubWorkItem.issue_number).where(
+                    GithubWorkItem.scope_id == scope.id,
+                    GithubWorkItem.dispatch_status == "pending",
+                )
+            )
+        ).scalars().all()
+        if not pending_numbers:
+            return {}
+        issues = await client.get_issues_by_number(
+            scope.repo_owner,
+            scope.repo_name,
+            list(pending_numbers),
+        )
+        return {
+            number: [label["name"] for label in issue.get("labels", []) if "name" in label]
+            for number, issue in issues.items()
+        }
+
+    def _job_id(self, owner: str, repo: str) -> str:
+        return f"{_JOB_PREFIX}{owner}/{repo}"
+
+
+github_dispatch_scheduler = GithubDispatchScheduler()

--- a/backend/app/services/github_dispatch_service.py
+++ b/backend/app/services/github_dispatch_service.py
@@ -3,14 +3,15 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.database import AgentTeamSlot, GithubWorkItem, TeamGithubScope
+from app.models.database import AgentTeamSlot, GithubWorkItem, MailTeamMember, TeamGithubScope
 from app.models.schemas import AgentTeamLaunchRequest
 from app.services.agent_team_service import agent_team_service
 
 _BUSY_STATUSES = ("dispatched", "verifying")
+_SCOPE_CONCURRENCY_STATUSES = ("dispatched", "verifying")
 
 
 class GithubDispatchService:
@@ -63,6 +64,20 @@ class GithubDispatchService:
         ).first()
         return pending_handoff is not None
 
+    async def scope_active_count(self, db: AsyncSession, scope_id: int) -> int:
+        return int(
+            (
+                await db.execute(
+                    select(func.count())
+                    .select_from(GithubWorkItem)
+                    .where(
+                        GithubWorkItem.scope_id == scope_id,
+                        GithubWorkItem.dispatch_status.in_(_SCOPE_CONCURRENCY_STATUSES),
+                    )
+                )
+            ).scalar_one()
+        )
+
     async def dispatch_pending(
         self,
         db: AsyncSession,
@@ -76,25 +91,30 @@ class GithubDispatchService:
         launcher = launcher or agent_team_service.launch
         issue_labels_by_number = issue_labels_by_number or {}
         slots_dispatched_this_batch: set[int] = set()
+        scope_dispatched_this_batch = 0
+        scope_active = await self.scope_active_count(db, scope.id)
 
         pending = (
             await db.execute(
                 select(GithubWorkItem).where(
                     GithubWorkItem.scope_id == scope.id,
                     GithubWorkItem.dispatch_status == "pending",
-                )
+                ).order_by(GithubWorkItem.created_at, GithubWorkItem.id)
             )
         ).scalars().all()
 
         for item in pending:
+            if scope_active + scope_dispatched_this_batch >= scope.max_concurrent_dispatched:
+                item.pending_reason = "queued_repo_cap"
+                item.updated_at = datetime.utcnow()
+                await db.commit()
+                continue
             issue_labels = issue_labels_by_number.get(item.issue_number, [])
             owner_slot_id, method = await self.route_item(
                 db, item, preset_slots, issue_labels, classify=classify
             )
             if owner_slot_id is None:
-                item.dispatch_status = "escalated"
-                item.escalation_reason = "plan_blocked"
-                item.updated_at = datetime.utcnow()
+                await self.escalate(db, item, "plan_blocked")
                 await db.commit()
                 continue
             if owner_slot_id in slots_dispatched_this_batch or await self.slot_is_busy(
@@ -120,10 +140,8 @@ class GithubDispatchService:
             except ValueError:
                 item.owner_slot_id = owner_slot_id
                 item.routing_method = method
-                item.dispatch_status = "escalated"
-                item.escalation_reason = "plan_blocked"
                 item.pending_reason = None
-                item.updated_at = datetime.utcnow()
+                await self.escalate(db, item, "plan_blocked")
                 await db.commit()
                 continue
             item.owner_slot_id = owner_slot_id
@@ -141,6 +159,7 @@ class GithubDispatchService:
             else:
                 item.dispatch_status = "dispatched"
                 slots_dispatched_this_batch.add(owner_slot_id)
+                scope_dispatched_this_batch += 1
             item.pending_reason = None
             item.updated_at = datetime.utcnow()
             await db.commit()
@@ -150,8 +169,7 @@ class GithubDispatchService:
     ) -> None:
         item.approval_round_count += 1
         if item.approval_round_count >= scope.max_approval_rounds:
-            item.dispatch_status = "escalated"
-            item.escalation_reason = "approval_rounds_exhausted"
+            await self.escalate(db, item, "approval_rounds_exhausted")
         item.updated_at = datetime.utcnow()
         await db.commit()
 
@@ -216,12 +234,133 @@ class GithubDispatchService:
 
         for item in dispatched:
             if leader_wake == "offline":
-                item.dispatch_status = "escalated"
-                item.escalation_reason = "leader_offline"
-                item.updated_at = datetime.utcnow()
+                await self.escalate(db, item, "leader_offline")
             # Leader reachable but idle nudge/escalation is intentionally deferred;
             # it needs agent-mail last-activity plumbing beyond Phase A's backend core.
         await db.commit()
+
+    async def escalate(
+        self,
+        db: AsyncSession,
+        item: GithubWorkItem,
+        reason: str,
+        note: str | None = None,
+    ) -> None:
+        item.dispatch_status = "escalated"
+        item.escalation_reason = reason
+        item.pending_reason = None
+        if note is not None:
+            item.status_note = note
+        item.updated_at = datetime.utcnow()
+        await self._send_escalation_broadcast(db, item, reason, note)
+        if reason == "dispatch_label_removed":
+            await self._send_label_removed_owner_message(db, item)
+
+    async def notify_owner(
+        self,
+        db: AsyncSession,
+        item: GithubWorkItem,
+        *,
+        subject: str,
+        body_markdown: str,
+        payload: dict | None = None,
+    ) -> None:
+        member = await self._owner_member(db, item)
+        if member is None:
+            return
+        from app.services.agent_mail_service import agent_mail_service
+
+        await agent_mail_service.send_direct_message(
+            db,
+            recipient_member_id=member.id,
+            subject=subject,
+            body_markdown=body_markdown,
+            payload=payload,
+        )
+
+    async def notify_team(
+        self,
+        db: AsyncSession,
+        *,
+        subject: str,
+        body_markdown: str,
+        payload: dict | None = None,
+    ) -> None:
+        from app.services.agent_mail_service import agent_mail_service
+
+        await agent_mail_service.send_broadcast(
+            db,
+            subject=subject,
+            body_markdown=body_markdown,
+            payload=payload,
+        )
+
+    async def _send_escalation_broadcast(
+        self,
+        db: AsyncSession,
+        item: GithubWorkItem,
+        reason: str,
+        note: str | None,
+    ) -> None:
+        scope = await db.get(TeamGithubScope, item.scope_id)
+        repo = f"{scope.repo_owner}/{scope.repo_name}" if scope is not None else "unknown repo"
+        lines = [
+            f"Autonomous GitHub dispatch escalated issue #{item.issue_number}.",
+            "",
+            f"- Repo: {repo}",
+            f"- Reason: {reason}",
+            f"- Issue: {item.issue_title}",
+        ]
+        if item.issue_url:
+            lines.append(f"- URL: {item.issue_url}")
+        if note:
+            lines.extend(["", note])
+        await self.notify_team(
+            db,
+            subject=f"Autonomy escalation: {reason}",
+            body_markdown="\n".join(lines),
+            payload={
+                "kind": "github_dispatch_escalation",
+                "work_item_id": item.id,
+                "issue_number": item.issue_number,
+                "scope_id": item.scope_id,
+                "reason": reason,
+            },
+        )
+
+    async def _send_label_removed_owner_message(
+        self,
+        db: AsyncSession,
+        item: GithubWorkItem,
+    ) -> None:
+        await self.notify_owner(
+            db,
+            item,
+            subject="Dispatch label removed",
+            body_markdown=(
+                f"The triggering label was removed from issue #{item.issue_number}. "
+                "A human wants this stopped or reconsidered. Finish or discard your "
+                "current work at your discretion, but do not open or merge a PR without "
+                "re-confirming with the team leader."
+            ),
+            payload={
+                "kind": "github_dispatch_label_removed",
+                "work_item_id": item.id,
+                "issue_number": item.issue_number,
+            },
+        )
+
+    async def _owner_member(self, db: AsyncSession, item: GithubWorkItem) -> MailTeamMember | None:
+        if item.owner_slot_id is None:
+            return None
+        return (
+            await db.execute(
+                select(MailTeamMember)
+                .where(MailTeamMember.team_slot_id == item.owner_slot_id)
+                .order_by(MailTeamMember.updated_at.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
 
 
 github_dispatch_service = GithubDispatchService()

--- a/backend/app/services/github_dispatch_service.py
+++ b/backend/app/services/github_dispatch_service.py
@@ -1,6 +1,7 @@
 """Routing and dispatch lifecycle for autonomous GitHub dispatch."""
 from __future__ import annotations
 
+import logging
 from datetime import datetime
 
 from sqlalchemy import func, select
@@ -12,6 +13,8 @@ from app.services.agent_team_service import agent_team_service
 
 _BUSY_STATUSES = ("dispatched", "verifying")
 _SCOPE_CONCURRENCY_STATUSES = ("dispatched", "verifying")
+
+logger = logging.getLogger(__name__)
 
 
 class GithubDispatchService:
@@ -246,15 +249,31 @@ class GithubDispatchService:
         reason: str,
         note: str | None = None,
     ) -> None:
+        self._apply_escalation(item, reason, note)
+        try:
+            await self._send_escalation_broadcast(db, item, reason, note)
+            if reason == "dispatch_label_removed":
+                await self._send_label_removed_owner_message(db, item)
+        except Exception:
+            logger.exception(
+                "Failed to send autonomous dispatch escalation notification for item %s",
+                item.id,
+            )
+            await db.rollback()
+            self._apply_escalation(item, reason, note)
+
+    def _apply_escalation(
+        self,
+        item: GithubWorkItem,
+        reason: str,
+        note: str | None = None,
+    ) -> None:
         item.dispatch_status = "escalated"
         item.escalation_reason = reason
         item.pending_reason = None
         if note is not None:
             item.status_note = note
         item.updated_at = datetime.utcnow()
-        await self._send_escalation_broadcast(db, item, reason, note)
-        if reason == "dispatch_label_removed":
-            await self._send_label_removed_owner_message(db, item)
 
     async def notify_owner(
         self,

--- a/backend/app/services/github_verification_service.py
+++ b/backend/app/services/github_verification_service.py
@@ -1,24 +1,30 @@
 """GitHub PR verification and merge loop for autonomous dispatch."""
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timedelta
 
 import httpx
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import settings
 from app.models.database import GithubWorkItem, TeamGithubScope
 from app.services.github_client import GithubClient, github_client
 from app.services.github_dispatch_service import github_dispatch_service
 
 _SUCCESS_CONCLUSIONS = {"success", "neutral", "skipped"}
-_FAILURE_CONCLUSIONS = {"failure", "timed_out", "cancelled", "action_required"}
+_STATUS_SUCCESS_STATES = {"success"}
+_STATUS_FAILURE_STATES = {"failure", "error"}
 _TRANSIENT_MERGE_STATES = {"unstable", "blocked"}
 _HUMAN_MERGE_NOTE_PREFIXES = (
     "Auto-merge blocked",
     "Auto-merge budget exhausted",
     "Auto-merge retry budget exhausted",
 )
+_MERGE_TRANSIENT_STATUS_CODES = {405, 409, 422}
+
+logger = logging.getLogger(__name__)
 
 
 class GithubVerificationService:
@@ -29,6 +35,11 @@ class GithubVerificationService:
         scope: TeamGithubScope,
         pr_number: int,
     ) -> None:
+        if item.dispatch_status != "dispatched":
+            raise ValueError(
+                f"pr_opened is only valid for dispatched work items; current status is "
+                f"{item.dispatch_status}"
+            )
         item.pr_number = pr_number
         if item.issue_type == "design":
             item.dispatch_status = "awaiting_human_review"
@@ -65,17 +76,30 @@ class GithubVerificationService:
                     GithubWorkItem.scope_id == scope.id,
                     GithubWorkItem.pr_number.is_not(None),
                     GithubWorkItem.dispatch_status.in_(
-                        ("verifying", "ready_for_review", "awaiting_human_review")
+                        (
+                            "dispatched",
+                            "verifying",
+                            "ready_for_review",
+                            "awaiting_human_review",
+                        )
                     ),
                 )
             )
         ).scalars().all()
 
         for item in items:
-            if item.dispatch_status == "verifying":
-                await self._verify_item(db, scope, item, client)
-            else:
-                await self._process_review_item(db, scope, item, client)
+            try:
+                if item.dispatch_status in ("dispatched", "verifying"):
+                    await self._verify_item(db, scope, item, client)
+                else:
+                    await self._process_review_item(db, scope, item, client)
+            except httpx.HTTPError as exc:
+                logger.exception(
+                    "GitHub verification failed for work item %s", item.id
+                )
+                item.status_note = f"GitHub verification failed; will retry: {exc}"
+                item.updated_at = datetime.utcnow()
+                await db.commit()
 
     async def _verify_item(
         self,
@@ -96,20 +120,20 @@ class GithubVerificationService:
             pull.get("head", {}).get("sha", ""),
         )
         if not checks:
-            await github_dispatch_service.escalate(
-                db,
-                item,
-                "no_check_runs",
-                "No GitHub check-runs found for PR.",
-            )
-            await db.commit()
+            if await self._process_combined_status(db, scope, item, client, pull):
+                return
+            await self._handle_no_check_signal(db, item)
             return
 
-        failed = [check for check in checks if check.get("conclusion") in _FAILURE_CONCLUSIONS]
         pending = [
             check
             for check in checks
             if check.get("status") != "completed" or check.get("conclusion") is None
+        ]
+        failed = [
+            check
+            for check in checks
+            if check not in pending and check.get("conclusion") not in _SUCCESS_CONCLUSIONS
         ]
         if failed:
             item.retry_count += 1
@@ -129,7 +153,7 @@ class GithubVerificationService:
                     "retry_count": item.retry_count,
                 },
             )
-            if item.retry_count >= scope.max_verification_retries:
+            if item.retry_count > scope.max_verification_retries:
                 await github_dispatch_service.escalate(
                     db,
                     item,
@@ -152,6 +176,11 @@ class GithubVerificationService:
             item.updated_at = datetime.utcnow()
             if pull.get("draft") and pull.get("node_id"):
                 await client.mark_pull_ready_for_review(str(pull["node_id"]))
+                pull = await client.get_pull(
+                    scope.repo_owner,
+                    scope.repo_name,
+                    int(item.pr_number),
+                )
             if scope.merge_policy == "human":
                 await github_dispatch_service.notify_team(
                     db,
@@ -204,7 +233,7 @@ class GithubVerificationService:
             await client.merge_pull(scope.repo_owner, scope.repo_name, int(item.pr_number))
         except httpx.HTTPStatusError as exc:
             status_code = exc.response.status_code
-            if status_code in (405, 409):
+            if status_code in _MERGE_TRANSIENT_STATUS_CODES or status_code >= 500:
                 await self._record_transient_merge_failure(db, scope, item, str(exc))
             elif status_code == 403:
                 self._fallback_to_human_merge(
@@ -213,7 +242,11 @@ class GithubVerificationService:
                 )
                 await db.commit()
             else:
-                raise
+                self._fallback_to_human_merge(
+                    item,
+                    f"Auto-merge failed with GitHub status {status_code}; requires human merge.",
+                )
+                await db.commit()
             return
 
         self._mark_merged(item)
@@ -228,7 +261,7 @@ class GithubVerificationService:
         note: str,
     ) -> None:
         item.retry_count += 1
-        if item.retry_count >= scope.max_verification_retries:
+        if item.retry_count > scope.max_verification_retries:
             self._fallback_to_human_merge(
                 item,
                 f"Auto-merge retry budget exhausted after transient merge failure: {note}",
@@ -236,6 +269,106 @@ class GithubVerificationService:
         else:
             item.status_note = f"Transient merge failure; will retry: {note}"
             item.updated_at = datetime.utcnow()
+        await db.commit()
+
+    async def _process_combined_status(
+        self,
+        db: AsyncSession,
+        scope: TeamGithubScope,
+        item: GithubWorkItem,
+        client: GithubClient,
+        pull: dict,
+    ) -> bool:
+        status = await client.get_combined_status_for_ref(
+            scope.repo_owner,
+            scope.repo_name,
+            pull.get("head", {}).get("sha", ""),
+        )
+        contexts = status.get("statuses") or []
+        if not contexts:
+            return False
+        state = status.get("state")
+        if state in _STATUS_SUCCESS_STATES:
+            item.dispatch_status = "ready_for_review"
+            item.status_note = f"PR #{item.pr_number} is ready for review."
+            item.updated_at = datetime.utcnow()
+            if pull.get("draft") and pull.get("node_id"):
+                await client.mark_pull_ready_for_review(str(pull["node_id"]))
+                pull = await client.get_pull(
+                    scope.repo_owner,
+                    scope.repo_name,
+                    int(item.pr_number),
+                )
+            if scope.merge_policy == "human":
+                await github_dispatch_service.notify_team(
+                    db,
+                    subject="Code PR ready for review",
+                    body_markdown=(
+                        f"Code PR #{item.pr_number} is ready for human review for "
+                        f"issue #{item.issue_number}: {item.issue_title}"
+                    ),
+                    payload={
+                        "kind": "github_dispatch_code_pr_ready",
+                        "work_item_id": item.id,
+                        "pr_number": item.pr_number,
+                    },
+                )
+            await db.commit()
+            await self._process_review_item(db, scope, item, client, pull=pull)
+            return True
+        if state in _STATUS_FAILURE_STATES:
+            item.retry_count += 1
+            item.status_note = f"GitHub commit status failed: {state}"
+            await github_dispatch_service.notify_owner(
+                db,
+                item,
+                subject="GitHub commit status failed",
+                body_markdown=(
+                    f"GitHub commit status failed for issue #{item.issue_number} / "
+                    f"PR #{item.pr_number}.\n\n{item.status_note}"
+                ),
+                payload={
+                    "kind": "github_dispatch_status_failed",
+                    "work_item_id": item.id,
+                    "pr_number": item.pr_number,
+                    "retry_count": item.retry_count,
+                },
+            )
+            if item.retry_count > scope.max_verification_retries:
+                await github_dispatch_service.escalate(
+                    db,
+                    item,
+                    "retry_count_exhausted",
+                    item.status_note,
+                )
+            else:
+                item.dispatch_status = "dispatched"
+                item.updated_at = datetime.utcnow()
+            await db.commit()
+            return True
+        item.status_note = "GitHub commit statuses are still pending."
+        item.updated_at = datetime.utcnow()
+        await db.commit()
+        return True
+
+    async def _handle_no_check_signal(
+        self,
+        db: AsyncSession,
+        item: GithubWorkItem,
+    ) -> None:
+        grace_started_at = item.updated_at or item.created_at
+        grace_age = datetime.utcnow() - grace_started_at
+        if grace_age < timedelta(seconds=settings.github_check_signal_grace_seconds):
+            item.status_note = "Waiting for GitHub check-runs or commit statuses to appear."
+            item.updated_at = datetime.utcnow()
+            await db.commit()
+            return
+        await github_dispatch_service.escalate(
+            db,
+            item,
+            "retry_count_exhausted",
+            "No GitHub check-runs or commit statuses found for PR.",
+        )
         await db.commit()
 
     async def _auto_merge_budget_exhausted(

--- a/backend/app/services/github_verification_service.py
+++ b/backend/app/services/github_verification_service.py
@@ -1,0 +1,273 @@
+"""GitHub PR verification and merge loop for autonomous dispatch."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.database import GithubWorkItem, TeamGithubScope
+from app.services.github_client import GithubClient, github_client
+from app.services.github_dispatch_service import github_dispatch_service
+
+_SUCCESS_CONCLUSIONS = {"success", "neutral", "skipped"}
+_FAILURE_CONCLUSIONS = {"failure", "timed_out", "cancelled", "action_required"}
+_TRANSIENT_MERGE_STATES = {"unstable", "blocked"}
+_HUMAN_MERGE_NOTE_PREFIXES = (
+    "Auto-merge blocked",
+    "Auto-merge budget exhausted",
+    "Auto-merge retry budget exhausted",
+)
+
+
+class GithubVerificationService:
+    async def report_pr_opened(
+        self,
+        db: AsyncSession,
+        item: GithubWorkItem,
+        scope: TeamGithubScope,
+        pr_number: int,
+    ) -> None:
+        item.pr_number = pr_number
+        if item.issue_type == "design":
+            item.dispatch_status = "awaiting_human_review"
+            item.status_note = f"Design PR #{pr_number} is ready for human review."
+            await github_dispatch_service.notify_team(
+                db,
+                subject="Design PR ready for review",
+                body_markdown=(
+                    f"Design PR #{pr_number} is ready for human review for "
+                    f"issue #{item.issue_number}: {item.issue_title}"
+                ),
+                payload={
+                    "kind": "github_dispatch_design_pr_ready",
+                    "work_item_id": item.id,
+                    "pr_number": pr_number,
+                },
+            )
+        else:
+            item.dispatch_status = "verifying"
+            item.status_note = None
+        item.updated_at = datetime.utcnow()
+        await db.commit()
+
+    async def process_scope(
+        self,
+        db: AsyncSession,
+        scope: TeamGithubScope,
+        client: GithubClient | None = None,
+    ) -> None:
+        client = client or github_client
+        items = (
+            await db.execute(
+                select(GithubWorkItem).where(
+                    GithubWorkItem.scope_id == scope.id,
+                    GithubWorkItem.pr_number.is_not(None),
+                    GithubWorkItem.dispatch_status.in_(
+                        ("verifying", "ready_for_review", "awaiting_human_review")
+                    ),
+                )
+            )
+        ).scalars().all()
+
+        for item in items:
+            if item.dispatch_status == "verifying":
+                await self._verify_item(db, scope, item, client)
+            else:
+                await self._process_review_item(db, scope, item, client)
+
+    async def _verify_item(
+        self,
+        db: AsyncSession,
+        scope: TeamGithubScope,
+        item: GithubWorkItem,
+        client: GithubClient,
+    ) -> None:
+        pull = await client.get_pull(scope.repo_owner, scope.repo_name, int(item.pr_number))
+        if pull.get("merged"):
+            self._mark_merged(item)
+            await db.commit()
+            return
+
+        checks = await client.list_check_runs_for_ref(
+            scope.repo_owner,
+            scope.repo_name,
+            pull.get("head", {}).get("sha", ""),
+        )
+        if not checks:
+            await github_dispatch_service.escalate(
+                db,
+                item,
+                "no_check_runs",
+                "No GitHub check-runs found for PR.",
+            )
+            await db.commit()
+            return
+
+        failed = [check for check in checks if check.get("conclusion") in _FAILURE_CONCLUSIONS]
+        pending = [
+            check
+            for check in checks
+            if check.get("status") != "completed" or check.get("conclusion") is None
+        ]
+        if failed:
+            item.retry_count += 1
+            item.status_note = self._failed_check_note(failed)
+            await github_dispatch_service.notify_owner(
+                db,
+                item,
+                subject="GitHub checks failed",
+                body_markdown=(
+                    f"GitHub checks failed for issue #{item.issue_number} / "
+                    f"PR #{item.pr_number}.\n\n{item.status_note}"
+                ),
+                payload={
+                    "kind": "github_dispatch_check_failed",
+                    "work_item_id": item.id,
+                    "pr_number": item.pr_number,
+                    "retry_count": item.retry_count,
+                },
+            )
+            if item.retry_count >= scope.max_verification_retries:
+                await github_dispatch_service.escalate(
+                    db,
+                    item,
+                    "retry_count_exhausted",
+                    item.status_note,
+                )
+            else:
+                item.dispatch_status = "dispatched"
+                item.updated_at = datetime.utcnow()
+            await db.commit()
+            return
+        if pending:
+            item.status_note = "GitHub checks are still running."
+            item.updated_at = datetime.utcnow()
+            await db.commit()
+            return
+        if all(check.get("conclusion") in _SUCCESS_CONCLUSIONS for check in checks):
+            item.dispatch_status = "ready_for_review"
+            item.status_note = f"PR #{item.pr_number} is ready for review."
+            item.updated_at = datetime.utcnow()
+            if pull.get("draft") and pull.get("node_id"):
+                await client.mark_pull_ready_for_review(str(pull["node_id"]))
+            if scope.merge_policy == "human":
+                await github_dispatch_service.notify_team(
+                    db,
+                    subject="Code PR ready for review",
+                    body_markdown=(
+                        f"Code PR #{item.pr_number} is ready for human review for "
+                        f"issue #{item.issue_number}: {item.issue_title}"
+                    ),
+                    payload={
+                        "kind": "github_dispatch_code_pr_ready",
+                        "work_item_id": item.id,
+                        "pr_number": item.pr_number,
+                    },
+                )
+            await db.commit()
+            await self._process_review_item(db, scope, item, client, pull=pull)
+
+    async def _process_review_item(
+        self,
+        db: AsyncSession,
+        scope: TeamGithubScope,
+        item: GithubWorkItem,
+        client: GithubClient,
+        pull: dict | None = None,
+    ) -> None:
+        pull = pull or await client.get_pull(scope.repo_owner, scope.repo_name, int(item.pr_number))
+        if pull.get("merged"):
+            self._mark_merged(item)
+            await db.commit()
+            return
+        if item.issue_type == "design" or scope.merge_policy != "auto":
+            return
+        if item.status_note and item.status_note.startswith(_HUMAN_MERGE_NOTE_PREFIXES):
+            return
+        if await self._auto_merge_budget_exhausted(db, scope):
+            item.status_note = "Auto-merge budget exhausted; PR is ready for human merge."
+            item.updated_at = datetime.utcnow()
+            await db.commit()
+            return
+        merge_state = pull.get("mergeable_state")
+        if merge_state in _TRANSIENT_MERGE_STATES:
+            await self._record_transient_merge_failure(
+                db,
+                scope,
+                item,
+                f"mergeable_state={merge_state}",
+            )
+            return
+        try:
+            await client.merge_pull(scope.repo_owner, scope.repo_name, int(item.pr_number))
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code
+            if status_code in (405, 409):
+                await self._record_transient_merge_failure(db, scope, item, str(exc))
+            elif status_code == 403:
+                self._fallback_to_human_merge(
+                    item,
+                    "Auto-merge blocked by repository policy; requires human merge.",
+                )
+                await db.commit()
+            else:
+                raise
+            return
+
+        self._mark_merged(item)
+        item.auto_merged_at = datetime.utcnow()
+        await db.commit()
+
+    async def _record_transient_merge_failure(
+        self,
+        db: AsyncSession,
+        scope: TeamGithubScope,
+        item: GithubWorkItem,
+        note: str,
+    ) -> None:
+        item.retry_count += 1
+        if item.retry_count >= scope.max_verification_retries:
+            self._fallback_to_human_merge(
+                item,
+                f"Auto-merge retry budget exhausted after transient merge failure: {note}",
+            )
+        else:
+            item.status_note = f"Transient merge failure; will retry: {note}"
+            item.updated_at = datetime.utcnow()
+        await db.commit()
+
+    async def _auto_merge_budget_exhausted(
+        self, db: AsyncSession, scope: TeamGithubScope
+    ) -> bool:
+        since = datetime.utcnow() - timedelta(days=1)
+        count = (
+            await db.execute(
+                select(GithubWorkItem.id).where(
+                    GithubWorkItem.scope_id == scope.id,
+                    GithubWorkItem.auto_merged_at.is_not(None),
+                    GithubWorkItem.auto_merged_at >= since,
+                )
+            )
+        ).all()
+        return len(count) >= scope.max_auto_merges_per_day
+
+    def _mark_merged(self, item: GithubWorkItem) -> None:
+        item.dispatch_status = "merged"
+        item.escalation_reason = None
+        item.status_note = None
+        item.updated_at = datetime.utcnow()
+
+    def _fallback_to_human_merge(self, item: GithubWorkItem, note: str) -> None:
+        item.dispatch_status = "ready_for_review"
+        item.escalation_reason = None
+        item.status_note = note
+        item.updated_at = datetime.utcnow()
+
+    def _failed_check_note(self, checks: list[dict]) -> str:
+        names = ", ".join(str(check.get("name") or check.get("id")) for check in checks)
+        return f"GitHub check failed: {names}"
+
+
+github_verification_service = GithubVerificationService()

--- a/backend/app/services/github_watcher_service.py
+++ b/backend/app/services/github_watcher_service.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.database import GithubWorkItem, TeamGithubScope
 from app.services.github_client import GithubClient, github_client
+from app.services.github_dispatch_service import github_dispatch_service
 
 _ACTIVE_STATUSES = ("dispatched", "verifying", "awaiting_human_review")
 _RECOVERABLE_STATUSES = ("failed", "escalated")
@@ -102,9 +103,12 @@ class GithubWatcherService:
                 label["name"] == scope.dispatch_label for label in issue.get("labels", [])
             )
             if not still_labeled:
-                item.dispatch_status = "escalated"
-                item.escalation_reason = "dispatch_label_removed"
-                item.updated_at = datetime.utcnow()
+                await github_dispatch_service.escalate(
+                    db,
+                    item,
+                    "dispatch_label_removed",
+                    "The dispatch label was removed from the issue.",
+                )
 
 
 github_watcher_service = GithubWatcherService()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "tomlkit>=0.13.2",
     "pytest-asyncio>=0.24.0",
     "mcp>=1.2.0",
+    "apscheduler>=3.10.4",
 ]
 
 [build-system]

--- a/backend/tests/agent_mail/test_dispatch_status_tool.py
+++ b/backend/tests/agent_mail/test_dispatch_status_tool.py
@@ -44,15 +44,16 @@ async def _seed_item(maker, **overrides):
         )
         db.add(scope)
         await db.flush()
-        item = GithubWorkItem(
-            scope_id=scope.id,
-            issue_number=1,
-            issue_title="x",
-            issue_url="u",
-            github_updated_at=datetime.utcnow(),
-            dispatch_status="dispatched",
-            **overrides,
-        )
+        values = {
+            "scope_id": scope.id,
+            "issue_number": 1,
+            "issue_title": "x",
+            "issue_url": "u",
+            "github_updated_at": datetime.utcnow(),
+            "dispatch_status": "dispatched",
+        }
+        values.update(overrides)
+        item = GithubWorkItem(**values)
         db.add(item)
         await db.commit()
         await db.refresh(item)
@@ -104,6 +105,21 @@ async def test_blocked_uses_spec_reason_and_persists_note(client_and_db):
         assert item.dispatch_status == "escalated"
         assert item.escalation_reason == "plan_blocked"
         assert item.status_note == "missing credentials"
+
+
+@pytest.mark.asyncio
+async def test_pr_opened_rejected_after_item_escalated(client_and_db):
+    ac, maker = client_and_db
+    item_id = await _seed_item(maker, dispatch_status="escalated")
+    resp = await ac.post(
+        "/api/v1/agent-teams/dispatch-status",
+        json={"work_item_id": item_id, "status": "pr_opened", "pr_number": 12},
+    )
+    assert resp.status_code == 409
+    async with maker() as db:
+        item = await db.get(GithubWorkItem, item_id)
+        assert item.dispatch_status == "escalated"
+        assert item.pr_number is None
 
 
 def test_shim_exposes_dispatch_status_tool():

--- a/backend/tests/agent_teams/test_github_dispatch_scheduler.py
+++ b/backend/tests/agent_teams/test_github_dispatch_scheduler.py
@@ -1,0 +1,159 @@
+"""Hosted autonomous GitHub dispatch scheduler tests."""
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+import app.models.database  # noqa: F401
+from app.database import Base
+from app.models.database import AgentTeamPreset, AgentTeamSlot, GithubWorkItem, TeamGithubScope
+from app.services.github_dispatch_scheduler import GithubDispatchScheduler
+
+
+@pytest_asyncio.fixture
+async def db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _scope(db, *, repo_owner="o", repo_name="r", autonomy=True, enabled=True):
+    preset = AgentTeamPreset(name=f"{repo_owner}/{repo_name}", autonomy_enabled=autonomy)
+    db.add(preset)
+    await db.flush()
+    slot = AgentTeamSlot(
+        preset_id=preset.id,
+        position=0,
+        display_name="Owner",
+        provider="codex-cli",
+        repo_id=repo_name,
+        repo_path=f"/tmp/{repo_name}",
+        repo_name=repo_name,
+    )
+    scope = TeamGithubScope(
+        preset_id=preset.id,
+        repo_owner=repo_owner,
+        repo_name=repo_name,
+        repo_path=f"/tmp/{repo_name}",
+        enabled=enabled,
+    )
+    db.add_all([slot, scope])
+    await db.flush()
+    return scope
+
+
+class _FakeWatcher:
+    def __init__(self):
+        self.calls = []
+
+    async def poll_scope(self, db, scope, client):
+        self.calls.append(scope.id)
+
+
+class _FakeDispatch:
+    def __init__(self):
+        self.dispatch_calls = []
+        self.monitor_calls = []
+
+    async def dispatch_pending(self, db, scope, slots, **kwargs):
+        self.dispatch_calls.append((scope.id, [slot.id for slot in slots]))
+
+    async def monitor_dispatched(self, db, scope, slots):
+        self.monitor_calls.append(scope.id)
+
+
+class _FakeVerification:
+    def __init__(self):
+        self.calls = []
+
+    async def process_scope(self, db, scope, client=None):
+        self.calls.append(scope.id)
+
+
+class _FakeClient:
+    async def get_issues_by_number(self, owner, repo, numbers):
+        return {number: {"labels": [{"name": "area:backend"}]} for number in numbers}
+
+
+class _FakeJob:
+    def __init__(self, job_id):
+        self.id = job_id
+
+
+class _FakeScheduler:
+    running = False
+
+    def __init__(self):
+        self.jobs = {}
+
+    def get_jobs(self):
+        return [_FakeJob(job_id) for job_id in self.jobs]
+
+    def add_job(self, func, trigger, **kwargs):
+        self.jobs[kwargs["id"]] = kwargs
+
+    def remove_job(self, job_id):
+        self.jobs.pop(job_id)
+
+    def start(self):
+        self.running = True
+
+    def shutdown(self, wait=False):
+        self.running = False
+
+
+@pytest.mark.asyncio
+async def test_run_repo_once_only_processes_enabled_autonomy_scopes(db):
+    active = await _scope(db, repo_owner="o", repo_name="r", autonomy=True, enabled=True)
+    await _scope(db, repo_owner="o", repo_name="r", autonomy=False, enabled=True)
+    await _scope(db, repo_owner="o", repo_name="r", autonomy=True, enabled=False)
+    await _scope(db, repo_owner="o", repo_name="other", autonomy=True, enabled=True)
+    db.add(
+        GithubWorkItem(
+            scope_id=active.id,
+            issue_number=1,
+            issue_title="x",
+            issue_url="u",
+            github_updated_at=datetime.utcnow(),
+            dispatch_status="pending",
+        )
+    )
+    await db.commit()
+    watcher = _FakeWatcher()
+    dispatch = _FakeDispatch()
+    verification = _FakeVerification()
+    service = GithubDispatchScheduler(
+        scheduler=_FakeScheduler(),
+        watcher=watcher,
+        dispatch=dispatch,
+        verification=verification,
+    )
+
+    await service.run_repo_once(db, "o", "r", client=_FakeClient())
+
+    assert watcher.calls == [active.id]
+    assert [call[0] for call in dispatch.dispatch_calls] == [active.id]
+    assert dispatch.monitor_calls == [active.id]
+    assert verification.calls == [active.id]
+
+
+@pytest.mark.asyncio
+async def test_sync_jobs_uses_one_job_per_distinct_enabled_repo(db):
+    await _scope(db, repo_owner="o", repo_name="r", autonomy=True, enabled=True)
+    await _scope(db, repo_owner="o", repo_name="r", autonomy=True, enabled=True)
+    await _scope(db, repo_owner="o", repo_name="disabled", autonomy=True, enabled=False)
+    await _scope(db, repo_owner="o", repo_name="manual", autonomy=False, enabled=True)
+    scheduler = _FakeScheduler()
+    service = GithubDispatchScheduler(scheduler=scheduler, interval_seconds=30)
+
+    await service.sync_jobs(db)
+
+    assert list(scheduler.jobs) == ["github-dispatch:o/r"]
+    assert scheduler.jobs["github-dispatch:o/r"]["seconds"] == 30

--- a/backend/tests/agent_teams/test_github_dispatch_service.py
+++ b/backend/tests/agent_teams/test_github_dispatch_service.py
@@ -647,6 +647,37 @@ async def test_escalation_creates_agent_mail_broadcast(db):
 
 
 @pytest.mark.asyncio
+async def test_escalation_state_persists_when_notification_fails(db, monkeypatch):
+    preset, slots, scope = await _team(db)
+    scope.max_approval_rounds = 1
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=37,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="dispatched",
+    )
+    db.add(item)
+    await db.commit()
+
+    async def fail_broadcast(db_, item_, reason, note):
+        raise RuntimeError("mail down")
+
+    monkeypatch.setattr(
+        github_dispatch_service,
+        "_send_escalation_broadcast",
+        fail_broadcast,
+    )
+
+    await github_dispatch_service.record_approval_round(db, item, scope)
+
+    await db.refresh(item)
+    assert item.dispatch_status == "escalated"
+    assert item.escalation_reason == "approval_rounds_exhausted"
+
+
+@pytest.mark.asyncio
 async def test_two_phase_handoff(db):
     preset, slots, scope = await _team(db)
     architect, backend = slots[0], slots[1]

--- a/backend/tests/agent_teams/test_github_dispatch_service.py
+++ b/backend/tests/agent_teams/test_github_dispatch_service.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 import pytest
 import pytest_asyncio
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 import app.models.database  # noqa: F401
@@ -11,6 +12,8 @@ from app.models.database import (
     AgentTeamPreset,
     AgentTeamSlot,
     GithubWorkItem,
+    MailMessage,
+    MailTeamMember,
     TeamGithubScope,
 )
 from app.services.github_dispatch_service import github_dispatch_service
@@ -477,6 +480,115 @@ async def test_dispatch_pending_queues_when_slot_busy(db):
 
 
 @pytest.mark.asyncio
+async def test_dispatch_pending_queues_when_scope_concurrency_cap_reached(db):
+    preset, slots, scope = await _team(db)
+    scope.max_concurrent_dispatched = 1
+    backend = next(slot for slot in slots if slot.display_name == "Backend SME")
+    db.add(
+        GithubWorkItem(
+            scope_id=scope.id,
+            issue_number=29,
+            issue_title="x",
+            issue_url="u",
+            github_updated_at=datetime.utcnow(),
+            dispatch_status="dispatched",
+            owner_slot_id=slots[0].id,
+        )
+    )
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=31,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="pending",
+    )
+    db.add(item)
+    await db.commit()
+
+    async def fake_launcher(db_, preset_id, request):
+        raise AssertionError("repo cap should queue before launch")
+
+    await github_dispatch_service.dispatch_pending(
+        db,
+        scope,
+        slots,
+        launcher=fake_launcher,
+        issue_labels_by_number={31: ["area:backend"]},
+    )
+    await db.refresh(item)
+    assert backend.id != slots[0].id
+    assert item.owner_slot_id is None
+    assert item.dispatch_status == "pending"
+    assert item.pending_reason == "queued_repo_cap"
+
+
+@pytest.mark.asyncio
+async def test_scope_concurrency_ignores_human_review_and_escalated_items(db):
+    preset, slots, scope = await _team(db)
+    scope.max_concurrent_dispatched = 1
+    backend = next(slot for slot in slots if slot.display_name == "Backend SME")
+    db.add_all(
+        [
+            GithubWorkItem(
+                scope_id=scope.id,
+                issue_number=32,
+                issue_title="x",
+                issue_url="u",
+                github_updated_at=datetime.utcnow(),
+                dispatch_status="awaiting_human_review",
+                owner_slot_id=backend.id,
+            ),
+            GithubWorkItem(
+                scope_id=scope.id,
+                issue_number=33,
+                issue_title="x",
+                issue_url="u",
+                github_updated_at=datetime.utcnow(),
+                dispatch_status="ready_for_review",
+                owner_slot_id=backend.id,
+            ),
+            GithubWorkItem(
+                scope_id=scope.id,
+                issue_number=34,
+                issue_title="x",
+                issue_url="u",
+                github_updated_at=datetime.utcnow(),
+                dispatch_status="escalated",
+                owner_slot_id=backend.id,
+            ),
+        ]
+    )
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=35,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="pending",
+    )
+    db.add(item)
+    await db.commit()
+
+    class _Result:
+        launch_id = 104
+
+    async def fake_launcher(db_, preset_id, request):
+        return _Result()
+
+    await github_dispatch_service.dispatch_pending(
+        db,
+        scope,
+        slots,
+        launcher=fake_launcher,
+        issue_labels_by_number={35: ["area:backend"]},
+    )
+    await db.refresh(item)
+    assert item.dispatch_status == "dispatched"
+    assert item.owner_slot_id == backend.id
+
+
+@pytest.mark.asyncio
 async def test_approval_round_cap_escalates(db):
     preset, slots, scope = await _team(db)
     scope.max_approval_rounds = 2
@@ -498,6 +610,40 @@ async def test_approval_round_cap_escalates(db):
     await db.refresh(item)
     assert item.dispatch_status == "escalated"
     assert item.escalation_reason == "approval_rounds_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_escalation_creates_agent_mail_broadcast(db):
+    preset, slots, scope = await _team(db)
+    scope.max_approval_rounds = 1
+    db.add(
+        MailTeamMember(
+            identity_key="slot:1",
+            repo_id="r",
+            repo_path="/tmp/r",
+            repo_name="r",
+            display_name="Architect",
+            participant_kind="team_slot",
+            team_preset_id=preset.id,
+            team_slot_id=slots[0].id,
+        )
+    )
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=36,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="dispatched",
+    )
+    db.add(item)
+    await db.commit()
+
+    await github_dispatch_service.record_approval_round(db, item, scope)
+
+    messages = (await db.execute(select(MailMessage))).scalars().all()
+    assert any(message.kind == "broadcast" for message in messages)
+    assert any("approval_rounds_exhausted" in (message.subject or "") for message in messages)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_teams/test_github_scope_models.py
+++ b/backend/tests/agent_teams/test_github_scope_models.py
@@ -43,6 +43,9 @@ async def test_team_github_scope_round_trips(db):
     assert scope.design_label == "claude-deck-design"
     assert scope.merge_policy == "human"
     assert scope.max_approval_rounds == 3
+    assert scope.max_concurrent_dispatched == 3
+    assert scope.max_verification_retries == 2
+    assert scope.max_auto_merges_per_day == 5
     assert scope.enabled is True
 
 
@@ -73,6 +76,7 @@ async def test_github_work_item_defaults(db):
     assert item.retry_count == 0
     assert item.handoff_state is None
     assert item.status_note is None
+    assert item.auto_merged_at is None
 
 
 @pytest.mark.asyncio
@@ -116,14 +120,20 @@ async def test_compat_migration_adds_new_columns_to_legacy_db():
             "enabled BOOLEAN NOT NULL, created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL)"
         ))
         await conn.execute(text("CREATE TABLE github_work_items (id INTEGER PRIMARY KEY AUTOINCREMENT)"))
+        await conn.execute(text("CREATE TABLE team_github_scopes (id INTEGER PRIMARY KEY AUTOINCREMENT)"))
     async with engine.connect() as conn:
         await _run_sqlite_compat_migrations(conn)
     async with engine.connect() as conn:
         preset_cols = {row[1] for row in (await conn.execute(text("PRAGMA table_info(agent_team_presets)"))).fetchall()}
         slot_cols = {row[1] for row in (await conn.execute(text("PRAGMA table_info(agent_team_slots)"))).fetchall()}
         work_item_cols = {row[1] for row in (await conn.execute(text("PRAGMA table_info(github_work_items)"))).fetchall()}
+        scope_cols = {row[1] for row in (await conn.execute(text("PRAGMA table_info(team_github_scopes)"))).fetchall()}
     assert "autonomy_enabled" in preset_cols
     assert "area_labels" in slot_cols
     assert "expertise" in slot_cols
     assert "status_note" in work_item_cols
+    assert "auto_merged_at" in work_item_cols
+    assert "max_concurrent_dispatched" in scope_cols
+    assert "max_verification_retries" in scope_cols
+    assert "max_auto_merges_per_day" in scope_cols
     await engine.dispose()

--- a/backend/tests/agent_teams/test_github_verification_service.py
+++ b/backend/tests/agent_teams/test_github_verification_service.py
@@ -184,7 +184,6 @@ async def test_verify_green_code_pr_marks_ready_for_review(db):
     assert item.dispatch_status == "ready_for_review"
     assert client.ready_calls == 1
     assert client.pull_calls == 2
-    assert client.ready_calls == 1
 
 
 @pytest.mark.asyncio
@@ -231,6 +230,8 @@ async def test_combined_status_success_verifies_without_check_runs(db):
 
     await db.refresh(item)
     assert item.dispatch_status == "ready_for_review"
+    assert client.ready_calls == 1
+    assert client.pull_calls == 2
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_teams/test_github_verification_service.py
+++ b/backend/tests/agent_teams/test_github_verification_service.py
@@ -103,6 +103,7 @@ class _Client:
         *,
         pull=None,
         check_runs=None,
+        combined_status=None,
         merge_result=None,
         merge_error: httpx.HTTPStatusError | None = None,
     ):
@@ -115,16 +116,26 @@ class _Client:
             "head": {"sha": "sha"},
         }
         self.check_runs = check_runs if check_runs is not None else []
+        self.combined_status = (
+            combined_status
+            if combined_status is not None
+            else {"state": "pending", "statuses": []}
+        )
         self.merge_result = merge_result or {"merged": True}
         self.merge_error = merge_error
         self.ready_calls = 0
         self.merge_calls = 0
+        self.pull_calls = 0
 
     async def get_pull(self, owner, repo, pr_number):
+        self.pull_calls += 1
         return dict(self.pull)
 
     async def list_check_runs_for_ref(self, owner, repo, ref):
         return list(self.check_runs)
+
+    async def get_combined_status_for_ref(self, owner, repo, ref):
+        return dict(self.combined_status)
 
     async def mark_pull_ready_for_review(self, pull_node_id):
         self.ready_calls += 1
@@ -172,19 +183,69 @@ async def test_verify_green_code_pr_marks_ready_for_review(db):
     await db.refresh(item)
     assert item.dispatch_status == "ready_for_review"
     assert client.ready_calls == 1
+    assert client.pull_calls == 2
+    assert client.ready_calls == 1
 
 
 @pytest.mark.asyncio
 async def test_verify_zero_check_runs_escalates(db):
+    scope = await _scope(db)
+    item = await _item(
+        db,
+        scope,
+        dispatch_status="verifying",
+        pr_number=5,
+        updated_at=datetime.utcnow() - timedelta(minutes=5),
+    )
+
+    await github_verification_service.process_scope(db, scope, client=_Client(check_runs=[]))
+
+    await db.refresh(item)
+    assert item.dispatch_status == "escalated"
+    assert item.escalation_reason == "retry_count_exhausted"
+    assert "No GitHub check-runs or commit statuses" in item.status_note
+
+
+@pytest.mark.asyncio
+async def test_zero_check_runs_waits_during_grace_window(db):
     scope = await _scope(db)
     item = await _item(db, scope, dispatch_status="verifying", pr_number=5)
 
     await github_verification_service.process_scope(db, scope, client=_Client(check_runs=[]))
 
     await db.refresh(item)
+    assert item.dispatch_status == "verifying"
+    assert "Waiting for GitHub check-runs" in item.status_note
+
+
+@pytest.mark.asyncio
+async def test_combined_status_success_verifies_without_check_runs(db):
+    scope = await _scope(db)
+    item = await _item(db, scope, dispatch_status="verifying", pr_number=5)
+    client = _Client(
+        check_runs=[],
+        combined_status={"state": "success", "statuses": [{"context": "ci"}]},
+    )
+
+    await github_verification_service.process_scope(db, scope, client=client)
+
+    await db.refresh(item)
+    assert item.dispatch_status == "ready_for_review"
+
+
+@pytest.mark.asyncio
+async def test_unrecognized_check_conclusion_counts_as_failed(db):
+    scope = await _scope(db, max_verification_retries=0)
+    item = await _item(db, scope, dispatch_status="verifying", pr_number=5)
+    client = _Client(
+        check_runs=[{"name": "ci", "status": "completed", "conclusion": "startup_failure"}]
+    )
+
+    await github_verification_service.process_scope(db, scope, client=client)
+
+    await db.refresh(item)
     assert item.dispatch_status == "escalated"
-    assert item.escalation_reason == "no_check_runs"
-    assert "No GitHub check-runs" in item.status_note
+    assert item.escalation_reason == "retry_count_exhausted"
 
 
 @pytest.mark.asyncio
@@ -219,8 +280,33 @@ async def test_failed_check_returns_to_dispatched_until_budget_exhausted(db):
     await db.commit()
     await github_verification_service.process_scope(db, scope, client=client)
     await db.refresh(item)
+    assert item.dispatch_status == "dispatched"
+    assert item.retry_count == 2
+
+    item.dispatch_status = "verifying"
+    await db.commit()
+    await github_verification_service.process_scope(db, scope, client=client)
+    await db.refresh(item)
     assert item.dispatch_status == "escalated"
     assert item.escalation_reason == "retry_count_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_failed_check_dispatched_item_with_pr_is_reverified(db):
+    scope = await _scope(db, max_verification_retries=2)
+    item = await _item(db, scope, dispatch_status="verifying", pr_number=5)
+    client = _Client(
+        check_runs=[{"name": "ci", "status": "completed", "conclusion": "failure"}]
+    )
+
+    await github_verification_service.process_scope(db, scope, client=client)
+    await db.refresh(item)
+    assert item.dispatch_status == "dispatched"
+
+    client.check_runs = [{"name": "ci", "status": "completed", "conclusion": "success"}]
+    await github_verification_service.process_scope(db, scope, client=client)
+    await db.refresh(item)
+    assert item.dispatch_status == "ready_for_review"
 
 
 @pytest.mark.asyncio
@@ -274,6 +360,77 @@ async def test_durable_merge_failure_falls_back_to_human_without_escalation(db):
     assert item.escalation_reason is None
     assert "requires human merge" in item.status_note
     assert client.merge_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_unexpected_merge_status_is_transient_and_does_not_abort_batch(db):
+    scope = await _scope(db, merge_policy="auto", max_verification_retries=2)
+    first = await _item(db, scope, issue_number=1, dispatch_status="ready_for_review", pr_number=5)
+    second = await _item(db, scope, issue_number=2, dispatch_status="ready_for_review", pr_number=6)
+
+    class _BatchClient(_Client):
+        async def get_pull(self, owner, repo, pr_number):
+            return {
+                "number": pr_number,
+                "merged": False,
+                "mergeable_state": "clean",
+                "head": {"sha": f"sha-{pr_number}"},
+            }
+
+        async def merge_pull(self, owner, repo, pr_number):
+            self.merge_calls += 1
+            if pr_number == 5:
+                raise _http_error(422)
+            return {"merged": True}
+
+    client = _BatchClient()
+
+    await github_verification_service.process_scope(db, scope, client=client)
+
+    await db.refresh(first)
+    await db.refresh(second)
+    assert first.dispatch_status == "ready_for_review"
+    assert first.retry_count == 1
+    assert "Transient merge failure" in first.status_note
+    assert second.dispatch_status == "merged"
+
+
+@pytest.mark.asyncio
+async def test_draft_pr_is_refetched_before_auto_merge_decision(db):
+    scope = await _scope(db, merge_policy="auto")
+    item = await _item(db, scope, dispatch_status="verifying", pr_number=5)
+
+    class _DraftClient(_Client):
+        async def get_pull(self, owner, repo, pr_number):
+            self.pull_calls += 1
+            if self.pull_calls == 1:
+                return {
+                    "number": 5,
+                    "node_id": "node",
+                    "draft": True,
+                    "merged": False,
+                    "mergeable_state": "unknown",
+                    "head": {"sha": "sha"},
+                }
+            return {
+                "number": 5,
+                "node_id": "node",
+                "draft": False,
+                "merged": False,
+                "mergeable_state": "clean",
+                "head": {"sha": "sha"},
+            }
+
+    client = _DraftClient(
+        check_runs=[{"name": "ci", "status": "completed", "conclusion": "success"}]
+    )
+
+    await github_verification_service.process_scope(db, scope, client=client)
+
+    await db.refresh(item)
+    assert item.dispatch_status == "merged"
+    assert client.ready_calls == 1
+    assert client.pull_calls == 2
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_teams/test_github_verification_service.py
+++ b/backend/tests/agent_teams/test_github_verification_service.py
@@ -1,0 +1,292 @@
+"""GitHub PR verification and merge pipeline tests."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+import app.models.database  # noqa: F401
+from app.database import Base
+from app.models.database import (
+    AgentTeamPreset,
+    AgentTeamSlot,
+    GithubWorkItem,
+    MailMessage,
+    MailTeamMember,
+    TeamGithubScope,
+)
+from app.services.github_verification_service import github_verification_service
+
+
+@pytest_asyncio.fixture
+async def db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _scope(db, **kwargs):
+    preset = AgentTeamPreset(name="T", description="", created_by="t")
+    db.add(preset)
+    await db.flush()
+    values = {
+        "preset_id": preset.id,
+        "repo_owner": "o",
+        "repo_name": "r",
+        "repo_path": "/tmp/r",
+    }
+    values.update(kwargs)
+    scope = TeamGithubScope(
+        **values,
+    )
+    db.add(scope)
+    await db.flush()
+    return scope
+
+
+async def _item(db, scope, **kwargs):
+    values = {
+        "scope_id": scope.id,
+        "issue_number": 1,
+        "issue_title": "x",
+        "issue_url": "u",
+        "github_updated_at": datetime.utcnow(),
+        "dispatch_status": "dispatched",
+    }
+    values.update(kwargs)
+    item = GithubWorkItem(
+        **values,
+    )
+    db.add(item)
+    await db.commit()
+    return item
+
+
+async def _owner(db, scope):
+    slot = AgentTeamSlot(
+        preset_id=scope.preset_id,
+        position=0,
+        display_name="Owner",
+        provider="codex-cli",
+        repo_id="r",
+        repo_path="/tmp/r",
+        repo_name="r",
+    )
+    db.add(slot)
+    await db.flush()
+    member = MailTeamMember(
+        identity_key=f"slot:{slot.id}",
+        repo_id="r",
+        repo_path="/tmp/r",
+        repo_name="r",
+        display_name="Owner",
+        participant_kind="team_slot",
+        team_preset_id=scope.preset_id,
+        team_slot_id=slot.id,
+    )
+    db.add(member)
+    await db.flush()
+    return slot, member
+
+
+class _Client:
+    def __init__(
+        self,
+        *,
+        pull=None,
+        check_runs=None,
+        merge_result=None,
+        merge_error: httpx.HTTPStatusError | None = None,
+    ):
+        self.pull = pull or {
+            "number": 5,
+            "node_id": "node",
+            "draft": True,
+            "merged": False,
+            "mergeable_state": "clean",
+            "head": {"sha": "sha"},
+        }
+        self.check_runs = check_runs if check_runs is not None else []
+        self.merge_result = merge_result or {"merged": True}
+        self.merge_error = merge_error
+        self.ready_calls = 0
+        self.merge_calls = 0
+
+    async def get_pull(self, owner, repo, pr_number):
+        return dict(self.pull)
+
+    async def list_check_runs_for_ref(self, owner, repo, ref):
+        return list(self.check_runs)
+
+    async def mark_pull_ready_for_review(self, pull_node_id):
+        self.ready_calls += 1
+        return {"ok": True}
+
+    async def merge_pull(self, owner, repo, pr_number):
+        self.merge_calls += 1
+        if self.merge_error is not None:
+            raise self.merge_error
+        return self.merge_result
+
+
+def _http_error(status_code: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("PUT", "https://api.github.com/repos/o/r/pulls/5/merge")
+    response = httpx.Response(status_code, request=request, json={"message": "blocked"})
+    return httpx.HTTPStatusError("blocked", request=request, response=response)
+
+
+@pytest.mark.asyncio
+async def test_report_pr_opened_routes_code_and_design(db):
+    code_scope = await _scope(db)
+    design_scope = await _scope(db, repo_name="design")
+    code_item = await _item(db, code_scope, issue_type="code")
+    design_item = await _item(db, design_scope, issue_type="design")
+
+    await github_verification_service.report_pr_opened(db, code_item, code_scope, 10)
+    await github_verification_service.report_pr_opened(db, design_item, design_scope, 11)
+
+    await db.refresh(code_item)
+    await db.refresh(design_item)
+    assert code_item.pr_number == 10
+    assert code_item.dispatch_status == "verifying"
+    assert design_item.pr_number == 11
+    assert design_item.dispatch_status == "awaiting_human_review"
+
+
+@pytest.mark.asyncio
+async def test_verify_green_code_pr_marks_ready_for_review(db):
+    scope = await _scope(db)
+    item = await _item(db, scope, dispatch_status="verifying", pr_number=5)
+    client = _Client(check_runs=[{"name": "ci", "status": "completed", "conclusion": "success"}])
+
+    await github_verification_service.process_scope(db, scope, client=client)
+
+    await db.refresh(item)
+    assert item.dispatch_status == "ready_for_review"
+    assert client.ready_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_verify_zero_check_runs_escalates(db):
+    scope = await _scope(db)
+    item = await _item(db, scope, dispatch_status="verifying", pr_number=5)
+
+    await github_verification_service.process_scope(db, scope, client=_Client(check_runs=[]))
+
+    await db.refresh(item)
+    assert item.dispatch_status == "escalated"
+    assert item.escalation_reason == "no_check_runs"
+    assert "No GitHub check-runs" in item.status_note
+
+
+@pytest.mark.asyncio
+async def test_failed_check_returns_to_dispatched_until_budget_exhausted(db):
+    scope = await _scope(db, max_verification_retries=2)
+    slot, member = await _owner(db, scope)
+    item = await _item(
+        db,
+        scope,
+        dispatch_status="verifying",
+        pr_number=5,
+        retry_count=0,
+        owner_slot_id=slot.id,
+    )
+    client = _Client(
+        check_runs=[{"name": "ci", "status": "completed", "conclusion": "failure"}]
+    )
+
+    await github_verification_service.process_scope(db, scope, client=client)
+    await db.refresh(item)
+    assert item.dispatch_status == "dispatched"
+    assert item.retry_count == 1
+    messages = (await db.execute(select(MailMessage))).scalars().all()
+    assert any(
+        message.kind == "message"
+        and message.recipient_member_id == member.id
+        and "GitHub checks failed" in (message.subject or "")
+        for message in messages
+    )
+
+    item.dispatch_status = "verifying"
+    await db.commit()
+    await github_verification_service.process_scope(db, scope, client=client)
+    await db.refresh(item)
+    assert item.dispatch_status == "escalated"
+    assert item.escalation_reason == "retry_count_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_auto_merge_success_sets_merged_and_budget_timestamp(db):
+    scope = await _scope(db, merge_policy="auto")
+    item = await _item(db, scope, dispatch_status="ready_for_review", pr_number=5)
+    client = _Client()
+
+    await github_verification_service.process_scope(db, scope, client=client)
+
+    await db.refresh(item)
+    assert item.dispatch_status == "merged"
+    assert item.auto_merged_at is not None
+    assert client.merge_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_auto_merge_cap_falls_back_to_human_review(db):
+    scope = await _scope(db, merge_policy="auto", max_auto_merges_per_day=1)
+    await _item(
+        db,
+        scope,
+        issue_number=2,
+        dispatch_status="merged",
+        pr_number=4,
+        auto_merged_at=datetime.utcnow() - timedelta(minutes=5),
+    )
+    item = await _item(db, scope, dispatch_status="ready_for_review", pr_number=5)
+    client = _Client()
+
+    await github_verification_service.process_scope(db, scope, client=client)
+
+    await db.refresh(item)
+    assert item.dispatch_status == "ready_for_review"
+    assert item.escalation_reason is None
+    assert "Auto-merge budget exhausted" in item.status_note
+    assert client.merge_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_durable_merge_failure_falls_back_to_human_without_escalation(db):
+    scope = await _scope(db, merge_policy="auto")
+    item = await _item(db, scope, dispatch_status="ready_for_review", pr_number=5)
+    client = _Client(merge_error=_http_error(403))
+
+    await github_verification_service.process_scope(db, scope, client=client)
+    await github_verification_service.process_scope(db, scope, client=client)
+
+    await db.refresh(item)
+    assert item.dispatch_status == "ready_for_review"
+    assert item.escalation_reason is None
+    assert "requires human merge" in item.status_note
+    assert client.merge_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_transient_merge_failure_falls_back_to_human_after_budget(db):
+    scope = await _scope(db, merge_policy="auto", max_verification_retries=1)
+    item = await _item(db, scope, dispatch_status="ready_for_review", pr_number=5)
+    client = _Client(pull={"number": 5, "merged": False, "mergeable_state": "blocked"})
+
+    await github_verification_service.process_scope(db, scope, client=client)
+    await github_verification_service.process_scope(db, scope, client=client)
+
+    await db.refresh(item)
+    assert item.dispatch_status == "ready_for_review"
+    assert item.escalation_reason is None
+    assert "Auto-merge retry budget exhausted" in item.status_note
+    assert client.merge_calls == 0

--- a/backend/tests/agent_teams/test_github_watcher_service.py
+++ b/backend/tests/agent_teams/test_github_watcher_service.py
@@ -72,6 +72,8 @@ async def test_github_client_pr_check_and_merge_requests():
             )
         if request.url.path == "/repos/o/r/commits/abc/check-runs":
             return httpx.Response(200, json={"check_runs": [{"name": "ci", "conclusion": "success"}]})
+        if request.url.path == "/repos/o/r/commits/abc/status":
+            return httpx.Response(200, json={"state": "success", "statuses": [{"context": "ci"}]})
         if request.url.path == "/graphql":
             return httpx.Response(200, json={"data": {"markPullRequestReadyForReview": {"pullRequest": {"id": "PR_node"}}}})
         if request.url.path == "/repos/o/r/pulls/5/merge":
@@ -85,11 +87,13 @@ async def test_github_client_pr_check_and_merge_requests():
         client = GithubClient(http=http, token="tok")
         pull = await client.get_pull("o", "r", 5)
         checks = await client.list_check_runs_for_ref("o", "r", "abc")
+        status = await client.get_combined_status_for_ref("o", "r", "abc")
         ready = await client.mark_pull_ready_for_review("PR_node")
         merged = await client.merge_pull("o", "r", 5)
 
     assert pull["head"]["sha"] == "abc"
     assert checks[0]["name"] == "ci"
+    assert status["state"] == "success"
     assert ready["data"]["markPullRequestReadyForReview"]["pullRequest"]["id"] == "PR_node"
     assert merged["merged"] is True
 

--- a/backend/tests/agent_teams/test_github_watcher_service.py
+++ b/backend/tests/agent_teams/test_github_watcher_service.py
@@ -55,6 +55,38 @@ async def test_list_issues_with_label_builds_request():
     assert issues[0]["number"] == 42
 
 
+@pytest.mark.asyncio
+async def test_github_client_pr_check_and_merge_requests():
+    def handler(request):
+        if request.url.path == "/repos/o/r/pulls/5" and request.method == "GET":
+            return httpx.Response(
+                200,
+                json={"number": 5, "node_id": "PR_node", "head": {"sha": "abc"}, "merged": False},
+            )
+        if request.url.path == "/repos/o/r/commits/abc/check-runs":
+            return httpx.Response(200, json={"check_runs": [{"name": "ci", "conclusion": "success"}]})
+        if request.url.path == "/graphql":
+            return httpx.Response(200, json={"data": {"markPullRequestReadyForReview": {"pullRequest": {"id": "PR_node"}}}})
+        if request.url.path == "/repos/o/r/pulls/5/merge":
+            return httpx.Response(200, json={"merged": True})
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    transport = _RecordingTransport(handler)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://api.github.com"
+    ) as http:
+        client = GithubClient(http=http, token="tok")
+        pull = await client.get_pull("o", "r", 5)
+        checks = await client.list_check_runs_for_ref("o", "r", "abc")
+        ready = await client.mark_pull_ready_for_review("PR_node")
+        merged = await client.merge_pull("o", "r", 5)
+
+    assert pull["head"]["sha"] == "abc"
+    assert checks[0]["name"] == "ci"
+    assert ready["data"]["markPullRequestReadyForReview"]["pullRequest"]["id"] == "PR_node"
+    assert merged["merged"] is True
+
+
 @pytest_asyncio.fixture
 async def db():
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")

--- a/backend/tests/agent_teams/test_github_watcher_service.py
+++ b/backend/tests/agent_teams/test_github_watcher_service.py
@@ -9,7 +9,14 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 import app.models.database  # noqa: F401
 from app.database import Base
-from app.models.database import AgentTeamPreset, GithubWorkItem, TeamGithubScope
+from app.models.database import (
+    AgentTeamPreset,
+    AgentTeamSlot,
+    GithubWorkItem,
+    MailMessage,
+    MailTeamMember,
+    TeamGithubScope,
+)
 from app.services.github_client import GithubClient
 from app.services.github_watcher_service import github_watcher_service
 
@@ -223,6 +230,54 @@ async def test_active_item_escalates_when_label_removed(db):
     await db.refresh(item)
     assert item.dispatch_status == "escalated"
     assert item.escalation_reason == "dispatch_label_removed"
+
+
+@pytest.mark.asyncio
+async def test_label_removed_sends_broadcast_and_owner_direct_message(db):
+    scope = await _make_scope(db)
+    slot = AgentTeamSlot(
+        preset_id=scope.preset_id,
+        position=0,
+        display_name="Owner",
+        provider="codex-cli",
+        repo_id="r",
+        repo_path="/tmp/r",
+        repo_name="r",
+    )
+    db.add(slot)
+    await db.flush()
+    member = MailTeamMember(
+        identity_key="slot:owner",
+        repo_id="r",
+        repo_path="/tmp/r",
+        repo_name="r",
+        display_name="Owner",
+        participant_kind="team_slot",
+        team_preset_id=scope.preset_id,
+        team_slot_id=slot.id,
+    )
+    db.add(member)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=9,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime(2026, 7, 1),
+        dispatch_status="dispatched",
+        owner_slot_id=slot.id,
+    )
+    db.add(item)
+    await db.commit()
+    client = _FakeClient(labeled=[], by_number={9: _issue(9, ["some-other-label"])})
+
+    await github_watcher_service.poll_scope(db, scope, client)
+
+    messages = (await db.execute(select(MailMessage))).scalars().all()
+    assert any(message.kind == "broadcast" for message in messages)
+    assert any(
+        message.kind == "message" and message.recipient_member_id == member.id
+        for message in messages
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds GitHub PR verification for code items, design PR human-review routing, draft-ready promotion, and merge-policy handling.
- Enforces Phase B guardrails: per-scope concurrency, verification/merge retry budget, and auto-merge daily cap.
- Consolidates dispatch escalations through one helper and sends Agent Mail broadcasts plus owner-directed label-removal / CI-failure messages.
- Adds hosted APScheduler wiring, gated by `AgentTeamPreset.autonomy_enabled`, with one interval job per distinct watched repo.

Refs #275

## Deferred
- Deck-visible UI rows for escalation reasons remain Phase C, as scoped in #275.

## Validation
- `cd backend && source venv/bin/activate && pytest tests/agent_teams tests/agent_mail -q` — 209 passed.
- `cd backend && source venv/bin/activate && pytest tests/agent_teams/test_github_verification_service.py tests/agent_teams/test_github_dispatch_service.py tests/agent_teams/test_github_watcher_service.py tests/agent_teams/test_github_dispatch_scheduler.py tests/agent_mail/test_dispatch_status_tool.py tests/agent_teams/test_github_scope_models.py tests/agent_teams/test_github_watcher_service.py::test_github_client_pr_check_and_merge_requests -q` — 48 passed.
- `cd backend && source venv/bin/activate && python -m compileall -q app` — passed.
- `cd backend && source venv/bin/activate && python -c "from app.main import app; print(app.title)"` — passed.

## Known unrelated failure
- Full `cd backend && source venv/bin/activate && pytest -q` still fails at `tests/test_multi_provider_smoke.py::test_agent_bridge_session_filter_smoke`; this is the pre-existing async test issue where `agent_bridge_api.list_sessions()` is called without awaiting it.