### PR TITLE
Autonomous GitHub Dispatch Phase C

### DIFF
--- a/backend/app/api/v1/agent_teams.py
+++ b/backend/app/api/v1/agent_teams.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from fastapi.encoders import jsonable_encoder
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
@@ -23,7 +25,14 @@ from app.models.schemas import (
     AgentTeamSlotReorderRequest,
     AgentTeamSlotUpdate,
     DispatchStatusReport,
+    GithubWorkItemListResponse,
+    GithubWorkItemResponse,
+    TeamGithubScopeCreate,
+    TeamGithubScopeListResponse,
+    TeamGithubScopeResponse,
+    TeamGithubScopeUpdate,
 )
+from app.services.github_dispatch_scheduler import github_dispatch_scheduler
 from app.services.github_dispatch_service import github_dispatch_service
 from app.services.github_verification_service import github_verification_service
 from app.services.agent_team_service import PlanConflictError, agent_team_service
@@ -39,6 +48,108 @@ def _bad_request(exc: ValueError) -> HTTPException:
             detail={"message": str(exc), "block_code": exc.block_code},
         )
     return HTTPException(status_code=400, detail=str(exc))
+
+
+def _clean_required(value: str | None, label: str) -> str:
+    text = (value or "").strip()
+    if not text:
+        raise ValueError(f"{label} is required")
+    return text
+
+
+def _clean_repo_part(value: str | None, label: str) -> str:
+    text = _clean_required(value, label)
+    if any(char.isspace() for char in text) or "/" in text:
+        raise ValueError(f"{label} must not contain whitespace or slash")
+    return text
+
+
+def _clean_label(value: str | None, label: str) -> str:
+    return _clean_required(value, label)
+
+
+def _scope_response(scope: TeamGithubScope) -> TeamGithubScopeResponse:
+    return TeamGithubScopeResponse(
+        id=scope.id,
+        preset_id=scope.preset_id,
+        repo_owner=scope.repo_owner,
+        repo_name=scope.repo_name,
+        repo_path=scope.repo_path,
+        dispatch_label=scope.dispatch_label,
+        design_label=scope.design_label,
+        merge_policy=scope.merge_policy,
+        max_approval_rounds=scope.max_approval_rounds,
+        max_concurrent_dispatched=scope.max_concurrent_dispatched,
+        max_verification_retries=scope.max_verification_retries,
+        max_auto_merges_per_day=scope.max_auto_merges_per_day,
+        enabled=scope.enabled,
+        last_polled_at=scope.last_polled_at,
+        created_at=scope.created_at,
+        updated_at=scope.updated_at,
+    )
+
+
+def _work_item_response(item: GithubWorkItem, scope: TeamGithubScope) -> GithubWorkItemResponse:
+    return GithubWorkItemResponse(
+        id=item.id,
+        scope_id=item.scope_id,
+        repo_owner=scope.repo_owner,
+        repo_name=scope.repo_name,
+        issue_number=item.issue_number,
+        issue_title=item.issue_title,
+        issue_url=item.issue_url,
+        github_updated_at=item.github_updated_at,
+        issue_type=item.issue_type,
+        dispatch_status=item.dispatch_status,
+        pending_reason=item.pending_reason,
+        launch_id=item.launch_id,
+        owner_slot_id=item.owner_slot_id,
+        routing_method=item.routing_method,
+        handoff_state=item.handoff_state,
+        handoff_target_slot_id=item.handoff_target_slot_id,
+        approval_round_count=item.approval_round_count,
+        pr_number=item.pr_number,
+        retry_count=item.retry_count,
+        escalation_reason=item.escalation_reason,
+        status_note=item.status_note,
+        auto_merged_at=item.auto_merged_at,
+        created_at=item.created_at,
+        updated_at=item.updated_at,
+    )
+
+
+async def _sync_github_jobs(db: AsyncSession) -> None:
+    await github_dispatch_scheduler.sync_jobs(db)
+
+
+def _apply_scope_create(
+    scope: TeamGithubScope,
+    request: TeamGithubScopeCreate | TeamGithubScopeUpdate,
+) -> None:
+    if request.repo_owner is not None:
+        scope.repo_owner = _clean_repo_part(request.repo_owner, "Repo owner")
+    if request.repo_name is not None:
+        scope.repo_name = _clean_repo_part(request.repo_name, "Repo name")
+    if request.repo_path is not None:
+        repo_path, _ = agent_team_service._normalize_repo(request.repo_path)
+        scope.repo_path = repo_path
+    if request.dispatch_label is not None:
+        scope.dispatch_label = _clean_label(request.dispatch_label, "Dispatch label")
+    if request.design_label is not None:
+        scope.design_label = _clean_label(request.design_label, "Design label")
+    if request.merge_policy is not None:
+        scope.merge_policy = request.merge_policy
+    if request.max_approval_rounds is not None:
+        scope.max_approval_rounds = request.max_approval_rounds
+    if request.max_concurrent_dispatched is not None:
+        scope.max_concurrent_dispatched = request.max_concurrent_dispatched
+    if request.max_verification_retries is not None:
+        scope.max_verification_retries = request.max_verification_retries
+    if request.max_auto_merges_per_day is not None:
+        scope.max_auto_merges_per_day = request.max_auto_merges_per_day
+    if request.enabled is not None:
+        scope.enabled = request.enabled
+    scope.updated_at = datetime.utcnow()
 
 
 @router.post("/dispatch-status")
@@ -149,23 +260,161 @@ async def update_preset(
     db: AsyncSession = Depends(get_db),
 ):
     try:
