### PR TITLE
feat(dispatch): add leader-owned dependency unblocking

### DIFF
--- a/backend/app/api/v1/agent_teams.py
+++ b/backend/app/api/v1/agent_teams.py
@@ -26,6 +26,7 @@ from app.models.schemas import (
     AgentTeamSlotUpdate,
     DispatchStatusReport,
     GithubWorkItemListResponse,
+    GithubWorkItemRetryRequest,
     GithubWorkItemResponse,
     TeamGithubScopeCreate,
     TeamGithubScopeListResponse,
@@ -405,7 +406,11 @@ async def list_github_work_items(
     "/github-work-items/{work_item_id}/retry",
     response_model=GithubWorkItemResponse,
 )
-async def retry_github_work_item(work_item_id: int, db: AsyncSession = Depends(get_db)):
+async def retry_github_work_item(
+    work_item_id: int,
+    request: GithubWorkItemRetryRequest | None = None,
+    db: AsyncSession = Depends(get_db),
+):
     item = await db.get(GithubWorkItem, work_item_id)
     if item is None:
         raise HTTPException(status_code=404, detail="GitHub work item not found")
@@ -415,6 +420,8 @@ async def retry_github_work_item(work_item_id: int, db: AsyncSession = Depends(g
     if item.dispatch_status != "escalated":
         raise HTTPException(status_code=409, detail="Only escalated work items can be retried")
     github_dispatch_service.reset_for_retry(item)
+    if request is not None and request.reason:
+        item.pending_reason = f"retry requested: {request.reason}"
     await db.commit()
     await db.refresh(item)
     return _work_item_response(item, scope)

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -2202,6 +2202,10 @@ class TeamGithubScopeListResponse(BaseModel):
     scopes: List[TeamGithubScopeResponse] = Field(default_factory=list)
 
 
+class GithubWorkItemRetryRequest(BaseModel):
+    reason: Optional[str] = None
+
+
 class GithubWorkItemResponse(BaseModel):
     id: int
     scope_id: int

--- a/backend/app/services/agent_team_service.py
+++ b/backend/app/services/agent_team_service.py
@@ -604,9 +604,12 @@ class AgentTeamService:
             return result
 
         try:
+            bootstrap_prompt = prompt_override or await self._bootstrap_prompt(
+                db, preset, slot
+            )
             options = self._spawn_options_for_slot(
                 slot,
-                prompt_override or self._bootstrap_prompt(preset, slot),
+                bootstrap_prompt,
                 repo_path_override,
             )
             spawned = spawn_session(
@@ -1085,19 +1088,49 @@ class AgentTeamService:
                 values[key] = value
         return SpawnCommandOptions(**values)
 
-    def _bootstrap_prompt(self, preset: AgentTeamPreset, slot: AgentTeamSlot) -> str:
+    async def _bootstrap_prompt(
+        self,
+        db: AsyncSession,
+        preset: AgentTeamPreset,
+        slot: AgentTeamSlot,
+    ) -> str:
+        is_leader = await self._slot_is_leader(db, preset, slot)
         if slot.bootstrap_prompt:
-            return slot.bootstrap_prompt
-        parts = [
-            f'You are being started by Claude Deck as part of Agent Team "{preset.name}".',
-            f'Your team slot is "{slot.display_name}" for repo "{slot.repo_name}".',
-            "Call `deck_whoami` when the session starts, then check your inbox with `deck_check_inbox(unread_only=False)`.",
-        ]
-        if slot.role:
-            parts.append(f"Role: {slot.role}")
-        if slot.charter:
-            parts.append(f"Charter: {slot.charter}")
-        return "\n".join(parts)
+            base = slot.bootstrap_prompt
+        else:
+            parts = [
+                f'You are being started by Claude Deck as part of Agent Team "{preset.name}".',
+                f'Your team slot is "{slot.display_name}" for repo "{slot.repo_name}".',
+                "Call `deck_whoami` when the session starts, then check your inbox with `deck_check_inbox(unread_only=False)`.",
+            ]
+            if slot.role:
+                parts.append(f"Role: {slot.role}")
+            if slot.charter:
+                parts.append(f"Charter: {slot.charter}")
+            base = "\n".join(parts)
+        if is_leader:
+            from app.services.github_dispatch_service import github_dispatch_service
+
+            base = f"{base}\n\n{github_dispatch_service._leader_unblock_instructions()}"
+        return base
+
+    async def _slot_is_leader(
+        self,
+        db: AsyncSession,
+        preset: AgentTeamPreset,
+        slot: AgentTeamSlot,
+    ) -> bool:
+        first = (
+            await db.execute(
+                select(AgentTeamSlot)
+                .where(
+                    AgentTeamSlot.preset_id == preset.id,
+                    AgentTeamSlot.enabled.is_(True),
+                )
+                .order_by(AgentTeamSlot.position, AgentTeamSlot.id)
+            )
+        ).scalars().first()
+        return first is not None and first.id == slot.id
 
     def _discover_sessions(self) -> list[dict[str, Any]]:
         try:

--- a/backend/app/services/github_dispatch_service.py
+++ b/backend/app/services/github_dispatch_service.py
@@ -679,6 +679,77 @@ class GithubDispatchService:
             },
         )
 
+    async def _escalated_items_payload(
+        self, db: AsyncSession, scope: TeamGithubScope
+    ) -> list[dict]:
+        rows = (
+            await db.execute(
+                select(GithubWorkItem).where(
+                    GithubWorkItem.scope_id == scope.id,
+                    GithubWorkItem.dispatch_status == "escalated",
+                )
+            )
+        ).scalars().all()
+        return [
+            {
+                "work_item_id": row.id,
+                "issue_number": row.issue_number,
+                "escalation_reason": row.escalation_reason,
+                "status_note": row.status_note,
+            }
+            for row in rows
+        ]
+
+    async def notify_blocker_merged(
+        self,
+        db: AsyncSession,
+        scope: TeamGithubScope,
+        item: GithubWorkItem,
+        preset_slots: list[AgentTeamSlot],
+    ) -> None:
+        leader = self._leader_slot(preset_slots)
+        if leader is None:
+            return
+        member = await self._slot_member(db, leader.id)
+        if member is None:
+            return
+        escalated = await self._escalated_items_payload(db, scope)
+        lines = [
+            f"Blocker merged: issue #{item.issue_number} ({item.issue_title}).",
+            "",
+            "Currently escalated items (candidate dependents):",
+        ]
+        if escalated:
+            for entry in escalated:
+                lines.append(
+                    f"- #{entry['issue_number']} (work_item {entry['work_item_id']}): "
+                    f"{entry['status_note'] or entry['escalation_reason']}"
+                )
+        else:
+            lines.append("- (none)")
+        lines += [
+            "",
+            "If any of these were blocked ONLY by the merged issue (and all their "
+            "other blockers are resolved), call "
+            "`deck_retry_work_item(work_item_id=<id>, reason=\"prerequisite #"
+            f"{item.issue_number} merged\")` to re-dispatch them.",
+        ]
+        from app.services.agent_mail_service import agent_mail_service
+
+        await agent_mail_service.send_direct_message(
+            db,
+            recipient_member_id=member.id,
+            subject=f"Blocker merged: issue #{item.issue_number}",
+            body_markdown="\n".join(lines),
+            payload={
+                "kind": "github_dispatch_blocker_merged",
+                "issue_number": item.issue_number,
+                "work_item_id": item.id,
+                "scope_id": item.scope_id,
+                "escalated_items": escalated,
+            },
+        )
+
     async def _owner_member(self, db: AsyncSession, item: GithubWorkItem) -> MailTeamMember | None:
         if item.owner_slot_id is None:
             return None

--- a/backend/app/services/github_dispatch_service.py
+++ b/backend/app/services/github_dispatch_service.py
@@ -332,6 +332,24 @@ class GithubDispatchService:
             + report
         )
 
+    def _leader_unblock_instructions(self) -> str:
+        return (
+            "DEPENDENCY UNBLOCKING (leader duty):\n"
+            "- On team start, scan the roadmap issues and build a dependency map "
+            "(parse 'Blocked by #N' / 'Dependencies' from each issue body): "
+            "issue -> [blocker issues]. Note which blockers are already closed.\n"
+            "- When you receive a `github_dispatch_blocker_merged` notification, mark "
+            "that blocker satisfied in your map. For each ESCALATED dependent in the "
+            "notification's `escalated_items`, check whether ALL of its blockers are now "
+            "resolved.\n"
+            "- For each dependent whose blockers are ALL resolved, call "
+            "`deck_retry_work_item(work_item_id=<id from escalated_items>, "
+            "reason=\"prerequisite #<n> merged\")` to re-dispatch it.\n"
+            "- Only retry when ALL blockers are resolved (never on a single blocker for a "
+            "multi-blocker issue). Do not retry the same dependent twice for one event. If "
+            "a dependency is ambiguous, leave it escalated for a human."
+        )
+
     async def _send_dispatch_brief_to_slot(
         self,
         db: AsyncSession,

--- a/backend/app/services/github_verification_service.py
+++ b/backend/app/services/github_verification_service.py
@@ -9,7 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
-from app.models.database import GithubWorkItem, TeamGithubScope
+from app.models.database import AgentTeamSlot, GithubWorkItem, TeamGithubScope
 from app.services.github_client import GithubClient, github_client
 from app.services.github_dispatch_service import github_dispatch_service
 
@@ -103,6 +103,36 @@ class GithubVerificationService:
                 item.updated_at = datetime.utcnow()
                 await db.commit()
 
+    async def _preset_slots(
+        self, db: AsyncSession, scope: TeamGithubScope
+    ) -> list[AgentTeamSlot]:
+        return (
+            await db.execute(
+                select(AgentTeamSlot)
+                .where(AgentTeamSlot.preset_id == scope.preset_id)
+                .order_by(AgentTeamSlot.position, AgentTeamSlot.id)
+            )
+        ).scalars().all()
+
+    async def _notify_blocker_merged(
+        self,
+        db: AsyncSession,
+        scope: TeamGithubScope,
+        item: GithubWorkItem,
+    ) -> None:
+        try:
+            slots = await self._preset_slots(db, scope)
+            await github_dispatch_service.notify_blocker_merged(
+                db, scope, item, slots
+            )
+            await db.commit()
+        except Exception:
+            logger.exception(
+                "Failed to send blocker-merged notification for work item %s",
+                item.id,
+            )
+            await db.rollback()
+
     async def _verify_item(
         self,
         db: AsyncSession,
@@ -114,6 +144,7 @@ class GithubVerificationService:
         if pull.get("merged"):
             self._mark_merged(item)
             await db.commit()
+            await self._notify_blocker_merged(db, scope, item)
             return
 
         head_sha = self._head_sha(pull)
@@ -177,6 +208,7 @@ class GithubVerificationService:
         if pull.get("merged"):
             self._mark_merged(item)
             await db.commit()
+            await self._notify_blocker_merged(db, scope, item)
             return
         if item.issue_type == "design" or scope.merge_policy != "auto":
             return
@@ -233,6 +265,7 @@ class GithubVerificationService:
         self._mark_merged(item)
         item.auto_merged_at = datetime.utcnow()
         await db.commit()
+        await self._notify_blocker_merged(db, scope, item)
 
     async def _record_transient_merge_failure(
         self,

--- a/backend/app/services/github_watcher_service.py
+++ b/backend/app/services/github_watcher_service.py
@@ -1,17 +1,20 @@
 """Polling watcher for autonomous GitHub dispatch."""
 from __future__ import annotations
 
+import logging
 from datetime import datetime
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.database import GithubWorkItem, TeamGithubScope
+from app.models.database import AgentTeamSlot, GithubWorkItem, TeamGithubScope
 from app.services.github_client import GithubClient, github_client
 from app.services.github_dispatch_service import github_dispatch_service
 
 _ACTIVE_STATUSES = ("dispatched", "verifying", "awaiting_human_review")
 _RECOVERABLE_STATUSES = ("failed", "escalated")
+
+logger = logging.getLogger(__name__)
 
 
 def _parse_gh_ts(value: str) -> datetime:
@@ -94,6 +97,25 @@ class GithubWatcherService:
                 item.dispatch_status = "completed"
                 item.escalation_reason = None
                 item.updated_at = datetime.utcnow()
+                await db.commit()
+                try:
+                    slots = (
+                        await db.execute(
+                            select(AgentTeamSlot)
+                            .where(AgentTeamSlot.preset_id == scope.preset_id)
+                            .order_by(AgentTeamSlot.position, AgentTeamSlot.id)
+                        )
+                    ).scalars().all()
+                    await github_dispatch_service.notify_blocker_merged(
+                        db, scope, item, slots
+                    )
+                    await db.commit()
+                except Exception:
+                    logger.exception(
+                        "Failed to send blocker-merged notification for work item %s",
+                        item.id,
+                    )
+                    await db.rollback()
                 continue
             still_labeled = issue is not None and any(
                 label["name"] == scope.dispatch_label for label in issue.get("labels", [])

--- a/backend/mcp_shim/agent_mail_server.py
+++ b/backend/mcp_shim/agent_mail_server.py
@@ -627,6 +627,21 @@ def deck_report_dispatch_status(
     return _dispatch_request("POST", "/dispatch-status", json=payload)
 
 
+@mcp.tool()
+def deck_retry_work_item(work_item_id: int, reason: str = "") -> dict:
+    """Leader-only: request re-dispatch of an ESCALATED GitHub work item whose
+    blockers are now resolved. Pass the work_item_id (from the blocker-merged
+    notification's escalated_items) and a short reason, e.g.
+    'prerequisite #816 merged'. Rejected (409) if the item is not escalated.
+    """
+    _ensure_registered()
+    return _dispatch_request(
+        "POST",
+        f"/github-work-items/{work_item_id}/retry",
+        json={"reason": reason},
+    )
+
+
 if __name__ == "__main__":
     _start_heartbeat_thread()
     mcp.run()

--- a/backend/tests/agent_mail/test_dispatch_status_tool.py
+++ b/backend/tests/agent_mail/test_dispatch_status_tool.py
@@ -144,6 +144,7 @@ def test_shim_exposes_dispatch_status_tool():
 
     shim = importlib.import_module("mcp_shim.agent_mail_server")
     assert hasattr(shim, "deck_report_dispatch_status")
+    assert hasattr(shim, "deck_retry_work_item")
     assert hasattr(shim, "_dispatch_request")
 
 
@@ -176,3 +177,36 @@ def test_shim_dispatch_status_reports_team_slot(monkeypatch):
     assert requests[0][0:2] == ("POST", "/dispatch-status")
     assert requests[0][2]["json"]["reporting_slot_id"] == 7
     assert requests[0][2]["json"]["pr_number"] == 456
+
+
+def test_shim_retry_work_item_posts_reason(monkeypatch):
+    import importlib
+
+    shim = importlib.import_module("mcp_shim.agent_mail_server")
+    requests = []
+
+    monkeypatch.setattr(
+        shim,
+        "_ensure_registered",
+        lambda: {"ok": True, "data": {"member": {"id": 1, "team_slot_id": 7}}},
+    )
+
+    def fake_dispatch_request(method, path, **kwargs):
+        requests.append((method, path, kwargs))
+        return {"ok": True, "data": {"dispatch_status": "pending"}}
+
+    monkeypatch.setattr(shim, "_dispatch_request", fake_dispatch_request)
+
+    result = shim.deck_retry_work_item(
+        123,
+        reason="prerequisite #816 merged",
+    )
+
+    assert result["ok"] is True
+    assert requests == [
+        (
+            "POST",
+            "/github-work-items/123/retry",
+            {"json": {"reason": "prerequisite #816 merged"}},
+        )
+    ]

--- a/backend/tests/agent_teams/test_agent_team_api.py
+++ b/backend/tests/agent_teams/test_agent_team_api.py
@@ -328,18 +328,20 @@ async def test_github_work_item_feed_and_retry_guard(client, db, tmp_path):
     assert row["escalation_reason"] == "retry_count_exhausted"
 
     guard_response = await client.post(
-        f"/api/v1/agent-teams/github-work-items/{active.id}/retry"
+        f"/api/v1/agent-teams/github-work-items/{active.id}/retry",
+        json={"reason": "should remain guarded"},
     )
     assert guard_response.status_code == 409
 
     retry_response = await client.post(
-        f"/api/v1/agent-teams/github-work-items/{escalated.id}/retry"
+        f"/api/v1/agent-teams/github-work-items/{escalated.id}/retry",
+        json={"reason": "prerequisite #816 merged"},
     )
     assert retry_response.status_code == 200
     body = retry_response.json()
     assert body["dispatch_status"] == "pending"
     assert body["escalation_reason"] is None
-    assert body["pending_reason"] is None
+    assert body["pending_reason"] == "retry requested: prerequisite #816 merged"
     assert body["handoff_state"] is None
     assert body["handoff_target_slot_id"] is None
     assert body["pr_number"] is None

--- a/backend/tests/agent_teams/test_agent_team_service.py
+++ b/backend/tests/agent_teams/test_agent_team_service.py
@@ -1158,7 +1158,8 @@ async def test_launch_uses_custom_bootstrap_prompt(db, tmp_path, monkeypatch):
         AgentTeamLaunchRequest(confirm_plan_hash=plan.plan_hash),
     )
 
-    assert calls[0][1].prompt == "Custom team startup prompt."
+    assert calls[0][1].prompt.startswith("Custom team startup prompt.")
+    assert "deck_retry_work_item" in calls[0][1].prompt
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_teams/test_github_dispatch_service.py
+++ b/backend/tests/agent_teams/test_github_dispatch_service.py
@@ -124,6 +124,44 @@ async def _create_registered_slot_member(db, slot: AgentTeamSlot) -> MailTeamMem
     return member
 
 
+def test_leader_unblock_instructions_text():
+    text = github_dispatch_service._leader_unblock_instructions()
+    assert "dependency map" in text.lower()
+    assert "deck_retry_work_item" in text
+    assert "github_dispatch_blocker_merged" in text
+    assert "all" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_prompt_appends_unblock_only_for_leader(db):
+    from app.services.agent_team_service import agent_team_service
+
+    preset, slots, scope = await _team(db)
+    leader, non_leader = slots[0], slots[1]
+
+    leader_text = await agent_team_service._bootstrap_prompt(db, preset, leader)
+    non_leader_text = await agent_team_service._bootstrap_prompt(db, preset, non_leader)
+
+    assert "deck_retry_work_item" in leader_text
+    assert "dependency map" in leader_text.lower()
+    assert "deck_retry_work_item" not in non_leader_text
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_prompt_appends_unblock_even_with_custom_prompt(db):
+    from app.services.agent_team_service import agent_team_service
+
+    preset, slots, scope = await _team(db)
+    leader = slots[0]
+    leader.bootstrap_prompt = "CUSTOM standing prompt."
+    await db.commit()
+
+    text = await agent_team_service._bootstrap_prompt(db, preset, leader)
+
+    assert text.startswith("CUSTOM standing prompt.")
+    assert "deck_retry_work_item" in text
+
+
 @pytest.mark.asyncio
 async def test_notify_blocker_merged_sends_leader_message_with_escalated_items(db):
     preset, slots, scope = await _team(db)

--- a/backend/tests/agent_teams/test_github_dispatch_service.py
+++ b/backend/tests/agent_teams/test_github_dispatch_service.py
@@ -125,6 +125,98 @@ async def _create_registered_slot_member(db, slot: AgentTeamSlot) -> MailTeamMem
 
 
 @pytest.mark.asyncio
+async def test_notify_blocker_merged_sends_leader_message_with_escalated_items(db):
+    preset, slots, scope = await _team(db)
+    architect, backend = slots[0], slots[1]
+    from app.services.agent_mail_service import agent_mail_service
+
+    leader_member = await agent_mail_service.get_or_create_slot_member(db, architect)
+    await db.commit()
+    merged = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=816,
+        issue_title="baseline",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="merged",
+    )
+    dep1 = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=817,
+        issue_title="build",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="escalated",
+        escalation_reason="plan_blocked",
+        status_note="Blocked by #816",
+    )
+    dep2 = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=818,
+        issue_title="gmusic",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="escalated",
+        escalation_reason="plan_blocked",
+        status_note="Blocked by #817",
+    )
+    other = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=828,
+        issue_title="docs",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="dispatched",
+    )
+    db.add_all([merged, dep1, dep2, other])
+    await db.commit()
+
+    await github_dispatch_service.notify_blocker_merged(db, scope, merged, slots)
+
+    messages = (await db.execute(select(MailMessage))).scalars().all()
+    hit = [
+        message
+        for message in messages
+        if (message.payload or {}).get("kind") == "github_dispatch_blocker_merged"
+    ]
+    assert len(hit) == 1
+    message = hit[0]
+    assert message.recipient_member_id == leader_member.id
+    assert "816" in (message.subject or "")
+    escalated = {entry["issue_number"] for entry in message.payload["escalated_items"]}
+    assert escalated == {817, 818}
+    work_item_ids = {
+        entry["work_item_id"] for entry in message.payload["escalated_items"]
+    }
+    assert dep1.id in work_item_ids and dep2.id in work_item_ids
+    assert message.payload["issue_number"] == 816
+
+
+@pytest.mark.asyncio
+async def test_notify_blocker_merged_noop_when_no_leader_registered(db):
+    preset, slots, scope = await _team(db)
+    merged = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=816,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="merged",
+    )
+    db.add(merged)
+    await db.commit()
+
+    await github_dispatch_service.notify_blocker_merged(db, scope, merged, slots)
+
+    messages = (await db.execute(select(MailMessage))).scalars().all()
+    assert not [
+        message
+        for message in messages
+        if (message.payload or {}).get("kind") == "github_dispatch_blocker_merged"
+    ]
+
+
+@pytest.mark.asyncio
 async def test_work_item_has_lifecycle_columns(db):
     preset, slots, scope = await _team(db)
     now = datetime.utcnow()

