### PR TITLE
perf(dispatch): reuse labeled issues in closure sweep

### DIFF
--- a/backend/app/services/github_watcher_service.py
+++ b/backend/app/services/github_watcher_service.py
@@ -35,7 +35,12 @@ class GithubWatcherService:
         for issue in labeled:
             await self._upsert_item(db, scope, issue)
         await self._recheck_active_items(db, scope, client)
-        await self._reconcile_closed_issues(db, scope, client)
+        await self._reconcile_closed_issues(
+            db,
+            scope,
+            client,
+            open_labeled_numbers=frozenset(issue["number"] for issue in labeled),
+        )
         scope.last_polled_at = datetime.utcnow()
         await db.commit()
 
@@ -112,7 +117,12 @@ class GithubWatcherService:
                 )
 
     async def _reconcile_closed_issues(
-        self, db: AsyncSession, scope: TeamGithubScope, client: GithubClient
+        self,
+        db: AsyncSession,
+        scope: TeamGithubScope,
+        client: GithubClient,
+        *,
+        open_labeled_numbers: frozenset[int] = frozenset(),
     ) -> None:
         stalled = (
             await db.execute(
@@ -124,6 +134,13 @@ class GithubWatcherService:
                 )
             )
         ).scalars().all()
+        # Presence in the open labeled response proves an issue is open; absence
+        # proves nothing, so absent issues must still be fetched by number.
+        stalled = [
+            item
+            for item in stalled
+            if item.issue_number not in open_labeled_numbers
+        ]
         if not stalled:
             return
         current = await client.get_issues_by_number(

--- a/backend/tests/agent_teams/test_github_watcher_service.py
+++ b/backend/tests/agent_teams/test_github_watcher_service.py
@@ -575,3 +575,140 @@ async def test_escalated_item_with_open_labeled_issue_is_untouched(db):
         (message.payload or {}).get("kind") == "github_dispatch_blocker_merged"
         for message in messages
     )