-        return await agent_team_service.update_preset(
+        response = await agent_team_service.update_preset(
             db,
             preset_id,
             name=request.name,
             description=request.description,
+            autonomy_enabled=request.autonomy_enabled,
         )
     except ValueError as exc:
         raise _bad_request(exc) from exc
+    if request.autonomy_enabled is not None:
+        await _sync_github_jobs(db)
+    return response
 
 
 @router.delete("/presets/{preset_id}", status_code=204)
 async def delete_preset(preset_id: int, db: AsyncSession = Depends(get_db)):
     try:
         await agent_team_service.delete_preset(db, preset_id)
+        await _sync_github_jobs(db)
         return Response(status_code=204)
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.get(
+    "/presets/{preset_id}/github-scopes",
+    response_model=TeamGithubScopeListResponse,
+)
+async def list_github_scopes(preset_id: int, db: AsyncSession = Depends(get_db)):
+    try:
+        await agent_team_service._require_preset(db, preset_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    scopes = (
+        await db.execute(
+            select(TeamGithubScope)
+            .where(TeamGithubScope.preset_id == preset_id)
+            .order_by(TeamGithubScope.repo_owner, TeamGithubScope.repo_name, TeamGithubScope.id)
+        )
+    ).scalars().all()
+    return TeamGithubScopeListResponse(scopes=[_scope_response(scope) for scope in scopes])
+
+
+@router.post(
+    "/presets/{preset_id}/github-scopes",
+    response_model=TeamGithubScopeResponse,
+)
+async def create_github_scope(
+    preset_id: int,
+    request: TeamGithubScopeCreate,
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        await agent_team_service._require_preset(db, preset_id)
+        scope = TeamGithubScope(
+            preset_id=preset_id,
+            repo_owner="",
+            repo_name="",
+            repo_path="",
+        )
+        _apply_scope_create(scope, request)
+        db.add(scope)
+        await db.commit()
+        await db.refresh(scope)
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="GitHub scope already exists for this repo") from exc
+    except ValueError as exc:
+        raise _bad_request(exc) from exc
+    await _sync_github_jobs(db)
+    return _scope_response(scope)
+
+
+@router.patch("/github-scopes/{scope_id}", response_model=TeamGithubScopeResponse)
+async def update_github_scope(
+    scope_id: int,
+    request: TeamGithubScopeUpdate,
+    db: AsyncSession = Depends(get_db),
+):
+    scope = await db.get(TeamGithubScope, scope_id)
+    if scope is None:
+        raise HTTPException(status_code=404, detail="GitHub scope not found")
+    try:
+        _apply_scope_create(scope, request)
+        await db.commit()
+        await db.refresh(scope)
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="GitHub scope already exists for this repo") from exc
+    except ValueError as exc:
+        raise _bad_request(exc) from exc
+    await _sync_github_jobs(db)
+    return _scope_response(scope)
+
+
+@router.delete("/github-scopes/{scope_id}", status_code=204)
+async def delete_github_scope(scope_id: int, db: AsyncSession = Depends(get_db)):
+    scope = await db.get(TeamGithubScope, scope_id)
+    if scope is None:
+        raise HTTPException(status_code=404, detail="GitHub scope not found")
+    await db.delete(scope)
+    await db.commit()
+    await _sync_github_jobs(db)
+    return Response(status_code=204)
+
+
+@router.get(
+    "/presets/{preset_id}/github-work-items",
+    response_model=GithubWorkItemListResponse,
+)
+async def list_github_work_items(
+    preset_id: int,
+    limit: int = Query(default=50, ge=1, le=200),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        await agent_team_service._require_preset(db, preset_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    rows = (
+        await db.execute(
+            select(GithubWorkItem, TeamGithubScope)
+            .join(TeamGithubScope, TeamGithubScope.id == GithubWorkItem.scope_id)
+            .where(TeamGithubScope.preset_id == preset_id)
+            .order_by(GithubWorkItem.updated_at.desc(), GithubWorkItem.id.desc())
+            .limit(limit)
+        )
+    ).all()
+    return GithubWorkItemListResponse(
+        items=[_work_item_response(item, scope) for item, scope in rows]
+    )
+
+
+@router.post(
+    "/github-work-items/{work_item_id}/retry",
+    response_model=GithubWorkItemResponse,
+)
+async def retry_github_work_item(work_item_id: int, db: AsyncSession = Depends(get_db)):
+    item = await db.get(GithubWorkItem, work_item_id)
+    if item is None:
+        raise HTTPException(status_code=404, detail="GitHub work item not found")
+    scope = await db.get(TeamGithubScope, item.scope_id)
+    if scope is None:
+        raise HTTPException(status_code=404, detail="GitHub scope not found")
+    if item.dispatch_status != "escalated":
+        raise HTTPException(status_code=409, detail="Only escalated work items can be retried")
+    item.dispatch_status = "pending"
+    item.escalation_reason = None
+    item.pending_reason = None
+    item.retry_count = 0
+    item.approval_round_count = 0
+    item.updated_at = datetime.utcnow()
+    await db.commit()
+    await db.refresh(item)
+    return _work_item_response(item, scope)
 
 
 @router.post("/presets/{preset_id}/duplicate", response_model=AgentTeamPresetResponse)

--- a/backend/app/api/v1/agent_teams.py
+++ b/backend/app/api/v1/agent_teams.py
@@ -131,7 +131,7 @@ def _apply_scope_create(
     if request.repo_name is not None:
         scope.repo_name = _clean_repo_part(request.repo_name, "Repo name")
     if request.repo_path is not None:
-        repo_path, _ = agent_team_service._normalize_repo(request.repo_path)
+        repo_path, _ = agent_team_service.normalize_repo_path(request.repo_path)
         scope.repo_path = repo_path
     if request.dispatch_label is not None:
         scope.dispatch_label = _clean_label(request.dispatch_label, "Dispatch label")
@@ -290,7 +290,7 @@ async def delete_preset(preset_id: int, db: AsyncSession = Depends(get_db)):
 )
 async def list_github_scopes(preset_id: int, db: AsyncSession = Depends(get_db)):
     try:
-        await agent_team_service._require_preset(db, preset_id)
+        await agent_team_service.require_preset_row(db, preset_id)
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     scopes = (
@@ -313,7 +313,10 @@ async def create_github_scope(
     db: AsyncSession = Depends(get_db),
 ):
     try:
-        await agent_team_service._require_preset(db, preset_id)
+        await agent_team_service.require_preset_row(db, preset_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    try:
         scope = TeamGithubScope(
             preset_id=preset_id,
             repo_owner="",
@@ -376,7 +379,7 @@ async def list_github_work_items(
     db: AsyncSession = Depends(get_db),
 ):
     try:
-        await agent_team_service._require_preset(db, preset_id)
+        await agent_team_service.require_preset_row(db, preset_id)
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     rows = (
@@ -406,12 +409,7 @@ async def retry_github_work_item(work_item_id: int, db: AsyncSession = Depends(g
         raise HTTPException(status_code=404, detail="GitHub scope not found")
     if item.dispatch_status != "escalated":
         raise HTTPException(status_code=409, detail="Only escalated work items can be retried")
-    item.dispatch_status = "pending"
-    item.escalation_reason = None
-    item.pending_reason = None
-    item.retry_count = 0
-    item.approval_round_count = 0
-    item.updated_at = datetime.utcnow()
+    github_dispatch_service.reset_for_retry(item)
     await db.commit()
     await db.refresh(item)
     return _work_item_response(item, scope)

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -2062,6 +2062,8 @@ class AgentTeamSlotCreate(BaseModel):
     bootstrap_prompt: Optional[str] = None
     launch_mode: str = "plain"
     launch_options: Dict[str, Any] = Field(default_factory=dict)
+    area_labels: Optional[List[str]] = None
+    expertise: Optional[str] = None
     enabled: bool = True
     position: Optional[int] = None
 
@@ -2076,6 +2078,8 @@ class AgentTeamSlotUpdate(BaseModel):
     bootstrap_prompt: Optional[str] = None
     launch_mode: Optional[str] = None
     launch_options: Optional[Dict[str, Any]] = None
+    area_labels: Optional[List[str]] = None
+    expertise: Optional[str] = None
     enabled: Optional[bool] = None
     position: Optional[int] = None
 
@@ -2095,6 +2099,8 @@ class AgentTeamSlotResponse(BaseModel):
     bootstrap_prompt: Optional[str] = None
     launch_mode: str
     launch_options: Dict[str, Any] = Field(default_factory=dict)
+    area_labels: Optional[List[str]] = None
+    expertise: Optional[str] = None
     warnings: List[str] = Field(default_factory=list)
     enabled: bool
     created_at: datetime
@@ -2111,6 +2117,7 @@ class AgentTeamPresetCreate(BaseModel):
 class AgentTeamPresetUpdate(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
+    autonomy_enabled: Optional[bool] = None
 
 
 class AgentTeamPresetResponse(BaseModel):
@@ -2120,6 +2127,7 @@ class AgentTeamPresetResponse(BaseModel):
     created_by: Optional[str] = None
     created_at: datetime
     updated_at: datetime
+    autonomy_enabled: bool = False
     slots: List[AgentTeamSlotResponse] = Field(default_factory=list)
 
 
@@ -2141,6 +2149,88 @@ class AgentTeamCreateFromBridgeRequest(BaseModel):
 
 class AgentTeamSlotReorderRequest(BaseModel):
     slot_ids: List[int]
+
+
+class TeamGithubScopeCreate(BaseModel):
+    repo_owner: str
+    repo_name: str
+    repo_path: str
+    dispatch_label: str = "claude-deck-ready"
+    design_label: str = "claude-deck-design"
+    merge_policy: Literal["human", "auto"] = "human"
+    max_approval_rounds: int = Field(default=3, ge=1)
+    max_concurrent_dispatched: int = Field(default=3, ge=1)
+    max_verification_retries: int = Field(default=2, ge=0)
+    max_auto_merges_per_day: int = Field(default=5, ge=0)
+    enabled: bool = True
+
+
+class TeamGithubScopeUpdate(BaseModel):
+    repo_owner: Optional[str] = None
+    repo_name: Optional[str] = None
+    repo_path: Optional[str] = None
+    dispatch_label: Optional[str] = None
+    design_label: Optional[str] = None
+    merge_policy: Optional[Literal["human", "auto"]] = None
+    max_approval_rounds: Optional[int] = Field(default=None, ge=1)
+    max_concurrent_dispatched: Optional[int] = Field(default=None, ge=1)
+    max_verification_retries: Optional[int] = Field(default=None, ge=0)
+    max_auto_merges_per_day: Optional[int] = Field(default=None, ge=0)
+    enabled: Optional[bool] = None
+
+
+class TeamGithubScopeResponse(BaseModel):
+    id: int
+    preset_id: int
+    repo_owner: str
+    repo_name: str
+    repo_path: str
+    dispatch_label: str
+    design_label: str
+    merge_policy: str
+    max_approval_rounds: int
+    max_concurrent_dispatched: int
+    max_verification_retries: int
+    max_auto_merges_per_day: int
+    enabled: bool
+    last_polled_at: Optional[datetime] = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class TeamGithubScopeListResponse(BaseModel):
+    scopes: List[TeamGithubScopeResponse] = Field(default_factory=list)
+
+
+class GithubWorkItemResponse(BaseModel):
+    id: int
+    scope_id: int
+    repo_owner: str
+    repo_name: str
+    issue_number: int
+    issue_title: str
+    issue_url: str
+    github_updated_at: datetime
+    issue_type: str
+    dispatch_status: str
+    pending_reason: Optional[str] = None
+    launch_id: Optional[int] = None
+    owner_slot_id: Optional[int] = None
+    routing_method: Optional[str] = None
+    handoff_state: Optional[str] = None
+    handoff_target_slot_id: Optional[int] = None
+    approval_round_count: int
+    pr_number: Optional[int] = None
+    retry_count: int
+    escalation_reason: Optional[str] = None
+    status_note: Optional[str] = None
+    auto_merged_at: Optional[datetime] = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class GithubWorkItemListResponse(BaseModel):
+    items: List[GithubWorkItemResponse] = Field(default_factory=list)
 
 
 class AgentTeamLaunchPlanItem(BaseModel):

--- a/backend/app/services/agent_team_service.py
+++ b/backend/app/services/agent_team_service.py
@@ -110,6 +110,7 @@ class AgentTeamService:
         preset_id: int,
         name: str | None = None,
         description: str | None = None,
+        autonomy_enabled: bool | None = None,
     ) -> AgentTeamPresetResponse:
         preset = await self._require_preset(db, preset_id)
         if name is not None:
@@ -118,6 +119,8 @@ class AgentTeamService:
             preset.name = cleaned_name
         if description is not None:
             preset.description = self._clean_optional(description)
+        if autonomy_enabled is not None:
+            preset.autonomy_enabled = autonomy_enabled
         preset.updated_at = datetime.utcnow()
         await db.commit()
         await db.refresh(preset)
@@ -175,9 +178,12 @@ class AgentTeamService:
                     repo_name=slot.repo_name,
                     role=slot.role,
                     charter=slot.charter,
+                    ui_color=slot.ui_color,
                     bootstrap_prompt=slot.bootstrap_prompt,
                     launch_mode=slot.launch_mode,
                     launch_options=slot.launch_options or {},
+                    area_labels=slot.area_labels,
+                    expertise=slot.expertise,
                     enabled=slot.enabled,
                 )
             )
@@ -332,6 +338,10 @@ class AgentTeamService:
             updates["ui_color"] = self._clean_ui_color(request.ui_color)
         if request.bootstrap_prompt is not None:
             updates["bootstrap_prompt"] = self._clean_optional(request.bootstrap_prompt)
+        if "area_labels" in request.model_fields_set:
+            updates["area_labels"] = self._clean_area_labels(request.area_labels)
+        if request.expertise is not None:
+            updates["expertise"] = self._clean_optional(request.expertise)
         if request.launch_mode is not None:
             updates["launch_mode"] = request.launch_mode.strip() or "plain"
         if request.launch_options is not None:
@@ -1122,6 +1132,7 @@ class AgentTeamService:
             created_by=preset.created_by,
             created_at=preset.created_at,
             updated_at=preset.updated_at,
+            autonomy_enabled=preset.autonomy_enabled,
             slots=[self._slot_response(slot) for slot in slots],
         )
 
@@ -1141,6 +1152,8 @@ class AgentTeamService:
             bootstrap_prompt=slot.bootstrap_prompt,
             launch_mode=slot.launch_mode,
             launch_options=slot.launch_options or {},
+            area_labels=slot.area_labels,
+            expertise=slot.expertise,
             warnings=self._slot_launch_warnings(slot.provider, slot.launch_options or {}),
             enabled=slot.enabled,
             created_at=slot.created_at,
@@ -1226,6 +1239,8 @@ class AgentTeamService:
             "bootstrap_prompt": self._clean_optional(slot.bootstrap_prompt),
             "launch_mode": launch_mode,
             "launch_options": launch_options,
+            "area_labels": self._clean_area_labels(slot.area_labels),
+            "expertise": self._clean_optional(slot.expertise),
             "enabled": slot.enabled,
         }
 
@@ -1388,6 +1403,19 @@ class AgentTeamService:
             allowed = ", ".join(sorted(_TEAM_SLOT_UI_COLORS))
             raise ValueError(f"Unsupported ui_color: {color}. Expected one of: {allowed}")
         return color
+
+    def _clean_area_labels(self, value: list[str] | None) -> list[str] | None:
+        if value is None:
+            return None
+        labels: list[str] = []
+        seen: set[str] = set()
+        for raw_label in value:
+            label = self._clean_optional(raw_label)
+            if label is None or label in seen:
+                continue
+            labels.append(label)
+            seen.add(label)
+        return labels or None
 
 
 agent_team_service = AgentTeamService()

--- a/backend/app/services/agent_team_service.py
+++ b/backend/app/services/agent_team_service.py
@@ -80,6 +80,12 @@ class AgentTeamService:
         preset = await self._require_preset(db, preset_id)
         return await self._preset_response(db, preset)
 
+    async def require_preset_row(self, db: AsyncSession, preset_id: int) -> AgentTeamPreset:
+        return await self._require_preset(db, preset_id)
+
+    def normalize_repo_path(self, repo_path: str) -> tuple[str, dict[str, str]]:
+        return self._normalize_repo(repo_path)
+
     async def create_preset(
         self, db: AsyncSession, request: AgentTeamPresetCreate
     ) -> AgentTeamPresetResponse:

--- a/backend/app/services/github_dispatch_service.py
+++ b/backend/app/services/github_dispatch_service.py
@@ -18,6 +18,16 @@ logger = logging.getLogger(__name__)
 
 
 class GithubDispatchService:
+    def reset_for_retry(self, item: GithubWorkItem) -> None:
+        item.dispatch_status = "pending"
+        item.escalation_reason = None
+        item.pending_reason = None
+        item.handoff_state = None
+        item.handoff_target_slot_id = None
+        item.retry_count = 0
+        item.approval_round_count = 0
+        item.updated_at = datetime.utcnow()
+
     async def route_item(
         self,
         db: AsyncSession,

--- a/backend/app/services/github_watcher_service.py
+++ b/backend/app/services/github_watcher_service.py
@@ -63,11 +63,7 @@ class GithubWatcherService:
             existing.dispatch_status in _RECOVERABLE_STATUSES
             and github_updated_at > existing.github_updated_at
         ):
-            existing.dispatch_status = "pending"
-            existing.escalation_reason = None
-            existing.pending_reason = None
-            existing.retry_count = 0
-            existing.approval_round_count = 0
+            github_dispatch_service.reset_for_retry(existing)
         if existing.dispatch_status == "pending":
             existing.issue_type = issue_type
         existing.github_updated_at = github_updated_at

--- a/backend/tests/agent_teams/test_agent_team_api.py
+++ b/backend/tests/agent_teams/test_agent_team_api.py
@@ -1,4 +1,5 @@
 """HTTP contract tests for Agent Team presets."""
+from datetime import datetime
 from types import SimpleNamespace
 
 import httpx
@@ -7,6 +8,7 @@ import pytest_asyncio
 
 from app.database import get_db
 from app.main import app
+from app.models.database import GithubWorkItem, TeamGithubScope
 from app.models.schemas import AgentTeamPresetCreate, AgentTeamSlotCreate
 from app.services.agent_team_service import agent_team_service
 
@@ -111,3 +113,211 @@ async def test_create_preset_validation_error_includes_block_code(client, tmp_pa
     detail = response.json()["detail"]
     assert detail["message"] == "opencode-cli does not support reasoning_effort"
     assert detail["block_code"] == "reasoning_effort_unsupported"
+
+
+@pytest.mark.asyncio
+async def test_preset_autonomy_and_slot_routing_fields_round_trip(client, monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    sync_calls = 0
+
+    async def fake_sync(_db):
+        nonlocal sync_calls
+        sync_calls += 1
+
+    monkeypatch.setattr("app.api.v1.agent_teams._sync_github_jobs", fake_sync)
+
+    response = await client.post(
+        "/api/v1/agent-teams/presets",
+        json={
+            "name": "Autonomy team",
+            "slots": [
+                {
+                    "display_name": "Backend SME",
+                    "provider": "codex-cli",
+                    "repo_path": str(repo),
+                    "area_labels": ["area:backend", "area:api", "area:backend"],
+                    "expertise": "Owns the API",
+                }
+            ],
+        },
+    )
+    assert response.status_code == 200
+    preset = response.json()
+    assert preset["autonomy_enabled"] is False
+    slot = preset["slots"][0]
+    assert slot["area_labels"] == ["area:backend", "area:api"]
+    assert slot["expertise"] == "Owns the API"
+
+    response = await client.patch(
+        f"/api/v1/agent-teams/presets/{preset['id']}",
+        json={"autonomy_enabled": True},
+    )
+    assert response.status_code == 200
+    assert response.json()["autonomy_enabled"] is True
+    assert sync_calls == 1
+
+    response = await client.patch(
+        f"/api/v1/agent-teams/slots/{slot['id']}",
+        json={"area_labels": ["area:frontend"], "expertise": "Owns UI"},
+    )
+    assert response.status_code == 200
+    updated_slot = response.json()["slots"][0]
+    assert updated_slot["area_labels"] == ["area:frontend"]
+    assert updated_slot["expertise"] == "Owns UI"
+
+
+@pytest.mark.asyncio
+async def test_github_scope_crud_endpoints(client, monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    sync_calls = 0
+
+    async def fake_sync(_db):
+        nonlocal sync_calls
+        sync_calls += 1
+
+    monkeypatch.setattr("app.api.v1.agent_teams._sync_github_jobs", fake_sync)
+
+    preset_response = await client.post(
+        "/api/v1/agent-teams/presets",
+        json={"name": "Scope team", "slots": []},
+    )
+    preset_id = preset_response.json()["id"]
+
+    create_response = await client.post(
+        f"/api/v1/agent-teams/presets/{preset_id}/github-scopes",
+        json={
+            "repo_owner": "adrirubio",
+            "repo_name": "snazzyemail",
+            "repo_path": str(repo),
+            "dispatch_label": "deck-ready",
+            "design_label": "deck-design",
+            "merge_policy": "auto",
+            "max_approval_rounds": 4,
+            "max_concurrent_dispatched": 2,
+            "max_verification_retries": 3,
+            "max_auto_merges_per_day": 1,
+            "enabled": True,
+        },
+    )
+    assert create_response.status_code == 200
+    scope = create_response.json()
+    assert scope["repo_owner"] == "adrirubio"
+    assert scope["merge_policy"] == "auto"
+    assert scope["max_verification_retries"] == 3
+
+    list_response = await client.get(
+        f"/api/v1/agent-teams/presets/{preset_id}/github-scopes"
+    )
+    assert list_response.status_code == 200
+    assert [item["id"] for item in list_response.json()["scopes"]] == [scope["id"]]
+
+    update_response = await client.patch(
+        f"/api/v1/agent-teams/github-scopes/{scope['id']}",
+        json={"merge_policy": "human", "enabled": False},
+    )
+    assert update_response.status_code == 200
+    assert update_response.json()["merge_policy"] == "human"
+    assert update_response.json()["enabled"] is False
+
+    delete_response = await client.delete(
+        f"/api/v1/agent-teams/github-scopes/{scope['id']}"
+    )
+    assert delete_response.status_code == 204
+    assert sync_calls == 3
+
+
+@pytest.mark.asyncio
+async def test_github_scope_rejects_invalid_repo_path(client, tmp_path):
+    preset_response = await client.post(
+        "/api/v1/agent-teams/presets",
+        json={"name": "Invalid scope team", "slots": []},
+    )
+    preset_id = preset_response.json()["id"]
+
+    response = await client.post(
+        f"/api/v1/agent-teams/presets/{preset_id}/github-scopes",
+        json={
+            "repo_owner": "adrirubio",
+            "repo_name": "snazzyemail",
+            "repo_path": "relative/path",
+        },
+    )
+    assert response.status_code == 400
+    assert "Repo path must be absolute" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_github_work_item_feed_and_retry_guard(client, db, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    preset = await agent_team_service.create_preset(
+        db,
+        AgentTeamPresetCreate(
+            name="Feed team",
+            slots=[
+                AgentTeamSlotCreate(
+                    display_name="Backend SME",
+                    provider="codex-cli",
+                    repo_path=str(repo),
+                )
+            ],
+        ),
+    )
+    scope = TeamGithubScope(
+        preset_id=preset.id,
+        repo_owner="adrirubio",
+        repo_name="snazzyemail",
+        repo_path=str(repo),
+    )
+    db.add(scope)
+    await db.flush()
+    escalated = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=10,
+        issue_title="Fix CI",
+        issue_url="https://github.com/adrirubio/snazzyemail/issues/10",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="escalated",
+        escalation_reason="retry_count_exhausted",
+        pending_reason="queued_repo_cap",
+        retry_count=2,
+        approval_round_count=3,
+    )
+    active = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=11,
+        issue_title="Still running",
+        issue_url="https://github.com/adrirubio/snazzyemail/issues/11",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="dispatched",
+    )
+    db.add_all([escalated, active])
+    await db.commit()
+
+    feed_response = await client.get(
+        f"/api/v1/agent-teams/presets/{preset.id}/github-work-items"
+    )
+    assert feed_response.status_code == 200
+    rows = feed_response.json()["items"]
+    assert {row["issue_number"] for row in rows} == {10, 11}
+    row = next(item for item in rows if item["issue_number"] == 10)
+    assert row["repo_owner"] == "adrirubio"
+    assert row["escalation_reason"] == "retry_count_exhausted"
+
+    guard_response = await client.post(
+        f"/api/v1/agent-teams/github-work-items/{active.id}/retry"
+    )
+    assert guard_response.status_code == 409
+
+    retry_response = await client.post(
+        f"/api/v1/agent-teams/github-work-items/{escalated.id}/retry"
+    )
+    assert retry_response.status_code == 200
+    body = retry_response.json()
+    assert body["dispatch_status"] == "pending"
+    assert body["escalation_reason"] is None
+    assert body["pending_reason"] is None
+    assert body["retry_count"] == 0
+    assert body["approval_round_count"] == 0

--- a/backend/tests/agent_teams/test_agent_team_api.py
+++ b/backend/tests/agent_teams/test_agent_team_api.py
@@ -249,6 +249,23 @@ async def test_github_scope_rejects_invalid_repo_path(client, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_github_scope_create_missing_preset_returns_404(client, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    response = await client.post(
+        "/api/v1/agent-teams/presets/999999/github-scopes",
+        json={
+            "repo_owner": "adrirubio",
+            "repo_name": "snazzyemail",
+            "repo_path": str(repo),
+        },
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_github_work_item_feed_and_retry_guard(client, db, tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -282,6 +299,8 @@ async def test_github_work_item_feed_and_retry_guard(client, db, tmp_path):
         dispatch_status="escalated",
         escalation_reason="retry_count_exhausted",
         pending_reason="queued_repo_cap",
+        handoff_state="pending",
+        handoff_target_slot_id=1,
         retry_count=2,
         approval_round_count=3,
     )
@@ -319,5 +338,7 @@ async def test_github_work_item_feed_and_retry_guard(client, db, tmp_path):
     assert body["dispatch_status"] == "pending"
     assert body["escalation_reason"] is None
     assert body["pending_reason"] is None
+    assert body["handoff_state"] is None
+    assert body["handoff_target_slot_id"] is None
     assert body["retry_count"] == 0
     assert body["approval_round_count"] == 0

--- a/backend/tests/agent_teams/test_github_watcher_service.py
+++ b/backend/tests/agent_teams/test_github_watcher_service.py
@@ -197,6 +197,9 @@ async def test_escalated_item_recovers_on_updated_timestamp(db):
         github_updated_at=datetime(2026, 7, 1),
         dispatch_status="escalated",
         escalation_reason="retry_count_exhausted",
+        pending_reason="queued_slot_busy",
+        handoff_state="pending",
+        handoff_target_slot_id=123,
         retry_count=2,
         approval_round_count=1,
     )
@@ -209,6 +212,9 @@ async def test_escalated_item_recovers_on_updated_timestamp(db):
     await db.refresh(item)
     assert item.dispatch_status == "pending"
     assert item.escalation_reason is None
+    assert item.pending_reason is None
+    assert item.handoff_state is None
+    assert item.handoff_target_slot_id is None
     assert item.retry_count == 0
     assert item.approval_round_count == 0
 

--- a/frontend/src/features/agent-teams/AgentTeamsPage.tsx
+++ b/frontend/src/features/agent-teams/AgentTeamsPage.tsx
@@ -39,6 +39,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Textarea } from '@/components/ui/textarea'
 import { TEAM_SLOT_COLOR_OPTIONS, getTeamSlotColorClasses } from '@/lib/agentTeamColors'
 import { cn } from '@/lib/utils'
@@ -50,29 +51,40 @@ import type {
   AgentTeamPreset,
   AgentTeamSlot,
   AgentTeamSlotInput,
+  GithubWorkItem,
   SlotLaunchOptions,
+  TeamGithubScope,
+  TeamGithubScopeInput,
+  TeamGithubScopeUpdate,
 } from '@/types/agentTeams'
 import type { AgentProviderId, ProviderLaunchOptionsResponse } from '@/types/providers'
 import {
   addAgentTeamSlot,
+  createTeamGithubScope,
   createAgentTeamFromBridge,
   createAgentTeamFromMail,
   createAgentTeamPreset,
   deleteAgentTeamPreset,
   deleteAgentTeamSlot,
+  deleteTeamGithubScope,
   duplicateAgentTeamPreset,
   fetchAgentTeamPresets,
+  fetchGithubWorkItems,
+  fetchTeamGithubScopes,
   launchAgentTeam,
   planAgentTeamLaunch,
+  retryGithubWorkItem,
   reorderAgentTeamSlots,
   updateAgentTeamPreset,
   updateAgentTeamSlot,
+  updateTeamGithubScope,
 } from './api'
 import { fetchAgentMailTeam } from '@/features/agent-mail/api'
 import { fetchProviderLaunchOptions } from '@/hooks/useProviders'
 import type { MailMemberResponse } from '@/types/agentMail'
 import { AgentTeamsHelpDialog } from './AgentTeamsHelpDialog'
 import { ProviderLaunchOptionsFields } from '@/features/providers/ProviderLaunchOptionsFields'
+import { AutonomyPanel } from './AutonomyPanel'
 
 type PresetDialogState = 'new' | 'from-mail' | 'from-bridge' | null
 type SlotDialogState = { mode: 'add' | 'edit'; slot?: AgentTeamSlot } | null
@@ -91,6 +103,8 @@ const emptySlot: AgentTeamSlotInput = {
   bootstrap_prompt: '',
   launch_mode: 'plain',
   launch_options: {},
+  area_labels: [],
+  expertise: '',
   enabled: true,
 }
 
@@ -118,6 +132,18 @@ function parseLaunchOptions(raw: string): SlotLaunchOptions {
     throw new Error('Launch options must be a JSON object')
   }
   return parsed as SlotLaunchOptions
+}
+
+function parseLabelList(raw: string): string[] {
+  const seen = new Set<string>()
+  const labels: string[] = []
+  for (const part of raw.split(/[,\n]/)) {
+    const label = part.trim()
+    if (!label || seen.has(label)) continue
+    labels.push(label)
+    seen.add(label)
+  }
+  return labels
 }
 
 function modeOptionsFor(
@@ -149,6 +175,8 @@ function slotToInput(slot: AgentTeamSlot): AgentTeamSlotInput {
     bootstrap_prompt: slot.bootstrap_prompt ?? '',
     launch_mode: slot.launch_mode,
     launch_options: slot.launch_options ?? {},
+    area_labels: slot.area_labels ?? [],
+    expertise: slot.expertise ?? '',
     enabled: slot.enabled,
     position: slot.position,
   }
@@ -361,6 +389,7 @@ function SlotDialog({
 }) {
   const [form, setForm] = useState<AgentTeamSlotInput>(emptySlot)
   const [launchOptionsText, setLaunchOptionsText] = useState('{}')
+  const [areaLabelsText, setAreaLabelsText] = useState('')
   const [saving, setSaving] = useState(false)
   const open = state !== null
   const selectedProvider = form.provider as AgentProviderId
@@ -377,6 +406,7 @@ function SlotDialog({
     queueMicrotask(() => {
       setForm(next)
       setLaunchOptionsText(JSON.stringify(next.launch_options ?? {}, null, 2))
+      setAreaLabelsText((next.area_labels ?? []).join(', '))
     })
   }, [state])
 
@@ -399,6 +429,7 @@ function SlotDialog({
     try {
       await onSave({
         ...form,
+        area_labels: parseLabelList(areaLabelsText),
         launch_options: parseLaunchOptions(launchOptionsText),
       })
       onOpenChange(null)
@@ -503,6 +534,45 @@ function SlotDialog({
               value={form.charter ?? ''}
               onChange={(event) => update({ charter: event.target.value })}
             />
+          </div>
+          <div className="grid gap-4 rounded-lg border border-primary/30 bg-primary/5 p-4 md:col-span-2">
+            <div>
+              <Badge variant="outline" className="border-primary text-primary">
+                GitHub dispatch routing
+              </Badge>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Optional SME routing metadata used by autonomous GitHub dispatch.
+              </p>
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="slot-area-labels">Area labels</Label>
+              <Input
+                id="slot-area-labels"
+                value={areaLabelsText}
+                placeholder="area:backend, area:api"
+                onChange={(event) => setAreaLabelsText(event.target.value)}
+              />
+              <div className="flex flex-wrap gap-2">
+                {parseLabelList(areaLabelsText).map((label) => (
+                  <Badge key={label} variant="secondary">{label}</Badge>
+                ))}
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Mechanical match checked first against incoming GitHub issue labels.
+              </p>
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="slot-expertise">Expertise</Label>
+              <Textarea
+                id="slot-expertise"
+                value={form.expertise ?? ''}
+                placeholder="Owns the backend API, database models, and background jobs."
+                onChange={(event) => update({ expertise: event.target.value })}
+              />
+              <p className="text-xs text-muted-foreground">
+                Used only as fallback classifier input when no area label matches.
+              </p>
+            </div>
           </div>
           <div className="grid gap-2 md:col-span-2">
             <Label htmlFor="slot-bootstrap">Bootstrap prompt</Label>
@@ -662,6 +732,10 @@ export function AgentTeamsPage() {
   const [plannedSlotIds, setPlannedSlotIds] = useState<number[] | null>(null)
   const [helpOpen, setHelpOpen] = useState(false)
   const [launchOptionsByProvider, setLaunchOptionsByProvider] = useState<LaunchOptionsByProvider>({})
+  const [githubScopes, setGithubScopes] = useState<TeamGithubScope[]>([])
+  const [githubWorkItems, setGithubWorkItems] = useState<GithubWorkItem[]>([])
+  const [autonomyLoading, setAutonomyLoading] = useState(false)
+  const [autonomyRefreshing, setAutonomyRefreshing] = useState(false)
 
   const selectedPreset = useMemo(
     () => presets.find((preset) => preset.id === selectedPresetId),
@@ -700,6 +774,24 @@ export function AgentTeamsPage() {
     }
   }, [])
 
+  const loadAutonomy = useCallback(async (presetId: number, showLoading = false) => {
+    if (showLoading) setAutonomyLoading(true)
+    setAutonomyRefreshing(true)
+    try {
+      const [scopeResponse, workItemResponse] = await Promise.all([
+        fetchTeamGithubScopes(presetId),
+        fetchGithubWorkItems(presetId),
+      ])
+      setGithubScopes(scopeResponse.scopes)
+      setGithubWorkItems(workItemResponse.items)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to load autonomy state')
+    } finally {
+      setAutonomyLoading(false)
+      setAutonomyRefreshing(false)
+    }
+  }, [])
+
   useEffect(() => {
     let cancelled = false
     queueMicrotask(() => {
@@ -712,6 +804,23 @@ export function AgentTeamsPage() {
       cancelled = true
     }
   }, [loadPresets, loadProviderLaunchOptions])
+
+  useEffect(() => {
+    if (!selectedPresetId) {
+      queueMicrotask(() => {
+        setGithubScopes([])
+        setGithubWorkItems([])
+      })
+      return
+    }
+    queueMicrotask(() => {
+      void loadAutonomy(selectedPresetId, true)
+    })
+    const interval = window.setInterval(() => {
+      void loadAutonomy(selectedPresetId)
+    }, 5000)
+    return () => window.clearInterval(interval)
+  }, [loadAutonomy, selectedPresetId])
 
   const stats = useMemo(() => {
     const slots = presets.reduce((count, preset) => count + preset.slots.length, 0)
@@ -818,6 +927,50 @@ export function AgentTeamsPage() {
       : await addAgentTeamSlot(selectedPreset.id, normalizedInput)
     replacePreset(saved)
     toast.success('Slot saved')
+  }
+
+  const refreshAutonomy = async () => {
+    if (!selectedPreset) return
+    await loadAutonomy(selectedPreset.id)
+  }
+
+  const toggleAutonomy = async (enabled: boolean) => {
+    if (!selectedPreset) return
+    const updated = await updateAgentTeamPreset(selectedPreset.id, {
+      autonomy_enabled: enabled,
+    })
+    replacePreset(updated)
+    toast.success(enabled ? 'Autonomy enabled' : 'Autonomy disabled')
+  }
+
+  const createGithubScope = async (input: TeamGithubScopeInput) => {
+    if (!selectedPreset) return
+    await createTeamGithubScope(selectedPreset.id, input)
+    await loadAutonomy(selectedPreset.id)
+    toast.success('Watched repo added')
+  }
+
+  const updateGithubScope = async (scopeId: number, input: TeamGithubScopeUpdate) => {
+    if (!selectedPreset) return
+    await updateTeamGithubScope(scopeId, input)
+    await loadAutonomy(selectedPreset.id)
+    toast.success('Watched repo saved')
+  }
+
+  const removeGithubScope = async (scope: TeamGithubScope) => {
+    if (!selectedPreset) return
+    const confirmed = window.confirm(`Remove watched repo ${scope.repo_owner}/${scope.repo_name}?`)
+    if (!confirmed) return
+    await deleteTeamGithubScope(scope.id)
+    await loadAutonomy(selectedPreset.id)
+    toast.success('Watched repo removed')
+  }
+
+  const retryWorkItem = async (item: GithubWorkItem) => {
+    if (!selectedPreset) return
+    await retryGithubWorkItem(item.id)
+    await loadAutonomy(selectedPreset.id)
+    toast.success(`Issue #${item.issue_number} reset to pending`)
   }
 
   const removeSlot = async (slot: AgentTeamSlot) => {
@@ -968,7 +1121,12 @@ export function AgentTeamsPage() {
               >
                 <div className="flex items-center justify-between gap-2">
                   <p className="font-medium">{preset.name}</p>
-                  <Badge variant="secondary">{preset.slots.length}</Badge>
+                  <div className="flex shrink-0 items-center gap-1">
+                    {preset.autonomy_enabled && (
+                      <Badge variant="outline" className="border-primary text-primary">⚡ Autonomy</Badge>
+                    )}
+                    <Badge variant="secondary">{preset.slots.length}</Badge>
+                  </div>
                 </div>
                 <p className="mt-1 truncate text-xs text-muted-foreground">
                   Updated {formatDate(preset.updated_at)}
@@ -1016,7 +1174,13 @@ export function AgentTeamsPage() {
                 </div>
               </div>
 
-              <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-5">
+              <Tabs defaultValue="roster" className="border-t pt-5">
+                <TabsList>
+                  <TabsTrigger value="roster">Roster</TabsTrigger>
+                  <TabsTrigger value="autonomy">Autonomy</TabsTrigger>
+                </TabsList>
+                <TabsContent value="roster" className="space-y-5">
+              <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
                   <h2 className="text-lg font-semibold">Roster</h2>
                   <p className="text-sm text-muted-foreground">{selectedPreset.slots.length} slots</p>
@@ -1080,6 +1244,21 @@ export function AgentTeamsPage() {
                               <p>{slot.role || 'Unassigned'}</p>
                             </div>
                           </div>
+                          {(slot.area_labels?.length || slot.expertise) && (
+                            <div className="mt-3 rounded-md border border-primary/20 bg-primary/5 p-3 text-sm">
+                              <p className="text-xs uppercase text-muted-foreground">GitHub dispatch routing</p>
+                              {slot.area_labels && slot.area_labels.length > 0 && (
+                                <div className="mt-2 flex flex-wrap gap-2">
+                                  {slot.area_labels.map((label) => (
+                                    <Badge key={label} variant="secondary">{label}</Badge>
+                                  ))}
+                                </div>
+                              )}
+                              {slot.expertise && (
+                                <p className="mt-2 text-muted-foreground">{slot.expertise}</p>
+                              )}
+                            </div>
+                          )}
                           {slot.warnings && slot.warnings.length > 0 && (
                             <div className="mt-3 rounded-md border border-amber-500/40 bg-amber-500/10 p-2 text-sm text-amber-300">
                               {slot.warnings.join('; ')}
@@ -1126,6 +1305,23 @@ export function AgentTeamsPage() {
                   )
                 })}
               </div>
+                </TabsContent>
+                <TabsContent value="autonomy" className="mt-5">
+                  <AutonomyPanel
+                    preset={selectedPreset}
+                    scopes={githubScopes}
+                    workItems={githubWorkItems}
+                    loading={autonomyLoading}
+                    refreshing={autonomyRefreshing}
+                    onRefresh={refreshAutonomy}
+                    onToggleAutonomy={toggleAutonomy}
+                    onCreateScope={createGithubScope}
+                    onUpdateScope={updateGithubScope}
+                    onDeleteScope={removeGithubScope}
+                    onRetryWorkItem={retryWorkItem}
+                  />
+                </TabsContent>
+              </Tabs>
             </div>
           )}
         </div>

--- a/frontend/src/features/agent-teams/AgentTeamsPage.tsx
+++ b/frontend/src/features/agent-teams/AgentTeamsPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   ArrowDown,
   ArrowUp,
@@ -736,6 +736,7 @@ export function AgentTeamsPage() {
   const [githubWorkItems, setGithubWorkItems] = useState<GithubWorkItem[]>([])
   const [autonomyLoading, setAutonomyLoading] = useState(false)
   const [autonomyRefreshing, setAutonomyRefreshing] = useState(false)
+  const autonomyRequestIdRef = useRef(0)
 
   const selectedPreset = useMemo(
     () => presets.find((preset) => preset.id === selectedPresetId),
@@ -775,6 +776,8 @@ export function AgentTeamsPage() {
   }, [])
 
   const loadAutonomy = useCallback(async (presetId: number, showLoading = false) => {
+    const requestId = autonomyRequestIdRef.current + 1
+    autonomyRequestIdRef.current = requestId
     if (showLoading) setAutonomyLoading(true)
     setAutonomyRefreshing(true)
     try {
@@ -782,13 +785,19 @@ export function AgentTeamsPage() {
         fetchTeamGithubScopes(presetId),
         fetchGithubWorkItems(presetId),
       ])
-      setGithubScopes(scopeResponse.scopes)
-      setGithubWorkItems(workItemResponse.items)
+      if (autonomyRequestIdRef.current === requestId) {
+        setGithubScopes(scopeResponse.scopes)
+        setGithubWorkItems(workItemResponse.items)
+      }
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to load autonomy state')
+      if (autonomyRequestIdRef.current === requestId) {
+        toast.error(error instanceof Error ? error.message : 'Failed to load autonomy state')
+      }
     } finally {
-      setAutonomyLoading(false)
-      setAutonomyRefreshing(false)
+      if (autonomyRequestIdRef.current === requestId) {
+        setAutonomyLoading(false)
+        setAutonomyRefreshing(false)
+      }
     }
   }, [])
 
@@ -807,9 +816,12 @@ export function AgentTeamsPage() {
 
   useEffect(() => {
     if (!selectedPresetId) {
+      autonomyRequestIdRef.current += 1
       queueMicrotask(() => {
         setGithubScopes([])
         setGithubWorkItems([])
+        setAutonomyLoading(false)
+        setAutonomyRefreshing(false)
       })
       return
     }
@@ -936,41 +948,66 @@ export function AgentTeamsPage() {
 
   const toggleAutonomy = async (enabled: boolean) => {
     if (!selectedPreset) return
-    const updated = await updateAgentTeamPreset(selectedPreset.id, {
-      autonomy_enabled: enabled,
-    })
-    replacePreset(updated)
-    toast.success(enabled ? 'Autonomy enabled' : 'Autonomy disabled')
+    try {
+      const updated = await updateAgentTeamPreset(selectedPreset.id, {
+        autonomy_enabled: enabled,
+      })
+      replacePreset(updated)
+      toast.success(enabled ? 'Autonomy enabled' : 'Autonomy disabled')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to update autonomy')
+      throw error
+    }
   }
 
   const createGithubScope = async (input: TeamGithubScopeInput) => {
     if (!selectedPreset) return
-    await createTeamGithubScope(selectedPreset.id, input)
-    await loadAutonomy(selectedPreset.id)
-    toast.success('Watched repo added')
+    try {
+      await createTeamGithubScope(selectedPreset.id, input)
+      await loadAutonomy(selectedPreset.id)
+      toast.success('Watched repo added')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to add watched repo')
+      throw error
+    }
   }
 
   const updateGithubScope = async (scopeId: number, input: TeamGithubScopeUpdate) => {
     if (!selectedPreset) return
-    await updateTeamGithubScope(scopeId, input)
-    await loadAutonomy(selectedPreset.id)
-    toast.success('Watched repo saved')
+    try {
+      await updateTeamGithubScope(scopeId, input)
+      await loadAutonomy(selectedPreset.id)
+      toast.success('Watched repo saved')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to save watched repo')
+      throw error
+    }
   }
 
   const removeGithubScope = async (scope: TeamGithubScope) => {
     if (!selectedPreset) return
     const confirmed = window.confirm(`Remove watched repo ${scope.repo_owner}/${scope.repo_name}?`)
     if (!confirmed) return
-    await deleteTeamGithubScope(scope.id)
-    await loadAutonomy(selectedPreset.id)
-    toast.success('Watched repo removed')
+    try {
+      await deleteTeamGithubScope(scope.id)
+      await loadAutonomy(selectedPreset.id)
+      toast.success('Watched repo removed')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to remove watched repo')
+      throw error
+    }
   }
 
   const retryWorkItem = async (item: GithubWorkItem) => {
     if (!selectedPreset) return
-    await retryGithubWorkItem(item.id)
-    await loadAutonomy(selectedPreset.id)
-    toast.success(`Issue #${item.issue_number} reset to pending`)
+    try {
+      await retryGithubWorkItem(item.id)
+      await loadAutonomy(selectedPreset.id)
+      toast.success(`Issue #${item.issue_number} reset to pending`)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to retry work item')
+      throw error
+    }
   }
 
   const removeSlot = async (slot: AgentTeamSlot) => {

--- a/frontend/src/features/agent-teams/AutonomyPanel.tsx
+++ b/frontend/src/features/agent-teams/AutonomyPanel.tsx
@@ -22,6 +22,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
+import { MODAL_SIZES } from '@/lib/constants'
 import { cn } from '@/lib/utils'
 import type {
   AgentTeamPreset,
@@ -115,12 +116,14 @@ function ScopeDialog({
 }) {
   const [form, setForm] = useState<TeamGithubScopeInput>(emptyScope)
   const [saving, setSaving] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const open = state !== null
 
   useEffect(() => {
     if (!state) return
     queueMicrotask(() => {
       setForm(state.scope ? scopeToInput(state.scope) : emptyScope)
+      setErrorMessage(null)
     })
   }, [state])
 
@@ -128,13 +131,14 @@ function ScopeDialog({
     setForm((current) => ({ ...current, ...patch }))
   }
 
-  const numberValue = (value: string, fallback: number) => {
+  const numberValue = (value: string, fallback: number, min: number) => {
     const parsed = Number.parseInt(value, 10)
-    return Number.isFinite(parsed) ? parsed : fallback
+    return Number.isFinite(parsed) ? Math.max(parsed, min) : fallback
   }
 
   const submit = async () => {
     setSaving(true)
+    setErrorMessage(null)
     try {
       await onSave({
         ...form,
@@ -145,6 +149,8 @@ function ScopeDialog({
         design_label: form.design_label?.trim() || 'claude-deck-design',
       })
       onOpenChange(null)
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : 'Failed to save watched repo')
     } finally {
       setSaving(false)
     }
@@ -152,13 +158,18 @@ function ScopeDialog({
 
   return (
     <Dialog open={open} onOpenChange={(next) => onOpenChange(next ? state : null)}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent className={MODAL_SIZES.SM}>
         <DialogHeader>
           <DialogTitle>{state?.mode === 'edit' ? 'Edit watched repo' : 'Add watched repo'}</DialogTitle>
           <DialogDescription>
             This team will poll the repo for labeled issues and dispatch them automatically.
           </DialogDescription>
         </DialogHeader>
+        {errorMessage && (
+          <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+            {errorMessage}
+          </div>
+        )}
         <div className="grid gap-4 md:grid-cols-2">
           <div className="grid gap-2">
             <Label htmlFor="scope-owner">Repo owner</Label>
@@ -229,7 +240,7 @@ function ScopeDialog({
               min={1}
               value={form.max_approval_rounds}
               onChange={(event) => update({
-                max_approval_rounds: numberValue(event.target.value, 3),
+                max_approval_rounds: numberValue(event.target.value, 3, 1),
               })}
             />
           </div>
@@ -241,7 +252,7 @@ function ScopeDialog({
               min={1}
               value={form.max_concurrent_dispatched}
               onChange={(event) => update({
-                max_concurrent_dispatched: numberValue(event.target.value, 3),
+                max_concurrent_dispatched: numberValue(event.target.value, 3, 1),
               })}
             />
           </div>
@@ -253,7 +264,7 @@ function ScopeDialog({
               min={0}
               value={form.max_verification_retries}
               onChange={(event) => update({
-                max_verification_retries: numberValue(event.target.value, 2),
+                max_verification_retries: numberValue(event.target.value, 2, 0),
               })}
             />
           </div>
@@ -265,7 +276,7 @@ function ScopeDialog({
               min={0}
               value={form.max_auto_merges_per_day}
               onChange={(event) => update({
-                max_auto_merges_per_day: numberValue(event.target.value, 5),
+                max_auto_merges_per_day: numberValue(event.target.value, 5, 0),
               })}
             />
           </div>
@@ -302,14 +313,18 @@ function WorkItemDialog({
   onRetry: (item: GithubWorkItem) => Promise<void>
 }) {
   const [retrying, setRetrying] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const open = item !== null
 
   const retry = async () => {
     if (!item) return
     setRetrying(true)
+    setErrorMessage(null)
     try {
       await onRetry(item)
       onOpenChange(false)
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : 'Failed to retry work item')
     } finally {
       setRetrying(false)
     }
@@ -317,7 +332,7 @@ function WorkItemDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent className={MODAL_SIZES.SM}>
         {item && (
           <>
             <DialogHeader>
@@ -337,6 +352,11 @@ function WorkItemDialog({
                   {item.status_note && (
                     <p className="mt-2 text-sm text-muted-foreground">{item.status_note}</p>
                   )}
+                </div>
+              )}
+              {errorMessage && (
+                <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+                  {errorMessage}
                 </div>
               )}
               {item.handoff_state && (
@@ -409,18 +429,25 @@ export function AutonomyPanel({
   onRetryWorkItem: (item: GithubWorkItem) => Promise<void>
 }) {
   const [scopeDialog, setScopeDialog] = useState<ScopeDialogState>(null)
-  const [detailItem, setDetailItem] = useState<GithubWorkItem | null>(null)
+  const [detailItemId, setDetailItemId] = useState<number | null>(null)
   const [toggleSaving, setToggleSaving] = useState(false)
+  const [retryingWorkItemId, setRetryingWorkItemId] = useState<number | null>(null)
   const slotById = useMemo(
     () => new Map(preset.slots.map((slot) => [slot.id, slot])),
     [preset.slots]
   )
   const scopeCount = scopes.length
+  const detailItem = useMemo(
+    () => workItems.find((item) => item.id === detailItemId) ?? null,
+    [detailItemId, workItems]
+  )
 
   const toggle = async (enabled: boolean) => {
     setToggleSaving(true)
     try {
       await onToggleAutonomy(enabled)
+    } catch {
+      // Parent handlers surface the error toast; keep the controlled switch stable.
     } finally {
       setToggleSaving(false)
     }
@@ -431,6 +458,26 @@ export function AutonomyPanel({
       await onUpdateScope(scopeDialog.scope.id, input)
     } else {
       await onCreateScope(input as TeamGithubScopeInput)
+    }
+  }
+
+  const deleteScope = async (scope: TeamGithubScope) => {
+    try {
+      await onDeleteScope(scope)
+    } catch {
+      // Parent handlers surface the error toast.
+    }
+  }
+
+  const retryWorkItem = async (item: GithubWorkItem) => {
+    if (retryingWorkItemId !== null) return
+    setRetryingWorkItemId(item.id)
+    try {
+      await onRetryWorkItem(item)
+    } catch {
+      // Parent handlers surface the error toast.
+    } finally {
+      setRetryingWorkItemId(null)
     }
   }
 
@@ -494,7 +541,7 @@ export function AutonomyPanel({
                       variant="outline"
                       className={scope.merge_policy === 'auto' ? 'border-primary text-primary' : 'border-amber-500/70 text-amber-400'}
                     >
-                      merge: {scope.merge_policy}
+                      code merge: {scope.merge_policy}
                     </Badge>
                     {!scope.enabled && <Badge variant="secondary">disabled</Badge>}
                   </div>
@@ -509,7 +556,7 @@ export function AutonomyPanel({
                   <Button variant="outline" size="sm" onClick={() => setScopeDialog({ mode: 'edit', scope })}>
                     Edit
                   </Button>
-                  <Button variant="outline" size="sm" onClick={() => onDeleteScope(scope)}>
+                  <Button variant="outline" size="sm" onClick={() => void deleteScope(scope)}>
                     <Trash2 className="mr-2 h-4 w-4" />
                     Remove
                   </Button>
@@ -614,12 +661,16 @@ export function AutonomyPanel({
                         <td className="px-3 py-3 text-right">
                           <div className="flex justify-end gap-2">
                             {item.dispatch_status === 'escalated' && (
-                              <Button size="sm" onClick={() => void onRetryWorkItem(item)}>
+                              <Button
+                                size="sm"
+                                disabled={retryingWorkItemId !== null}
+                                onClick={() => void retryWorkItem(item)}
+                              >
                                 <RotateCcw className="mr-2 h-4 w-4" />
-                                Retry
+                                {retryingWorkItemId === item.id ? 'Retrying' : 'Retry'}
                               </Button>
                             )}
-                            <Button variant="outline" size="sm" onClick={() => setDetailItem(item)}>
+                            <Button variant="outline" size="sm" onClick={() => setDetailItemId(item.id)}>
                               <ExternalLink className="mr-2 h-4 w-4" />
                               View
                             </Button>
@@ -637,6 +688,7 @@ export function AutonomyPanel({
 
       <ScopeDialog state={scopeDialog} onOpenChange={setScopeDialog} onSave={saveScope} />
       <WorkItemDialog
+        key={detailItem?.id ?? 'closed'}
         item={detailItem}
         ownerName={detailItem?.owner_slot_id ? slotById.get(detailItem.owner_slot_id)?.display_name : undefined}
         handoffTargetName={
@@ -644,7 +696,7 @@ export function AutonomyPanel({
             ? slotById.get(detailItem.handoff_target_slot_id)?.display_name
             : undefined
         }
-        onOpenChange={(open) => setDetailItem(open ? detailItem : null)}
+        onOpenChange={(open) => setDetailItemId(open ? detailItemId : null)}
         onRetry={onRetryWorkItem}
       />
     </div>

--- a/frontend/src/features/agent-teams/AutonomyPanel.tsx
+++ b/frontend/src/features/agent-teams/AutonomyPanel.tsx
@@ -1,0 +1,652 @@
+import { useEffect, useMemo, useState } from 'react'
+import { AlertCircle, ExternalLink, GitPullRequest, Plus, RefreshCw, RotateCcw, Trash2 } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Switch } from '@/components/ui/switch'
+import { cn } from '@/lib/utils'
+import type {
+  AgentTeamPreset,
+  GithubWorkItem,
+  TeamGithubMergePolicy,
+  TeamGithubScope,
+  TeamGithubScopeInput,
+  TeamGithubScopeUpdate,
+} from '@/types/agentTeams'
+
+type ScopeDialogState = { mode: 'add' | 'edit'; scope?: TeamGithubScope } | null
+
+const emptyScope: TeamGithubScopeInput = {
+  repo_owner: '',
+  repo_name: '',
+  repo_path: '',
+  dispatch_label: 'claude-deck-ready',
+  design_label: 'claude-deck-design',
+  merge_policy: 'human',
+  max_approval_rounds: 3,
+  max_concurrent_dispatched: 3,
+  max_verification_retries: 2,
+  max_auto_merges_per_day: 5,
+  enabled: true,
+}
+
+function scopeToInput(scope: TeamGithubScope): TeamGithubScopeInput {
+  return {
+    repo_owner: scope.repo_owner,
+    repo_name: scope.repo_name,
+    repo_path: scope.repo_path,
+    dispatch_label: scope.dispatch_label,
+    design_label: scope.design_label,
+    merge_policy: scope.merge_policy === 'auto' ? 'auto' : 'human',
+    max_approval_rounds: scope.max_approval_rounds,
+    max_concurrent_dispatched: scope.max_concurrent_dispatched,
+    max_verification_retries: scope.max_verification_retries,
+    max_auto_merges_per_day: scope.max_auto_merges_per_day,
+    enabled: scope.enabled,
+  }
+}
+
+function formatDateTime(value?: string | null) {
+  if (!value) return 'never'
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(value))
+}
+
+function routeMethodLabel(value?: string | null) {
+  if (!value) return 'not routed'
+  if (value === 'label') return 'label match'
+  if (value === 'leader_fallback') return 'leader fallback'
+  return value.replaceAll('_', ' ')
+}
+
+function pendingReasonLabel(item: GithubWorkItem, ownerName?: string) {
+  if (item.pending_reason === 'queued_slot_busy') {
+    return `queued · behind ${ownerName ?? 'assigned slot'}`
+  }
+  if (item.pending_reason === 'queued_repo_cap') return 'queued · repo cap reached'
+  return null
+}
+
+function statusBadgeClass(status: string) {
+  if (status === 'escalated' || status === 'failed') return 'border-destructive text-destructive'
+  if (status === 'merged') return 'border-emerald-500/70 text-emerald-400'
+  if (status === 'awaiting_human_review' || status === 'ready_for_review') {
+    return 'border-sky-500/70 text-sky-400'
+  }
+  if (status === 'verifying' || status === 'dispatched') return 'border-primary/70 text-primary'
+  return 'border-muted-foreground/50 text-muted-foreground'
+}
+
+function prUrl(item: GithubWorkItem) {
+  if (!item.pr_number) return null
+  return `https://github.com/${item.repo_owner}/${item.repo_name}/pull/${item.pr_number}`
+}
+
+function ScopeDialog({
+  state,
+  onOpenChange,
+  onSave,
+}: {
+  state: ScopeDialogState
+  onOpenChange: (state: ScopeDialogState) => void
+  onSave: (scope: TeamGithubScopeInput | TeamGithubScopeUpdate) => Promise<void>
+}) {
+  const [form, setForm] = useState<TeamGithubScopeInput>(emptyScope)
+  const [saving, setSaving] = useState(false)
+  const open = state !== null
+
+  useEffect(() => {
+    if (!state) return
+    queueMicrotask(() => {
+      setForm(state.scope ? scopeToInput(state.scope) : emptyScope)
+    })
+  }, [state])
+
+  const update = (patch: Partial<TeamGithubScopeInput>) => {
+    setForm((current) => ({ ...current, ...patch }))
+  }
+
+  const numberValue = (value: string, fallback: number) => {
+    const parsed = Number.parseInt(value, 10)
+    return Number.isFinite(parsed) ? parsed : fallback
+  }
+
+  const submit = async () => {
+    setSaving(true)
+    try {
+      await onSave({
+        ...form,
+        repo_owner: form.repo_owner.trim(),
+        repo_name: form.repo_name.trim(),
+        repo_path: form.repo_path.trim(),
+        dispatch_label: form.dispatch_label?.trim() || 'claude-deck-ready',
+        design_label: form.design_label?.trim() || 'claude-deck-design',
+      })
+      onOpenChange(null)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => onOpenChange(next ? state : null)}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{state?.mode === 'edit' ? 'Edit watched repo' : 'Add watched repo'}</DialogTitle>
+          <DialogDescription>
+            This team will poll the repo for labeled issues and dispatch them automatically.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-2">
+            <Label htmlFor="scope-owner">Repo owner</Label>
+            <Input
+              id="scope-owner"
+              value={form.repo_owner}
+              onChange={(event) => update({ repo_owner: event.target.value })}
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="scope-name">Repo name</Label>
+            <Input
+              id="scope-name"
+              value={form.repo_name}
+              onChange={(event) => update({ repo_name: event.target.value })}
+            />
+          </div>
+          <div className="grid gap-2 md:col-span-2">
+            <Label htmlFor="scope-path">Local checkout path</Label>
+            <Input
+              id="scope-path"
+              value={form.repo_path}
+              onChange={(event) => update({ repo_path: event.target.value })}
+            />
+            <p className="text-xs text-muted-foreground">
+              Used as the per-dispatch repo override; it does not change any slot&apos;s saved repo path.
+            </p>
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="dispatch-label">Dispatch label</Label>
+            <Input
+              id="dispatch-label"
+              value={form.dispatch_label}
+              onChange={(event) => update({ dispatch_label: event.target.value })}
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="design-label">Design label</Label>
+            <Input
+              id="design-label"
+              value={form.design_label}
+              onChange={(event) => update({ design_label: event.target.value })}
+            />
+          </div>
+          <div className="grid gap-2 md:col-span-2">
+            <Label>Merge policy</Label>
+            <Select
+              value={form.merge_policy}
+              onValueChange={(mergePolicy) => update({ merge_policy: mergePolicy as TeamGithubMergePolicy })}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="human">Human reviews and merges</SelectItem>
+                <SelectItem value="auto">Auto-merge after checks pass</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-amber-400">
+              Applies to the code pipeline only. Design-pipeline PRs always require a human review.
+            </p>
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="approval-rounds">Max approval rounds</Label>
+            <Input
+              id="approval-rounds"
+              type="number"
+              min={1}
+              value={form.max_approval_rounds}
+              onChange={(event) => update({
+                max_approval_rounds: numberValue(event.target.value, 3),
+              })}
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="concurrent-dispatches">Max concurrent dispatched</Label>
+            <Input
+              id="concurrent-dispatches"
+              type="number"
+              min={1}
+              value={form.max_concurrent_dispatched}
+              onChange={(event) => update({
+                max_concurrent_dispatched: numberValue(event.target.value, 3),
+              })}
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="verification-retries">Max verification retries</Label>
+            <Input
+              id="verification-retries"
+              type="number"
+              min={0}
+              value={form.max_verification_retries}
+              onChange={(event) => update({
+                max_verification_retries: numberValue(event.target.value, 2),
+              })}
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="auto-merges">Max auto-merges per day</Label>
+            <Input
+              id="auto-merges"
+              type="number"
+              min={0}
+              value={form.max_auto_merges_per_day}
+              onChange={(event) => update({
+                max_auto_merges_per_day: numberValue(event.target.value, 5),
+              })}
+            />
+          </div>
+          <label className="flex items-center gap-2 text-sm">
+            <Checkbox checked={form.enabled} onCheckedChange={(checked) => update({ enabled: checked === true })} />
+            Enabled
+          </label>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(null)}>Cancel</Button>
+          <Button
+            onClick={submit}
+            disabled={saving || !form.repo_owner.trim() || !form.repo_name.trim() || !form.repo_path.trim()}
+          >
+            {saving ? 'Saving' : 'Save repo'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function WorkItemDialog({
+  item,
+  ownerName,
+  handoffTargetName,
+  onOpenChange,
+  onRetry,
+}: {
+  item: GithubWorkItem | null
+  ownerName?: string
+  handoffTargetName?: string
+  onOpenChange: (open: boolean) => void
+  onRetry: (item: GithubWorkItem) => Promise<void>
+}) {
+  const [retrying, setRetrying] = useState(false)
+  const open = item !== null
+
+  const retry = async () => {
+    if (!item) return
+    setRetrying(true)
+    try {
+      await onRetry(item)
+      onOpenChange(false)
+    } finally {
+      setRetrying(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        {item && (
+          <>
+            <DialogHeader>
+              <DialogTitle>#{item.issue_number} — {item.issue_title}</DialogTitle>
+              <DialogDescription>
+                {item.repo_owner}/{item.repo_name} · updated {formatDateTime(item.updated_at)}
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-4">
+              {item.dispatch_status === 'escalated' && (
+                <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-4">
+                  <div className="flex items-center gap-2 font-medium text-destructive">
+                    <AlertCircle className="h-4 w-4" />
+                    Why this escalated
+                  </div>
+                  <p className="mt-2 text-sm">{item.escalation_reason ?? 'Unknown reason'}</p>
+                  {item.status_note && (
+                    <p className="mt-2 text-sm text-muted-foreground">{item.status_note}</p>
+                  )}
+                </div>
+              )}
+              {item.handoff_state && (
+                <div className="rounded-lg border border-sky-500/40 bg-sky-500/10 p-4 text-sm">
+                  <span className="font-medium">{ownerName ?? 'Current owner'}</span>
+                  <span className="mx-2 text-muted-foreground">→ handoff {item.handoff_state} →</span>
+                  <span className="font-medium">{handoffTargetName ?? 'target slot'}</span>
+                </div>
+              )}
+              <div className="rounded-lg border">
+                <dl className="grid gap-0 text-sm">
+                  <div className="grid grid-cols-[150px_1fr] border-b p-3">
+                    <dt className="text-muted-foreground">Status</dt>
+                    <dd>{item.dispatch_status}</dd>
+                  </div>
+                  <div className="grid grid-cols-[150px_1fr] border-b p-3">
+                    <dt className="text-muted-foreground">Owner</dt>
+                    <dd>{ownerName ?? 'Unassigned'} ({routeMethodLabel(item.routing_method)})</dd>
+                  </div>
+                  <div className="grid grid-cols-[150px_1fr] border-b p-3">
+                    <dt className="text-muted-foreground">Retries</dt>
+                    <dd>{item.retry_count}</dd>
+                  </div>
+                  <div className="grid grid-cols-[150px_1fr] p-3">
+                    <dt className="text-muted-foreground">PR</dt>
+                    <dd>{item.pr_number ? `#${item.pr_number}` : 'None yet'}</dd>
+                  </div>
+                </dl>
+              </div>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => onOpenChange(false)}>Close</Button>
+              {item.dispatch_status === 'escalated' && (
+                <Button onClick={retry} disabled={retrying}>
+                  <RotateCcw className="mr-2 h-4 w-4" />
+                  {retrying ? 'Retrying' : 'Retry'}
+                </Button>
+              )}
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function AutonomyPanel({
+  preset,
+  scopes,
+  workItems,
+  loading,
+  refreshing,
+  onRefresh,
+  onToggleAutonomy,
+  onCreateScope,
+  onUpdateScope,
+  onDeleteScope,
+  onRetryWorkItem,
+}: {
+  preset: AgentTeamPreset
+  scopes: TeamGithubScope[]
+  workItems: GithubWorkItem[]
+  loading: boolean
+  refreshing: boolean
+  onRefresh: () => Promise<void>
+  onToggleAutonomy: (enabled: boolean) => Promise<void>
+  onCreateScope: (input: TeamGithubScopeInput) => Promise<void>
+  onUpdateScope: (scopeId: number, input: TeamGithubScopeUpdate) => Promise<void>
+  onDeleteScope: (scope: TeamGithubScope) => Promise<void>
+  onRetryWorkItem: (item: GithubWorkItem) => Promise<void>
+}) {
+  const [scopeDialog, setScopeDialog] = useState<ScopeDialogState>(null)
+  const [detailItem, setDetailItem] = useState<GithubWorkItem | null>(null)
+  const [toggleSaving, setToggleSaving] = useState(false)
+  const slotById = useMemo(
+    () => new Map(preset.slots.map((slot) => [slot.id, slot])),
+    [preset.slots]
+  )
+  const scopeCount = scopes.length
+
+  const toggle = async (enabled: boolean) => {
+    setToggleSaving(true)
+    try {
+      await onToggleAutonomy(enabled)
+    } finally {
+      setToggleSaving(false)
+    }
+  }
+
+  const saveScope = async (input: TeamGithubScopeInput | TeamGithubScopeUpdate) => {
+    if (scopeDialog?.mode === 'edit' && scopeDialog.scope) {
+      await onUpdateScope(scopeDialog.scope.id, input)
+    } else {
+      await onCreateScope(input as TeamGithubScopeInput)
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      <Card>
+        <CardContent className="flex flex-col gap-4 p-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="font-semibold">Autonomous GitHub dispatch</p>
+            <p className="text-sm text-muted-foreground">
+              Poll watched repos for labeled issues and dispatch work into this team automatically.
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="text-sm text-muted-foreground">
+              {preset.autonomy_enabled ? 'Enabled' : 'Disabled'}
+            </span>
+            <Switch
+              checked={preset.autonomy_enabled}
+              disabled={toggleSaving}
+              onCheckedChange={toggle}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold">Watched repos</h2>
+          <p className="text-sm text-muted-foreground">{scopeCount} configured scope{scopeCount === 1 ? '' : 's'}</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" onClick={onRefresh} disabled={refreshing}>
+            <RefreshCw className={cn('mr-2 h-4 w-4', refreshing && 'animate-spin')} />
+            Refresh
+          </Button>
+          <Button onClick={() => setScopeDialog({ mode: 'add' })}>
+            <Plus className="mr-2 h-4 w-4" />
+            Add repo
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-3">
+        {loading && <div className="rounded-lg border p-5 text-sm text-muted-foreground">Loading autonomy state...</div>}
+        {!loading && scopes.length === 0 && (
+          <div className="rounded-lg border p-5 text-sm text-muted-foreground">
+            No watched repos yet. Add a scope before enabling autonomy for useful work.
+          </div>
+        )}
+        {scopes.map((scope) => (
+          <Card key={scope.id} className={cn(!scope.enabled && 'opacity-70')}>
+            <CardContent className="p-4">
+              <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="font-semibold">{scope.repo_owner}/{scope.repo_name}</p>
+                    <Badge variant="outline">{scope.dispatch_label}</Badge>
+                    <Badge variant="secondary">{scope.design_label}</Badge>
+                    <Badge
+                      variant="outline"
+                      className={scope.merge_policy === 'auto' ? 'border-primary text-primary' : 'border-amber-500/70 text-amber-400'}
+                    >
+                      merge: {scope.merge_policy}
+                    </Badge>
+                    {!scope.enabled && <Badge variant="secondary">disabled</Badge>}
+                  </div>
+                  <p className="mt-2 truncate text-sm text-muted-foreground">
+                    Local checkout: {scope.repo_path}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Approval rounds: {scope.max_approval_rounds} · Concurrent: {scope.max_concurrent_dispatched} · Verification retries: {scope.max_verification_retries} · Auto-merges/day: {scope.max_auto_merges_per_day} · Last polled {formatDateTime(scope.last_polled_at)}
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Button variant="outline" size="sm" onClick={() => setScopeDialog({ mode: 'edit', scope })}>
+                    Edit
+                  </Button>
+                  <Button variant="outline" size="sm" onClick={() => onDeleteScope(scope)}>
+                    <Trash2 className="mr-2 h-4 w-4" />
+                    Remove
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <Card>
+        <CardHeader className="flex flex-row items-start justify-between gap-3">
+          <div>
+            <CardTitle>Activity</CardTitle>
+            <p className="mt-1 text-sm text-muted-foreground">Recent GitHub work items across this preset&apos;s scopes.</p>
+          </div>
+          <Badge variant="secondary">auto-refreshes</Badge>
+        </CardHeader>
+        <CardContent>
+          {workItems.length === 0 ? (
+            <div className="rounded-lg border p-5 text-sm text-muted-foreground">
+              No GitHub work items yet.
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                    <th className="px-3 py-2 font-medium">Issue</th>
+                    <th className="px-3 py-2 font-medium">Type</th>
+                    <th className="px-3 py-2 font-medium">Status</th>
+                    <th className="px-3 py-2 font-medium">Owner</th>
+                    <th className="px-3 py-2 font-medium">PR</th>
+                    <th className="px-3 py-2 font-medium" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {workItems.map((item) => {
+                    const owner = item.owner_slot_id ? slotById.get(item.owner_slot_id) : undefined
+                    const handoffTarget = item.handoff_target_slot_id
+                      ? slotById.get(item.handoff_target_slot_id)
+                      : undefined
+                    const pendingLabel = pendingReasonLabel(item, owner?.display_name)
+                    const pullUrl = prUrl(item)
+                    return (
+                      <tr key={item.id} className="border-b last:border-0">
+                        <td className="min-w-[280px] px-3 py-3">
+                          <a
+                            href={item.issue_url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="font-medium text-foreground hover:text-primary"
+                          >
+                            #{item.issue_number} — {item.issue_title}
+                          </a>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {item.repo_owner}/{item.repo_name} · updated {formatDateTime(item.updated_at)}
+                          </p>
+                        </td>
+                        <td className="px-3 py-3">
+                          <Badge variant={item.issue_type === 'design' ? 'default' : 'secondary'}>
+                            {item.issue_type}
+                          </Badge>
+                        </td>
+                        <td className="px-3 py-3">
+                          <Badge variant="outline" className={statusBadgeClass(item.dispatch_status)}>
+                            {item.dispatch_status.replaceAll('_', ' ')}
+                          </Badge>
+                          {pendingLabel && <p className="mt-1 text-xs text-muted-foreground">{pendingLabel}</p>}
+                          {item.handoff_state && (
+                            <p className="mt-1 text-xs text-sky-400">
+                              handoff {item.handoff_state}
+                              {handoffTarget ? ` → ${handoffTarget.display_name}` : ''}
+                            </p>
+                          )}
+                          {item.escalation_reason && (
+                            <p className="mt-1 text-xs text-destructive">{item.escalation_reason}</p>
+                          )}
+                        </td>
+                        <td className="px-3 py-3">
+                          <span>{owner?.display_name ?? 'Unassigned'}</span>
+                          <p className="mt-1 text-xs text-muted-foreground">{routeMethodLabel(item.routing_method)}</p>
+                        </td>
+                        <td className="px-3 py-3">
+                          {pullUrl ? (
+                            <a
+                              href={pullUrl}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="inline-flex items-center gap-1 text-primary"
+                            >
+                              <GitPullRequest className="h-3.5 w-3.5" />
+                              #{item.pr_number}
+                            </a>
+                          ) : (
+                            <span className="text-muted-foreground">—</span>
+                          )}
+                          {item.retry_count > 0 && (
+                            <p className="mt-1 text-xs text-muted-foreground">retries: {item.retry_count}</p>
+                          )}
+                        </td>
+                        <td className="px-3 py-3 text-right">
+                          <div className="flex justify-end gap-2">
+                            {item.dispatch_status === 'escalated' && (
+                              <Button size="sm" onClick={() => void onRetryWorkItem(item)}>
+                                <RotateCcw className="mr-2 h-4 w-4" />
+                                Retry
+                              </Button>
+                            )}
+                            <Button variant="outline" size="sm" onClick={() => setDetailItem(item)}>
+                              <ExternalLink className="mr-2 h-4 w-4" />
+                              View
+                            </Button>
+                          </div>
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <ScopeDialog state={scopeDialog} onOpenChange={setScopeDialog} onSave={saveScope} />
+      <WorkItemDialog
+        item={detailItem}
+        ownerName={detailItem?.owner_slot_id ? slotById.get(detailItem.owner_slot_id)?.display_name : undefined}
+        handoffTargetName={
+          detailItem?.handoff_target_slot_id
+            ? slotById.get(detailItem.handoff_target_slot_id)?.display_name
+            : undefined
+        }
+        onOpenChange={(open) => setDetailItem(open ? detailItem : null)}
+        onRetry={onRetryWorkItem}
+      />
+    </div>
+  )
+}

--- a/frontend/src/features/agent-teams/api.ts
+++ b/frontend/src/features/agent-teams/api.ts
@@ -11,6 +11,12 @@ import type {
   AgentTeamPresetUpdate,
   AgentTeamSlotInput,
   AgentTeamSlotUpdate,
+  GithubWorkItem,
+  GithubWorkItemListResponse,
+  TeamGithubScope,
+  TeamGithubScopeInput,
+  TeamGithubScopeListResponse,
+  TeamGithubScopeUpdate,
 } from '@/types/agentTeams'
 
 export function fetchAgentTeamPresets(): Promise<AgentTeamPresetListResponse> {
@@ -117,5 +123,47 @@ export function launchAgentTeam(
   return apiClient<AgentTeamLaunchResult>(`agent-teams/presets/${presetId}/launch`, {
     method: 'POST',
     body: JSON.stringify(input),
+  })
+}
+
+export function fetchTeamGithubScopes(presetId: number): Promise<TeamGithubScopeListResponse> {
+  return apiClient<TeamGithubScopeListResponse>(`agent-teams/presets/${presetId}/github-scopes`)
+}
+
+export function createTeamGithubScope(
+  presetId: number,
+  input: TeamGithubScopeInput
+): Promise<TeamGithubScope> {
+  return apiClient<TeamGithubScope>(`agent-teams/presets/${presetId}/github-scopes`, {
+    method: 'POST',
+    body: JSON.stringify(input),
+  })
+}
+
+export function updateTeamGithubScope(
+  scopeId: number,
+  input: TeamGithubScopeUpdate
+): Promise<TeamGithubScope> {
+  return apiClient<TeamGithubScope>(`agent-teams/github-scopes/${scopeId}`, {
+    method: 'PATCH',
+    body: JSON.stringify(input),
+  })
+}
+
+export function deleteTeamGithubScope(scopeId: number): Promise<Record<string, never>> {
+  return apiClient<Record<string, never>>(`agent-teams/github-scopes/${scopeId}`, {
+    method: 'DELETE',
+  })
+}
+
+export function fetchGithubWorkItems(presetId: number, limit = 50): Promise<GithubWorkItemListResponse> {
+  return apiClient<GithubWorkItemListResponse>(
+    `agent-teams/presets/${presetId}/github-work-items?limit=${limit}`
+  )
+}
+
+export function retryGithubWorkItem(workItemId: number): Promise<GithubWorkItem> {
+  return apiClient<GithubWorkItem>(`agent-teams/github-work-items/${workItemId}/retry`, {
+    method: 'POST',
   })
 }

--- a/frontend/src/types/agentTeams.ts
+++ b/frontend/src/types/agentTeams.ts
@@ -54,6 +54,8 @@ export interface AgentTeamSlot {
   bootstrap_prompt?: string | null
   launch_mode: string
   launch_options: SlotLaunchOptions
+  area_labels?: string[] | null
+  expertise?: string | null
   warnings?: string[]
   enabled: boolean
   created_at: string
@@ -67,6 +69,7 @@ export interface AgentTeamPreset {
   created_by?: string | null
   created_at: string
   updated_at: string
+  autonomy_enabled: boolean
   slots: AgentTeamSlot[]
 }
 
@@ -84,6 +87,8 @@ export interface AgentTeamSlotInput {
   bootstrap_prompt?: string | null
   launch_mode?: string
   launch_options?: SlotLaunchOptions
+  area_labels?: string[] | null
+  expertise?: string | null
   enabled?: boolean
   position?: number | null
 }
@@ -98,6 +103,8 @@ export interface AgentTeamSlotUpdate {
   bootstrap_prompt?: string | null
   launch_mode?: string
   launch_options?: SlotLaunchOptions
+  area_labels?: string[] | null
+  expertise?: string | null
   enabled?: boolean
   position?: number
 }
@@ -112,6 +119,7 @@ export interface AgentTeamPresetInput {
 export interface AgentTeamPresetUpdate {
   name?: string
   description?: string | null
+  autonomy_enabled?: boolean
 }
 
 export interface AgentTeamCreateFromMailRequest {
@@ -133,6 +141,91 @@ export interface AgentTeamLaunchRequest {
   include_disabled?: boolean
   confirm_plan_hash?: string | null
   skip_plan_confirmation?: boolean
+  repo_path_override?: string | null
+}
+
+export type TeamGithubMergePolicy = 'human' | 'auto'
+
+export interface TeamGithubScope {
+  id: number
+  preset_id: number
+  repo_owner: string
+  repo_name: string
+  repo_path: string
+  dispatch_label: string
+  design_label: string
+  merge_policy: TeamGithubMergePolicy | string
+  max_approval_rounds: number
+  max_concurrent_dispatched: number
+  max_verification_retries: number
+  max_auto_merges_per_day: number
+  enabled: boolean
+  last_polled_at?: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface TeamGithubScopeInput {
+  repo_owner: string
+  repo_name: string
+  repo_path: string
+  dispatch_label?: string
+  design_label?: string
+  merge_policy?: TeamGithubMergePolicy
+  max_approval_rounds?: number
+  max_concurrent_dispatched?: number
+  max_verification_retries?: number
+  max_auto_merges_per_day?: number
+  enabled?: boolean
+}
+
+export interface TeamGithubScopeUpdate {
+  repo_owner?: string
+  repo_name?: string
+  repo_path?: string
+  dispatch_label?: string
+  design_label?: string
+  merge_policy?: TeamGithubMergePolicy
+  max_approval_rounds?: number
+  max_concurrent_dispatched?: number
+  max_verification_retries?: number
+  max_auto_merges_per_day?: number
+  enabled?: boolean
+}
+
+export interface TeamGithubScopeListResponse {
+  scopes: TeamGithubScope[]
+}
+
+export interface GithubWorkItem {
+  id: number
+  scope_id: number
+  repo_owner: string
+  repo_name: string
+  issue_number: number
+  issue_title: string
+  issue_url: string
+  github_updated_at: string
+  issue_type: 'code' | 'design' | string
+  dispatch_status: string
+  pending_reason?: string | null
+  launch_id?: number | null
+  owner_slot_id?: number | null
+  routing_method?: string | null
+  handoff_state?: string | null
+  handoff_target_slot_id?: number | null
+  approval_round_count: number
+  pr_number?: number | null
+  retry_count: number
+  escalation_reason?: string | null
+  status_note?: string | null
+  auto_merged_at?: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface GithubWorkItemListResponse {
+  items: GithubWorkItem[]
 }
 
 export interface AgentTeamLaunchPlanItem {


### PR DESCRIPTION
## Summary

Implements #277 Phase C: human-facing configuration and observability for Autonomous GitHub Dispatch.

### Backend
- Extends preset update responses and requests with `autonomy_enabled`.
- Exposes slot `area_labels` and `expertise` through create/update/response schemas and service normalization.
- Adds REST endpoints for watched repo scope CRUD:
  - `GET /api/v1/agent-teams/presets/{preset_id}/github-scopes`
  - `POST /api/v1/agent-teams/presets/{preset_id}/github-scopes`
  - `PATCH /api/v1/agent-teams/github-scopes/{scope_id}`
  - `DELETE /api/v1/agent-teams/github-scopes/{scope_id}`
- Adds activity feed endpoint:
  - `GET /api/v1/agent-teams/presets/{preset_id}/github-work-items`
- Adds narrow escalated-item retry endpoint:
  - `POST /api/v1/agent-teams/github-work-items/{work_item_id}/retry`
- Resyncs scheduler jobs after autonomy toggles, preset deletion, and scope CRUD changes.

### Frontend
- Adds Autonomy tab to Agent Teams preset detail view.
- Adds autonomy-enabled badge on the saved team list.
- Adds watched repo cards, add/edit dialog, scope guardrail controls, code-pipeline-only merge-policy warning, and enabled toggle.
- Adds slot editor routing block for `area_labels` and `expertise`.
- Adds activity feed with issue type, status, pending reason, handoff state, owner/routing method, PR link, retry count, escalation reason, and retry action.

## Validation

- `cd backend && source venv/bin/activate && pytest tests/agent_teams/test_agent_team_api.py -q` → 6 passed
- `cd backend && source venv/bin/activate && pytest tests/agent_teams tests/agent_mail -q` → 221 passed
- `cd frontend && npx eslint src/features/agent-teams/AgentTeamsPage.tsx src/features/agent-teams/AutonomyPanel.tsx src/features/agent-teams/api.ts src/types/agentTeams.ts` → passed
- `cd frontend && npm run build` → passed

## Known unrelated failures

- Full backend suite still fails on pre-existing `tests/test_multi_provider_smoke.py::test_agent_bridge_session_filter_smoke`.
- Full frontend `npm run lint` still fails on existing repo-wide lint debt outside this change (`chart.tsx`, usage charts, `lib/api.ts`, and React Compiler warnings in existing pages). The changed Agent Teams files pass targeted ESLint.