--- a/backend/tests/agent_teams/test_github_verification_service.py
+++ b/backend/tests/agent_teams/test_github_verification_service.py
@@ -163,6 +163,15 @@ async def _ready_review_messages(db):
     return [message for message in messages if message.subject == "Code PR ready for review"]
 
 
+async def _blocker_merged_messages(db):
+    messages = (await db.execute(select(MailMessage))).scalars().all()
+    return [
+        message
+        for message in messages
+        if (message.payload or {}).get("kind") == "github_dispatch_blocker_merged"
+    ]
+
+
 async def _auto_ready_item(
     db,
     *,
@@ -229,10 +238,58 @@ async def test_auto_merge_proceeds_when_head_unchanged_and_green(db):
         current_head="aaa111",
         head_checks=[{"status": "completed", "conclusion": "success"}],
     )
+    await _owner(db, scope)
     await github_verification_service._process_review_item(db, scope, item, client)
     await db.refresh(item)
     assert item.dispatch_status == "merged"
     assert client.merge_calls == 1
+    assert len(await _blocker_merged_messages(db)) == 1
+
+
+@pytest.mark.asyncio
+async def test_verifying_merged_pull_fires_blocker_merged_notification(db):
+    scope = await _scope(db, merge_policy="human")
+    await _owner(db, scope)
+    item = await _item(db, scope, dispatch_status="verifying", pr_number=5)
+    client = _Client(
+        pull={
+            "number": 5,
+            "node_id": "node",
+            "draft": False,
+            "merged": True,
+            "mergeable_state": "clean",
+            "head": {"sha": "sha"},
+        }
+    )
+
+    await github_verification_service._verify_item(db, scope, item, client)
+
+    await db.refresh(item)
+    assert item.dispatch_status == "merged"
+    assert len(await _blocker_merged_messages(db)) == 1
+
+
+@pytest.mark.asyncio
+async def test_human_merge_fires_blocker_merged_notification(db):
+    scope = await _scope(db, merge_policy="human")
+    await _owner(db, scope)
+    item = await _item(db, scope, dispatch_status="ready_for_review", pr_number=5)
+    client = _Client(
+        pull={
+            "number": 5,
+            "node_id": "node",
+            "draft": False,
+            "merged": True,
+            "mergeable_state": "clean",
+            "head": {"sha": "sha"},
+        }
+    )
+
+    await github_verification_service._process_review_item(db, scope, item, client)
+
+    await db.refresh(item)
+    assert item.dispatch_status == "merged"
+    assert len(await _blocker_merged_messages(db)) == 1
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_teams/test_github_watcher_service.py
+++ b/backend/tests/agent_teams/test_github_watcher_service.py
@@ -310,3 +310,59 @@ async def test_active_item_closed_does_not_escalate_as_label_removed(db):
     await db.refresh(item)
     assert item.dispatch_status == "completed"
     assert item.escalation_reason is None
