### PR TITLE
fix(dispatch): preserve in-flight work across escalation

### DIFF
--- a/backend/app/api/v1/agent_teams.py
+++ b/backend/app/api/v1/agent_teams.py
@@ -419,6 +419,14 @@ async def retry_github_work_item(
         raise HTTPException(status_code=404, detail="GitHub scope not found")
     if item.dispatch_status != "escalated":
         raise HTTPException(status_code=409, detail="Only escalated work items can be retried")
+    if item.pr_number is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Work item has PR #{item.pr_number} already open; retry would orphan "
+                "it. Resolve or close the PR first."
+            ),
+        )
     github_dispatch_service.reset_for_retry(item)
     if request is not None and request.reason:
         item.pending_reason = f"retry requested: {request.reason}"

--- a/backend/app/services/github_dispatch_service.py
+++ b/backend/app/services/github_dispatch_service.py
@@ -647,11 +647,20 @@ class GithubDispatchService:
         reason: str,
         note: str | None = None,
     ) -> None:
+        owner_may_be_active = (
+            item.dispatch_status == "dispatched" and item.owner_slot_id is not None
+        )
         applied = self._apply_escalation(item, reason, note)
         if not applied:
             return
         try:
-            await self._send_escalation_broadcast(db, item, reason, note)
+            await self._send_escalation_broadcast(
+                db,
+                item,
+                reason,
+                note,
+                owner_may_be_active=owner_may_be_active,
+            )
             if reason == "dispatch_label_removed":
                 await self._send_label_removed_owner_message(db, item)
         except Exception:
@@ -729,6 +738,8 @@ class GithubDispatchService:
         item: GithubWorkItem,
         reason: str,
         note: str | None,
+        *,
+        owner_may_be_active: bool = False,
     ) -> None:
         scope = await db.get(TeamGithubScope, item.scope_id)
         repo = f"{scope.repo_owner}/{scope.repo_name}" if scope is not None else "unknown repo"
@@ -741,6 +752,15 @@ class GithubDispatchService:
         ]
         if item.issue_url:
             lines.append(f"- URL: {item.issue_url}")
+        if owner_may_be_active:
+            lines.extend(
+                [
+                    "",
+                    "- NOTE: this item's owner session may still be working. Do NOT "
+                    "retry it — retrying clears any PR it has opened. Confirm with the "
+                    "coordinator first.",
+                ]
+            )
         if note:
             lines.extend(["", note])
         await self.notify_team(
@@ -753,6 +773,7 @@ class GithubDispatchService:
                 "issue_number": item.issue_number,
                 "scope_id": item.scope_id,
                 "reason": reason,
+                "owner_may_be_active": owner_may_be_active,
             },
         )
 

--- a/backend/app/services/github_verification_service.py
+++ b/backend/app/services/github_verification_service.py
@@ -24,6 +24,17 @@ _HUMAN_MERGE_NOTE_PREFIXES = (
     "Auto-merge retry budget exhausted",
 )
 _MERGE_TRANSIENT_STATUS_CODES = {405, 409, 422}
+# Escalations a late PR legitimately resolves: the agent said it was stuck, or Deck
+# inferred it from a timer. Anything not listed stays rejected by default.
+_PR_OPENED_RECOVERABLE_ESCALATIONS = frozenset(
+    {
+        "plan_blocked",
+        "owner_idle_timeout",
+        "owner_offline",
+        "leader_offline",
+        "leader_ack_timeout",
+    }
+)
 
 logger = logging.getLogger(__name__)
 
@@ -36,11 +47,18 @@ class GithubVerificationService:
         scope: TeamGithubScope,
         pr_number: int,
     ) -> None:
-        if item.dispatch_status != "dispatched":
-            raise ValueError(
-                f"pr_opened is only valid for dispatched work items; current status is "
-                f"{item.dispatch_status}"
+        recoverable = (
+            item.dispatch_status == "escalated"
+            and item.escalation_reason in _PR_OPENED_RECOVERABLE_ESCALATIONS
         )
+        if item.dispatch_status != "dispatched" and not recoverable:
+            raise ValueError(
+                f"pr_opened is only valid for dispatched work items, or escalated "
+                f"items with a recoverable reason; current status is "
+                f"{item.dispatch_status} ({item.escalation_reason})"
+            )
+        if recoverable:
+            item.escalation_reason = None
         item.pr_number = pr_number
         item.last_verified_sha = None
         if item.issue_type == "design":

--- a/backend/app/services/github_watcher_service.py
+++ b/backend/app/services/github_watcher_service.py
@@ -94,28 +94,7 @@ class GithubWatcherService:
         for item in active:
             issue = current.get(item.issue_number)
             if issue is not None and issue.get("state") == "closed":
-                item.dispatch_status = "completed"
-                item.escalation_reason = None
-                item.updated_at = datetime.utcnow()
-                await db.commit()
-                try:
-                    slots = (
-                        await db.execute(
-                            select(AgentTeamSlot)
-                            .where(AgentTeamSlot.preset_id == scope.preset_id)
-                            .order_by(AgentTeamSlot.position, AgentTeamSlot.id)
-                        )
-                    ).scalars().all()
-                    await github_dispatch_service.notify_blocker_merged(
-                        db, scope, item, slots
-                    )
-                    await db.commit()
-                except Exception:
-                    logger.exception(
-                        "Failed to send blocker-merged notification for work item %s",
-                        item.id,
-                    )
-                    await db.rollback()
+                await self._complete_and_notify(db, scope, item)
                 continue
             still_labeled = issue is not None and any(
                 label["name"] == scope.dispatch_label for label in issue.get("labels", [])
@@ -127,6 +106,29 @@ class GithubWatcherService:
                     "dispatch_label_removed",
                     "The dispatch label was removed from the issue.",
                 )
+
+    async def _complete_and_notify(
+        self, db: AsyncSession, scope: TeamGithubScope, item: GithubWorkItem
+    ) -> None:
+        item.dispatch_status = "completed"
+        item.escalation_reason = None
+        item.updated_at = datetime.utcnow()
+        await db.commit()
+        try:
+            slots = (
+                await db.execute(
+                    select(AgentTeamSlot)
+                    .where(AgentTeamSlot.preset_id == scope.preset_id)
+                    .order_by(AgentTeamSlot.position, AgentTeamSlot.id)
+                )
+            ).scalars().all()
+            await github_dispatch_service.notify_blocker_merged(db, scope, item, slots)
+            await db.commit()
+        except Exception:
+            logger.exception(
+                "Failed to send blocker-merged notification for work item %s", item.id
+            )
+            await db.rollback()
 
 
 github_watcher_service = GithubWatcherService()

--- a/backend/app/services/github_watcher_service.py
+++ b/backend/app/services/github_watcher_service.py
@@ -13,6 +13,9 @@ from app.services.github_dispatch_service import github_dispatch_service
 
 _ACTIVE_STATUSES = ("dispatched", "verifying", "awaiting_human_review")
 _RECOVERABLE_STATUSES = ("failed", "escalated")
+# Kept separate from _ACTIVE_STATUSES: that tuple also drives label removal,
+# which would turn failed items into retryable escalations behind the operator's back.
+_CLOSED_ISSUE_RECONCILABLE_STATUSES = ("escalated", "failed")
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +35,7 @@ class GithubWatcherService:
         for issue in labeled:
             await self._upsert_item(db, scope, issue)
         await self._recheck_active_items(db, scope, client)
+        await self._reconcile_closed_issues(db, scope, client)
         scope.last_polled_at = datetime.utcnow()
         await db.commit()
 
@@ -106,6 +110,41 @@ class GithubWatcherService:
                     "dispatch_label_removed",
                     "The dispatch label was removed from the issue.",
                 )