+
+
+@pytest.mark.asyncio
+async def test_sweep_skips_issues_already_in_labeled_list(db):
+    scope = await _make_scope(db)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=824,
+        issue_title="open labeled work",
+        issue_url="u",
+        github_updated_at=datetime(2026, 7, 4),
+        dispatch_status="escalated",
+        escalation_reason="plan_blocked",
+    )
+    db.add(item)
+    await db.commit()
+    open_issue = _issue(824, ["claude-deck-ready"])
+    client = _FakeClient(labeled=[open_issue], by_number={824: open_issue})
+
+    await github_watcher_service.poll_scope(db, scope, client)
+
+    requested = [number for call in client.by_number_calls for number in call]
+    assert 824 not in requested
+    await db.refresh(item)
+    assert item.dispatch_status == "escalated"
+
+
+@pytest.mark.asyncio
+async def test_sweep_fetches_only_issues_absent_from_labeled_list(db):
+    scope = await _make_scope(db)
+    labeled_item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=825,
+        issue_title="open labeled work",
+        issue_url="u",
+        github_updated_at=datetime(2026, 7, 4),
+        dispatch_status="escalated",
+        escalation_reason="plan_blocked",
+    )
+    absent_item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=826,
+        issue_title="closed absent work",
+        issue_url="u",
+        github_updated_at=datetime(2026, 7, 4),
+        dispatch_status="escalated",
+        escalation_reason="plan_blocked",
+    )
+    db.add_all([labeled_item, absent_item])
+    await db.commit()
+    open_issue = _issue(825, ["claude-deck-ready"])
+    closed_issue = _issue(826, ["claude-deck-ready"])
+    closed_issue["state"] = "closed"
+    client = _FakeClient(
+        labeled=[open_issue],
+        by_number={825: open_issue, 826: closed_issue},
+    )
+
+    await github_watcher_service.poll_scope(db, scope, client)
+
+    requested = [number for call in client.by_number_calls for number in call]
+    assert requested == [826]
+    await db.refresh(labeled_item)
+    await db.refresh(absent_item)
+    assert labeled_item.dispatch_status == "escalated"
+    assert absent_item.dispatch_status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_sweep_does_not_treat_absent_open_issue_as_closed(db):
+    scope = await _make_scope(db)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=858,
+        issue_title="open unlabeled work",
+        issue_url="u",
+        github_updated_at=datetime(2026, 7, 4),
+        dispatch_status="escalated",
+        escalation_reason="dispatch_label_removed",
+        pr_number=860,
+    )
+    db.add(item)
+    await db.commit()
+    open_issue = _issue(858, [])
+    client = _FakeClient(labeled=[], by_number={858: open_issue})
+
+    await github_watcher_service.poll_scope(db, scope, client)
+
+    requested = [number for call in client.by_number_calls for number in call]
+    assert requested == [858]
+    await db.refresh(item)
+    assert item.dispatch_status == "escalated"
+    assert item.escalation_reason == "dispatch_label_removed"
+    messages = (await db.execute(select(MailMessage))).scalars().all()
+    assert not any(
+        (message.payload or {}).get("kind") == "github_dispatch_blocker_merged"
+        for message in messages
+    )
+
+
+@pytest.mark.asyncio
+async def test_sweep_makes_no_request_when_all_stalled_items_are_labeled(db):
+    scope = await _make_scope(db)
+    escalated = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=827,
+        issue_title="open escalated work",
+        issue_url="u",
+        github_updated_at=datetime(2026, 7, 4),
+        dispatch_status="escalated",
+        escalation_reason="plan_blocked",
+    )
+    failed = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=828,
+        issue_title="open failed work",
+        issue_url="u",
+        github_updated_at=datetime(2026, 7, 4),
+        dispatch_status="failed",
+        escalation_reason="launch_failed",
+    )
+    db.add_all([escalated, failed])
+    await db.commit()
+    escalated_issue = _issue(827, ["claude-deck-ready"])
+    failed_issue = _issue(828, ["claude-deck-ready"])
+    client = _FakeClient(
+        labeled=[escalated_issue, failed_issue],
+        by_number={827: escalated_issue, 828: failed_issue},
+    )
+
+    await github_watcher_service.poll_scope(db, scope, client)
+
+    assert client.by_number_calls == []
+    await db.refresh(escalated)
+    await db.refresh(failed)
+    assert escalated.dispatch_status == "escalated"
+    assert failed.dispatch_status == "failed"

--- a/backend/tests/agent_teams/test_github_watcher_service.py
+++ b/backend/tests/agent_teams/test_github_watcher_service.py
@@ -113,6 +113,7 @@ class _FakeClient:
     def __init__(self, labeled=None, by_number=None):
         self._labeled = labeled or []
         self._by_number = by_number or {}
+        self.by_number_calls = []
 
     async def list_issues_with_label(self, owner, repo, label):
         return list(self._labeled)
@@ -125,6 +126,7 @@ class _FakeClient:
         }
 
     async def get_issues_by_number(self, owner, repo, numbers):
+        self.by_number_calls.append(list(numbers))
         return {number: self._by_number[number] for number in numbers if number in self._by_number}
 
     async def list_repo_labels(self, owner, repo):


### PR DESCRIPTION
## Summary
- reduce the closure sweep from 12 GitHub requests per poll to 2 by reusing issue numbers already present in the open-labeled response
- keep behavior bit-identical: skipped items are positively known open, and the existing sweep already ignored issues whose state was not `closed`
- record `_FakeClient.by_number_calls` so avoided requests are directly assertable

## Correctness boundary
- presence in the open-labeled response proves an issue is open and may be skipped
- absence proves nothing, so absent issues are still fetched individually
- regression coverage names the live #858 absent-but-open case to prevent false completion and bogus blocker-cleared notifications

## Validation
- `pytest tests/agent_teams tests/agent_mail -q`: **294 passed**
- focused request-budget regressions: **4 passed**
- watcher module: **20 passed**
- schema/client/database/requirements diff: empty

Addresses #302