+
+
+@pytest.mark.asyncio
+async def test_watcher_completed_fires_blocker_merged_notification(db):
+    scope = await _make_scope(db)
+    leader = AgentTeamSlot(
+        preset_id=scope.preset_id,
+        position=0,
+        display_name="Leader",
+        provider="codex-cli",
+        repo_id="r",
+        repo_path="/tmp/r",
+        repo_name="r",
+    )
+    db.add(leader)
+    await db.flush()
+    member = MailTeamMember(
+        identity_key="slot:leader",
+        repo_id="r",
+        repo_path="/tmp/r",
+        repo_name="r",
+        display_name="Leader",
+        participant_kind="team_slot",
+        team_preset_id=scope.preset_id,
+        team_slot_id=leader.id,
+    )
+    db.add(member)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=858,
+        issue_title="design",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="awaiting_human_review",
+    )
+    db.add(item)
+    await db.commit()
+    closed = _issue(858, ["claude-deck-ready"])
+    closed["state"] = "closed"
+
+    await github_watcher_service.poll_scope(
+        db,
+        scope,
+        _FakeClient(labeled=[], by_number={858: closed}),
+    )
+
+    await db.refresh(item)
+    assert item.dispatch_status == "completed"
+    messages = (await db.execute(select(MailMessage))).scalars().all()
+    notifications = [
+        message
+        for message in messages
+        if (message.payload or {}).get("kind") == "github_dispatch_blocker_merged"
+    ]
+    assert len(notifications) == 1
+    assert notifications[0].recipient_member_id == member.id


### PR DESCRIPTION
## Summary

- notify the registered leader whenever a work item reaches merged/completed, with a self-contained list of currently escalated candidates
- fire the notification for verifying merges, human merges, auto-merges, and watcher-detected completion without allowing notification failures to roll back terminal state
- add `deck_retry_work_item` and preserve the leader's retry reason while retaining the escalated-only guard
- deliver dependency-map/unblocking guidance through the first enabled slot's standing bootstrap prompt, including custom bootstrap prompts

## Verification

- `cd backend && .venv/bin/pytest tests/agent_teams tests/agent_mail -q`
- 261 passed
- no changes to `backend/app/models/database.py` or `backend/app/database.py`

Relates to #294. Targets the autonomous-dispatch integration branch; do not merge to master yet.