+
+    async def _reconcile_closed_issues(
+        self, db: AsyncSession, scope: TeamGithubScope, client: GithubClient
+    ) -> None:
+        stalled = (
+            await db.execute(
+                select(GithubWorkItem).where(
+                    GithubWorkItem.scope_id == scope.id,
+                    GithubWorkItem.dispatch_status.in_(
+                        _CLOSED_ISSUE_RECONCILABLE_STATUSES
+                    ),
+                )
+            )
+        ).scalars().all()
+        if not stalled:
+            return
+        current = await client.get_issues_by_number(
+            scope.repo_owner,
+            scope.repo_name,
+            [item.issue_number for item in stalled],
+        )
+        for item in stalled:
+            issue = current.get(item.issue_number)
+            if issue is None or issue.get("state") != "closed":
+                continue
+            if item.pr_number is not None:
+                logger.info(
+                    "Work item %s (issue #%s) has a closed issue but an unresolved "
+                    "PR #%s; leaving it for the verification path",
+                    item.id,
+                    item.issue_number,
+                    item.pr_number,
+                )
+                continue
+            await self._complete_and_notify(db, scope, item)
 
     async def _complete_and_notify(
         self, db: AsyncSession, scope: TeamGithubScope, item: GithubWorkItem

--- a/backend/tests/agent_teams/test_agent_team_api.py
+++ b/backend/tests/agent_teams/test_agent_team_api.py
@@ -8,7 +8,7 @@ import pytest_asyncio
 
 from app.database import get_db
 from app.main import app
-from app.models.database import GithubWorkItem, TeamGithubScope
+from app.models.database import AgentTeamPreset, GithubWorkItem, TeamGithubScope
 from app.models.schemas import AgentTeamPresetCreate, AgentTeamSlotCreate
 from app.services.agent_team_service import agent_team_service
 
@@ -301,7 +301,7 @@ async def test_github_work_item_feed_and_retry_guard(client, db, tmp_path):
         pending_reason="queued_repo_cap",
         handoff_state="pending",
         handoff_target_slot_id=1,
-        pr_number=12,
+        pr_number=None,
         retry_count=2,
         last_verified_sha="abc123",
         approval_round_count=3,
@@ -348,3 +348,60 @@ async def test_github_work_item_feed_and_retry_guard(client, db, tmp_path):
     assert body["retry_count"] == 0
     assert body["last_verified_sha"] is None
     assert body["approval_round_count"] == 0
+
+
+async def _create_retry_work_item(db, *, pr_number: int | None) -> GithubWorkItem:
+    preset = AgentTeamPreset(name="Retry team")
+    db.add(preset)
+    await db.flush()
+    scope = TeamGithubScope(
+        preset_id=preset.id,
+        repo_owner="adrirubio",
+        repo_name="snazzyemail",
+        repo_path="/tmp/snazzyemail",
+    )
+    db.add(scope)
+    await db.flush()
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=865,
+        issue_title="Preserve open PR",
+        issue_url="https://github.com/adrirubio/snazzyemail/issues/865",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="escalated",
+        escalation_reason="plan_blocked",
+        pr_number=pr_number,
+    )
+    db.add(item)
+    await db.commit()
+    return item
+
+
+@pytest.mark.asyncio
+async def test_retry_rejected_when_pr_open(client, db):
+    item = await _create_retry_work_item(db, pr_number=865)
+
+    response = await client.post(
+        f"/api/v1/agent-teams/github-work-items/{item.id}/retry",
+        json={"reason": "try again"},
+    )
+
+    assert response.status_code == 409
+    assert "865" in response.json()["detail"]
+    await db.refresh(item)
+    assert item.pr_number == 865
+    assert item.dispatch_status == "escalated"
+
+
+@pytest.mark.asyncio
+async def test_retry_allowed_when_no_pr(client, db):
+    item = await _create_retry_work_item(db, pr_number=None)
+
+    response = await client.post(
+        f"/api/v1/agent-teams/github-work-items/{item.id}/retry",
+        json={"reason": "try again"},
+    )
+
+    assert response.status_code == 200
+    await db.refresh(item)
+    assert item.dispatch_status == "pending"

--- a/backend/tests/agent_teams/test_github_dispatch_service.py
+++ b/backend/tests/agent_teams/test_github_dispatch_service.py
@@ -962,6 +962,62 @@ async def test_escalate_sets_reason_for_active_item(db):
 
 
 @pytest.mark.asyncio
+async def test_escalation_broadcast_flags_active_owner(db):
+    preset, slots, scope = await _team(db)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=65,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="dispatched",
+        owner_slot_id=slots[1].id,
+    )
+    db.add(item)
+    await db.commit()
+
+    await github_dispatch_service.escalate(db, item, "owner_idle_timeout")
+
+    message = (
+        await db.execute(
+            select(MailMessage).where(
+                MailMessage.kind == "broadcast",
+                MailMessage.payload["kind"].as_string() == "github_dispatch_escalation",
+            )
+        )
+    ).scalar_one()
+    assert message.payload["owner_may_be_active"] is True
+    assert "Do NOT retry" in message.body_markdown
+
+
+@pytest.mark.asyncio
+async def test_escalation_broadcast_no_active_owner_for_pending_item(db):
+    preset, slots, scope = await _team(db)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=66,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="pending",
+    )
+    db.add(item)
+    await db.commit()
+
+    await github_dispatch_service.escalate(db, item, "plan_blocked")
+
+    message = (
+        await db.execute(
+            select(MailMessage).where(
+                MailMessage.kind == "broadcast",
+                MailMessage.payload["kind"].as_string() == "github_dispatch_escalation",
+            )
+        )
+    ).scalar_one()
+    assert message.payload["owner_may_be_active"] is False
+
+
+@pytest.mark.asyncio
 async def test_escalate_preserves_first_reason_for_already_escalated_item(db):
     preset, slots, scope = await _team(db)
     item = GithubWorkItem(

--- a/backend/tests/agent_teams/test_github_verification_service.py
+++ b/backend/tests/agent_teams/test_github_verification_service.py
@@ -311,6 +311,95 @@ async def test_report_pr_opened_routes_code_and_design(db):
 
 
 @pytest.mark.asyncio
+async def test_pr_opened_accepted_from_recoverable_escalation(db):
+    scope = await _scope(db)
+    item = await _item(
+        db,
+        scope,
+        dispatch_status="escalated",
+        escalation_reason="plan_blocked",
+        issue_type="code",
+    )
+
+    await github_verification_service.report_pr_opened(db, item, scope, 865)
+
+    await db.refresh(item)
+    assert item.dispatch_status == "verifying"
+    assert item.pr_number == 865
+    assert item.escalation_reason is None
+
+
+@pytest.mark.asyncio
+async def test_pr_opened_accepted_from_recoverable_escalation_design_item(db):
+    scope = await _scope(db)
+    item = await _item(
+        db,
+        scope,
+        dispatch_status="escalated",
+        escalation_reason="plan_blocked",
+        issue_type="design",
+    )
+
+    await github_verification_service.report_pr_opened(db, item, scope, 865)
+
+    await db.refresh(item)
+    assert item.dispatch_status == "awaiting_human_review"
+    assert item.pr_number == 865
+    assert item.escalation_reason is None
+
+
+@pytest.mark.asyncio
+async def test_pr_opened_rejected_after_label_removed(db):
+    scope = await _scope(db)
+    item = await _item(
+        db,
+        scope,
+        dispatch_status="escalated",
+        escalation_reason="dispatch_label_removed",
+    )
+
+    with pytest.raises(ValueError):
+        await github_verification_service.report_pr_opened(db, item, scope, 865)
+
+
+@pytest.mark.asyncio
+async def test_pr_opened_rejected_after_retry_budget_exhausted(db):
+    scope = await _scope(db)
+    item = await _item(
+        db,
+        scope,
+        dispatch_status="escalated",
+        escalation_reason="retry_count_exhausted",
+    )
+
+    with pytest.raises(ValueError):
+        await github_verification_service.report_pr_opened(db, item, scope, 865)
+
+
+@pytest.mark.asyncio
+async def test_pr_opened_rejected_from_unattributed_escalation(db):
+    scope = await _scope(db)
+    item = await _item(
+        db,
+        scope,
+        dispatch_status="escalated",
+        escalation_reason=None,
+    )
+
+    with pytest.raises(ValueError):
+        await github_verification_service.report_pr_opened(db, item, scope, 865)
+
+
+@pytest.mark.asyncio
+async def test_pr_opened_still_rejected_from_merged(db):
+    scope = await _scope(db)
+    item = await _item(db, scope, dispatch_status="merged")
+
+    with pytest.raises(ValueError):
+        await github_verification_service.report_pr_opened(db, item, scope, 865)
+
+
+@pytest.mark.asyncio
 async def test_verify_green_code_pr_marks_ready_for_review(db):
     scope = await _scope(db)
     item = await _item(db, scope, dispatch_status="verifying", pr_number=5)

--- a/backend/tests/agent_teams/test_github_watcher_service.py
+++ b/backend/tests/agent_teams/test_github_watcher_service.py
@@ -366,3 +366,210 @@ async def test_watcher_completed_fires_blocker_merged_notification(db):
     ]
     assert len(notifications) == 1
     assert notifications[0].recipient_member_id == member.id
+
+
+@pytest.mark.asyncio
+async def test_closed_issue_reconciles_escalated_item(db):
+    scope = await _make_scope(db)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=818,
+        issue_title="blocked work",
+        issue_url="u",
+        github_updated_at=datetime(2026, 7, 4),
+        dispatch_status="escalated",
+        escalation_reason="plan_blocked",
+    )
+    db.add(item)
+    await db.commit()
+    closed = _issue(818, ["claude-deck-ready"])
+    closed["state"] = "closed"
+
+    await github_watcher_service.poll_scope(
+        db,
+        scope,
+        _FakeClient(labeled=[], by_number={818: closed}),
+    )
+
+    await db.refresh(item)
+    assert item.dispatch_status == "completed"
+    assert item.escalation_reason is None
+
+
+@pytest.mark.asyncio
+async def test_closed_issue_reconciliation_fires_blocker_merged_notification(db):
+    scope = await _make_scope(db)
+    leader = AgentTeamSlot(
+        preset_id=scope.preset_id,
+        position=0,
+        display_name="Leader",
+        provider="codex-cli",
+        repo_id="r",
+        repo_path="/tmp/r",
+        repo_name="r",
+    )
+    db.add(leader)
+    await db.flush()
+    member = MailTeamMember(
+        identity_key="slot:closed-reconciliation-leader",
+        repo_id="r",
+        repo_path="/tmp/r",
+        repo_name="r",
+        display_name="Leader",
+        participant_kind="team_slot",
+        team_preset_id=scope.preset_id,
+        team_slot_id=leader.id,
+    )
+    db.add(member)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=819,
+        issue_title="blocked work",
+        issue_url="u",
+        github_updated_at=datetime(2026, 7, 4),
+        dispatch_status="escalated",
+        escalation_reason="plan_blocked",
+    )
+    db.add(item)
+    await db.commit()
+    closed = _issue(819, ["claude-deck-ready"])
+    closed["state"] = "closed"
+
+    await github_watcher_service.poll_scope(
+        db,
+        scope,
+        _FakeClient(labeled=[], by_number={819: closed}),
+    )
+
+    messages = (await db.execute(select(MailMessage))).scalars().all()
+    notifications = [
+        message
+        for message in messages
+        if (message.payload or {}).get("kind") == "github_dispatch_blocker_merged"
+    ]
+    assert len(notifications) == 1
+    assert notifications[0].recipient_member_id == member.id
+
+
+@pytest.mark.asyncio
+async def test_closed_issue_reconciles_failed_item(db):
+    scope = await _make_scope(db)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=820,
+        issue_title="failed work",
+        issue_url="u",
+        github_updated_at=datetime(2026, 7, 4),
+        dispatch_status="failed",
+        escalation_reason="launch_failed",
+    )
+    db.add(item)
+    await db.commit()
+    closed = _issue(820, ["claude-deck-ready"])
+    closed["state"] = "closed"
+
+    await github_watcher_service.poll_scope(
+        db,
+        scope,
+        _FakeClient(labeled=[], by_number={820: closed}),
+    )
+
+    await db.refresh(item)
+    assert item.dispatch_status == "completed"
+    assert item.escalation_reason is None
+
+
+@pytest.mark.asyncio
+async def test_closed_issue_skips_item_with_open_pr(db, caplog):
+    scope = await _make_scope(db)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=821,
+        issue_title="work with open PR",
+        issue_url="u",
+        github_updated_at=datetime(2026, 7, 4),
+        dispatch_status="escalated",
+        escalation_reason="dispatch_label_removed",
+        pr_number=865,
+    )
+    db.add(item)
+    await db.commit()
+    closed = _issue(821, ["claude-deck-ready"])
+    closed["state"] = "closed"
+    caplog.set_level("INFO", logger="app.services.github_watcher_service")
+
+    await github_watcher_service.poll_scope(
+        db,
+        scope,
+        _FakeClient(labeled=[], by_number={821: closed}),
+    )
+
+    await db.refresh(item)
+    assert item.dispatch_status == "escalated"
+    assert item.escalation_reason == "dispatch_label_removed"
+    assert item.pr_number == 865
+    messages = (await db.execute(select(MailMessage))).scalars().all()
+    assert not any(
+        (message.payload or {}).get("kind") == "github_dispatch_blocker_merged"
+        for message in messages
+    )
+    assert "unresolved PR #865" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_failed_item_with_label_removed_is_not_laundered_into_escalated(db):
+    scope = await _make_scope(db)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=822,
+        issue_title="failed work",
+        issue_url="u",
+        github_updated_at=datetime(2026, 7, 4),
+        dispatch_status="failed",
+        escalation_reason="launch_failed",
+    )
+    db.add(item)
+    await db.commit()
+    open_issue = _issue(822, [])
+
+    await github_watcher_service.poll_scope(
+        db,
+        scope,
+        _FakeClient(labeled=[], by_number={822: open_issue}),
+    )
+
+    await db.refresh(item)
+    assert item.dispatch_status == "failed"
+    assert item.escalation_reason == "launch_failed"
+
+
+@pytest.mark.asyncio
+async def test_escalated_item_with_open_labeled_issue_is_untouched(db):
+    scope = await _make_scope(db)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=823,
+        issue_title="blocked work",
+        issue_url="u",
+        github_updated_at=datetime(2026, 7, 4),
+        dispatch_status="escalated",
+        escalation_reason="plan_blocked",
+    )
+    db.add(item)
+    await db.commit()
+    open_issue = _issue(823, ["claude-deck-ready"])
+
+    await github_watcher_service.poll_scope(
+        db,
+        scope,
+        _FakeClient(labeled=[open_issue], by_number={823: open_issue}),
+    )
+
+    await db.refresh(item)
+    assert item.dispatch_status == "escalated"
+    assert item.escalation_reason == "plan_blocked"
+    messages = (await db.execute(select(MailMessage))).scalars().all()
+    assert not any(
+        (message.payload or {}).get("kind") == "github_dispatch_blocker_merged"
+        for message in messages
+    )


### PR DESCRIPTION
## Summary
- Accepts `pr_opened` from an explicit allow-list of recoverable escalations, clears the resolved reason, and keeps human/policy stop reasons default-denied.
- Rejects manual retry with HTTP 409 when a work item already tracks an open PR, preserving the item and naming the PR in the response.
- Marks escalation broadcasts with `owner_may_be_active` and warns coordinators not to retry when the pre-escalation owner may still be working.

## Safety guarantees
- The T-S6 human stop signal remains intact: `dispatch_label_removed`, unattributed escalations, and exhausted-budget reasons still reject late PR reports.
- The existing `test_pr_opened_rejected_after_item_escalated` regression remains unmodified and passes.
- No new dispatch statuses, endpoints, schema, migrations, dependencies, or Phase G2 launch-path changes.

## Authorized fixture correction
Per the Phase G1 plan, `test_github_work_item_feed_and_retry_guard` changed only its incidental `pr_number=12` fixture value to `pr_number=None`; all assertions remain unchanged. This preserves that test's status-guard purpose under the new open-PR retry rule.

## Validation
- `cd backend && source venv/bin/activate && pytest tests/agent_teams tests/agent_mail -q`
- **284 passed** (baseline 274 plus 10 focused regressions)
- No other pre-existing tests failed or were rewritten.
- `git diff --stat feature/autonomous-github-dispatch...HEAD -- backend/app/models/database.py backend/app/database.py backend/requirements.txt` is empty.

Addresses #300.


## Phase G1b — Closed-Issue Reconciliation (Finding 14)

- Extracted `_complete_and_notify` so active-item completion and stalled-item reconciliation share the same status transition, commit, Leader notification, and rollback behavior. The pure refactor was verified against the unchanged **284-test** suite before the sweep landed.
- Added a separate query for closed `escalated`/`failed` items instead of widening `_ACTIVE_STATUSES`. Widening that tuple would feed failed items into the label-removal branch, laundering `failed` into retryable `escalated` state behind the operator's back.
- Reconciles a closed issue to `completed`, clears its escalation reason, and emits the existing blocker-merged notification; dependents remain Leader-controlled and are not auto-retried.
- Skips and logs any item with `pr_number is not None`, leaving unresolved PRs on the verification path.
- Final validation: `pytest tests/agent_teams tests/agent_mail -q` → **290 passed**.
- Schema/dependency audit remains empty for `backend/app/models/database.py`, `backend/app/database.py`, and `backend/requirements.txt`.
