### PR TITLE
feat: provision leased GitHub dispatch workspaces

### DIFF
--- a/backend/app/api/v1/agent_teams.py
+++ b/backend/app/api/v1/agent_teams.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from string import Formatter
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from fastapi.encoders import jsonable_encoder
@@ -10,7 +11,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.models.database import GithubWorkItem, TeamGithubScope
+from app.models.database import GithubWorkItem, GithubWorkspace, TeamGithubScope
 from app.models.schemas import (
     AgentTeamCreateFromBridgeRequest,
     AgentTeamCreateFromMailRequest,
@@ -25,9 +26,13 @@ from app.models.schemas import (
     AgentTeamSlotReorderRequest,
     AgentTeamSlotUpdate,
     DispatchStatusReport,
+    GithubWorkItemAbandonRequest,
     GithubWorkItemListResponse,
     GithubWorkItemRetryRequest,
     GithubWorkItemResponse,
+    GithubWorkspaceCreate,
+    GithubWorkspaceListResponse,
+    GithubWorkspaceResponse,
     TeamGithubScopeCreate,
     TeamGithubScopeListResponse,
     TeamGithubScopeResponse,
@@ -35,11 +40,27 @@ from app.models.schemas import (
 )
 from app.services.github_dispatch_scheduler import github_dispatch_scheduler
 from app.services.github_dispatch_service import github_dispatch_service
+from app.services.github_workspace_service import (
+    GithubWorkspaceError,
+    GithubWorkspaceResetError,
+    github_workspace_service,
+)
 from app.services.github_verification_service import github_verification_service
 from app.services.agent_team_service import PlanConflictError, agent_team_service
 from app.services.providers.base import ProviderLaunchError
 
 router = APIRouter()
+
+_WORKSPACE_CONFLICT_CODES = {
+    "workspace_path_registered",
+    "workspace_not_a_worktree",
+    "workspace_is_primary",
+    "workspace_dirty",
+    "workspace_occupied",
+    "workspace_leased",
+    "workspace_reset_failed",
+    "work_item_not_abandonable",
+}
 
 
 def _bad_request(exc: ValueError) -> HTTPException:
@@ -49,6 +70,13 @@ def _bad_request(exc: ValueError) -> HTTPException:
             detail={"message": str(exc), "block_code": exc.block_code},
         )
     return HTTPException(status_code=400, detail=str(exc))
+
+
+def _conflict(message: str, block_code: str) -> HTTPException:
+    return HTTPException(
+        status_code=409,
+        detail={"message": message, "block_code": block_code},
+    )
 
 
 def _clean_required(value: str | None, label: str) -> str:
@@ -69,6 +97,30 @@ def _clean_label(value: str | None, label: str) -> str:
     return _clean_required(value, label)
 
 
+def _validate_template(
+    value: str,
+    *,
+    label: str,
+    allowed_fields: set[str],
+    render_values: dict[str, object],
+) -> str:
+    try:
+        for _, field_name, format_spec, conversion in Formatter().parse(value):
+            if field_name is None:
+                continue
+            if (
+                field_name not in allowed_fields
+                or format_spec
+                or conversion is not None
+            ):
+                raise ValueError
+        value.format(**render_values)
+    except (KeyError, IndexError, ValueError) as exc:
+        allowed = ", ".join(f"{{{field}}}" for field in sorted(allowed_fields))
+        raise ValueError(f"{label} may only use placeholders: {allowed}") from exc
+    return value
+
+
 def _scope_response(scope: TeamGithubScope) -> TeamGithubScopeResponse:
     return TeamGithubScopeResponse(
         id=scope.id,
@@ -83,6 +135,11 @@ def _scope_response(scope: TeamGithubScope) -> TeamGithubScopeResponse:
         max_concurrent_dispatched=scope.max_concurrent_dispatched,
         max_verification_retries=scope.max_verification_retries,
         max_auto_merges_per_day=scope.max_auto_merges_per_day,
+        base_ref=scope.base_ref,
+        builds_out_of_tree=scope.builds_out_of_tree,
+        build_dir_template=scope.build_dir_template,
+        build_command_hint=scope.build_command_hint,
+        max_build_parallelism=scope.max_build_parallelism,
         enabled=scope.enabled,
         last_polled_at=scope.last_polled_at,
         created_at=scope.created_at,
@@ -90,7 +147,39 @@ def _scope_response(scope: TeamGithubScope) -> TeamGithubScopeResponse:
     )
 
 
-def _work_item_response(item: GithubWorkItem, scope: TeamGithubScope) -> GithubWorkItemResponse:
+def _workspace_lease_state(workspace: GithubWorkspace) -> str:
+    if workspace.leased_item_id is not None:
+        return "leased"
+    if not workspace.enabled:
+        return "disabled"
+    if not workspace.dispatchable:
+        return "disabled_for_dispatch"
+    return "available"
+
+
+def _workspace_response(workspace: GithubWorkspace) -> GithubWorkspaceResponse:
+    return GithubWorkspaceResponse(
+        id=workspace.id,
+        scope_id=workspace.scope_id,
+        path=workspace.path,
+        kind=workspace.kind,
+        lease_state=_workspace_lease_state(workspace),
+        dispatchable=workspace.dispatchable,
+        leased_item_id=workspace.leased_item_id,
+        leased_at=workspace.leased_at,
+        released_at=workspace.released_at,
+        provision_error=workspace.provision_error,
+        enabled=workspace.enabled,
+        created_at=workspace.created_at,
+        updated_at=workspace.updated_at,
+    )
+
+
+def _work_item_response(
+    item: GithubWorkItem,
+    scope: TeamGithubScope,
+    workspace_path: str | None = None,
+) -> GithubWorkItemResponse:
     return GithubWorkItemResponse(
         id=item.id,
         scope_id=item.scope_id,
@@ -115,6 +204,7 @@ def _work_item_response(item: GithubWorkItem, scope: TeamGithubScope) -> GithubW
         escalation_reason=item.escalation_reason,
         status_note=item.status_note,
         auto_merged_at=item.auto_merged_at,
+        workspace_path=workspace_path,
         created_at=item.created_at,
         updated_at=item.updated_at,
     )
@@ -149,6 +239,26 @@ def _apply_scope_create(
         scope.max_verification_retries = request.max_verification_retries
     if request.max_auto_merges_per_day is not None:
         scope.max_auto_merges_per_day = request.max_auto_merges_per_day
+    if request.base_ref is not None:
+        scope.base_ref = _clean_required(request.base_ref, "Base ref")
+    if request.builds_out_of_tree is not None:
+        scope.builds_out_of_tree = request.builds_out_of_tree
+    if request.build_dir_template is not None:
+        scope.build_dir_template = _validate_template(
+            request.build_dir_template,
+            label="Build directory template",
+            allowed_fields={"issue_number"},
+            render_values={"issue_number": 1},
+        )
+    if request.build_command_hint is not None:
+        scope.build_command_hint = _validate_template(
+            request.build_command_hint,
+            label="Build command hint",
+            allowed_fields={"build_dir", "parallelism"},
+            render_values={"build_dir": "build", "parallelism": 4},
+        )
+    if request.max_build_parallelism is not None:
+        scope.max_build_parallelism = request.max_build_parallelism
     if request.enabled is not None:
         scope.enabled = request.enabled
     scope.updated_at = datetime.utcnow()
@@ -376,6 +486,128 @@ async def delete_github_scope(scope_id: int, db: AsyncSession = Depends(get_db))
 
 
 @router.get(
+    "/github-scopes/{scope_id}/workspaces",
+    response_model=GithubWorkspaceListResponse,
+)
+async def list_github_workspaces(
+    scope_id: int,
+    db: AsyncSession = Depends(get_db),
+):
+    scope = await db.get(TeamGithubScope, scope_id)
+    if scope is None:
+        raise HTTPException(status_code=404, detail="GitHub scope not found")
+    workspaces = (
+        await db.execute(
+            select(GithubWorkspace)
+            .where(GithubWorkspace.scope_id == scope_id)
+            .order_by(GithubWorkspace.id)
+        )
+    ).scalars().all()
+    return GithubWorkspaceListResponse(
+        workspaces=[_workspace_response(workspace) for workspace in workspaces]
+    )
+
+
+@router.post(
+    "/github-scopes/{scope_id}/workspaces",
+    response_model=GithubWorkspaceResponse,
+    status_code=201,
+)
+async def create_github_workspace(
+    scope_id: int,
+    request: GithubWorkspaceCreate,
+    db: AsyncSession = Depends(get_db),
+):
+    scope = await db.get(TeamGithubScope, scope_id)
+    if scope is None:
+        raise HTTPException(status_code=404, detail="GitHub scope not found")
+    if request.kind not in {"primary", "worktree"}:
+        raise HTTPException(status_code=400, detail="Workspace kind must be primary or worktree")
+    try:
+        path, _ = agent_team_service.normalize_repo_path(request.path)
+    except ValueError as exc:
+        raise _bad_request(exc) from exc
+    existing = (
+        await db.execute(select(GithubWorkspace).where(GithubWorkspace.path == path))
+    ).scalar_one_or_none()
+    if existing is not None:
+        raise _conflict(
+            "Workspace path already registered",
+            block_code="workspace_path_registered",
+        )
+    dispatchable = (
+        request.dispatchable
+        if request.dispatchable is not None
+        else request.kind == "worktree"
+    )
+    try:
+        workspace = await github_workspace_service.register_workspace(
+            db,
+            scope,
+            path,
+            kind=request.kind,
+            dispatchable=dispatchable,
+            enabled=request.enabled,
+        )
+    except GithubWorkspaceError as exc:
+        block_code = (
+            exc.block_code
+            if exc.block_code in _WORKSPACE_CONFLICT_CODES
+            else "workspace_not_a_worktree"
+        )
+        raise _conflict(str(exc), block_code=block_code) from exc
+    except IntegrityError as exc:
+        await db.rollback()
+        raise _conflict(
+            "Workspace path already registered",
+            block_code="workspace_path_registered",
+        ) from exc
+    return _workspace_response(workspace)
+
+
+@router.post(
+    "/github-scopes/{scope_id}/workspaces/{workspace_id}/reprobe",
+    response_model=GithubWorkspaceResponse,
+)
+async def reprobe_github_workspace(
+    scope_id: int,
+    workspace_id: int,
+    db: AsyncSession = Depends(get_db),
+):
+    scope = await db.get(TeamGithubScope, scope_id)
+    if scope is None:
+        raise HTTPException(status_code=404, detail="GitHub scope not found")
+    workspace = await db.get(GithubWorkspace, workspace_id)
+    if workspace is None or workspace.scope_id != scope_id:
+        raise HTTPException(status_code=404, detail="GitHub workspace not found")
+    if workspace.leased_item_id is not None:
+        raise _conflict(
+            "Workspace is currently leased",
+            block_code="workspace_leased",
+        )
+    if workspace.kind == "primary":
+        raise _conflict(
+            "Primary workspaces are never reset",
+            block_code="workspace_is_primary",
+        )
+    was_enabled = workspace.enabled
+    try:
+        await github_workspace_service.reset_workspace(db, scope, workspace)
+    except GithubWorkspaceResetError as exc:
+        workspace.enabled = was_enabled if exc.transient else False
+        workspace.provision_error = str(exc)
+        workspace.updated_at = datetime.utcnow()
+        await db.commit()
+        raise _conflict(str(exc), block_code="workspace_reset_failed") from exc
+    workspace.enabled = True
+    workspace.provision_error = None
+    workspace.updated_at = datetime.utcnow()
+    await db.commit()
+    await db.refresh(workspace)
+    return _workspace_response(workspace)
+
+
+@router.get(
     "/presets/{preset_id}/github-work-items",
     response_model=GithubWorkItemListResponse,
 )
@@ -390,15 +622,19 @@ async def list_github_work_items(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     rows = (
         await db.execute(
-            select(GithubWorkItem, TeamGithubScope)
+            select(GithubWorkItem, TeamGithubScope, GithubWorkspace.path)
             .join(TeamGithubScope, TeamGithubScope.id == GithubWorkItem.scope_id)
+            .outerjoin(GithubWorkspace, GithubWorkspace.leased_item_id == GithubWorkItem.id)
             .where(TeamGithubScope.preset_id == preset_id)
             .order_by(GithubWorkItem.updated_at.desc(), GithubWorkItem.id.desc())
             .limit(limit)
         )
     ).all()
     return GithubWorkItemListResponse(
-        items=[_work_item_response(item, scope) for item, scope in rows]
+        items=[
+            _work_item_response(item, scope, workspace_path)
+            for item, scope, workspace_path in rows
+        ]
     )
 
 
@@ -430,6 +666,50 @@ async def retry_github_work_item(
     github_dispatch_service.reset_for_retry(item)
     if request is not None and request.reason:
         item.pending_reason = f"retry requested: {request.reason}"
+    await db.commit()
+    await db.refresh(item)
+    return _work_item_response(item, scope)
+
+
+@router.post(
+    "/github-work-items/{work_item_id}/abandon",
+    response_model=GithubWorkItemResponse,
+)
+async def abandon_github_work_item(
+    work_item_id: int,
+    request: GithubWorkItemAbandonRequest | None = None,
+    db: AsyncSession = Depends(get_db),
+):
+    item = await db.get(GithubWorkItem, work_item_id)
+    if item is None:
+        raise HTTPException(status_code=404, detail="GitHub work item not found")
+    scope = await db.get(TeamGithubScope, item.scope_id)
+    if scope is None:
+        raise HTTPException(status_code=404, detail="GitHub scope not found")
+    if item.dispatch_status not in {
+        "ready_for_review",
+        "awaiting_human_review",
+        "dispatched",
+        "verifying",
+    }:
+        raise _conflict(
+            f"Work item in status {item.dispatch_status} cannot be abandoned",
+            block_code="work_item_not_abandonable",
+        )
+    note = (
+        request.reason
+        if request is not None and request.reason
+        else (
+            "Abandoned by operator; workspace lease will be reclaimed once the "
+            "owner session is offline."
+        )
+    )
+    await github_dispatch_service.escalate(
+        db,
+        item,
+        "abandoned_by_operator",
+        note=note,
+    )
     await db.commit()
     await db.refresh(item)
     return _work_item_response(item, scope)

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -395,6 +395,26 @@ async def _run_sqlite_compat_migrations(conn) -> None:
         await conn.execute(
             text("ALTER TABLE team_github_scopes ADD COLUMN max_auto_merges_per_day INTEGER DEFAULT 5 NOT NULL")
         )
+    if scope_columns and "base_ref" not in scope_columns:
+        await conn.execute(
+            text("ALTER TABLE team_github_scopes ADD COLUMN base_ref VARCHAR DEFAULT 'origin/HEAD' NOT NULL")
+        )
+    if scope_columns and "builds_out_of_tree" not in scope_columns:
+        await conn.execute(
+            text("ALTER TABLE team_github_scopes ADD COLUMN builds_out_of_tree BOOLEAN DEFAULT 0 NOT NULL")
+        )
+    if scope_columns and "build_dir_template" not in scope_columns:
+        await conn.execute(
+            text("ALTER TABLE team_github_scopes ADD COLUMN build_dir_template VARCHAR DEFAULT 'build'")
+        )
+    if scope_columns and "build_command_hint" not in scope_columns:
+        await conn.execute(
+            text("ALTER TABLE team_github_scopes ADD COLUMN build_command_hint VARCHAR")
+        )
+    if scope_columns and "max_build_parallelism" not in scope_columns:
+        await conn.execute(
+            text("ALTER TABLE team_github_scopes ADD COLUMN max_build_parallelism INTEGER DEFAULT 4 NOT NULL")
+        )
 
     result = await conn.execute(text("PRAGMA table_info(github_work_items)"))
     work_item_columns = {row[1] for row in result.fetchall()}

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -222,6 +222,11 @@ class TeamGithubScope(Base):
     max_concurrent_dispatched: Mapped[int] = mapped_column(Integer, default=3, nullable=False)
     max_verification_retries: Mapped[int] = mapped_column(Integer, default=2, nullable=False)
     max_auto_merges_per_day: Mapped[int] = mapped_column(Integer, default=5, nullable=False)
+    base_ref: Mapped[str] = mapped_column(String, default="origin/HEAD", nullable=False)
+    builds_out_of_tree: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    build_dir_template: Mapped[str | None] = mapped_column(String, default="build", nullable=True)
+    build_command_hint: Mapped[str | None] = mapped_column(String, nullable=True)
+    max_build_parallelism: Mapped[int] = mapped_column(Integer, default=4, nullable=False)
     enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     last_polled_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
@@ -274,6 +279,35 @@ class GithubWorkItem(Base):
 
     __table_args__ = (
         UniqueConstraint("scope_id", "issue_number", name="uix_scope_issue"),
+    )
+
+
+class GithubWorkspace(Base):
+    """A checkout a dispatched work item may exclusively occupy."""
+
+    __tablename__ = "github_workspaces"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    scope_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("team_github_scopes.id", ondelete="CASCADE"),
+        index=True, nullable=False,
+    )
+    path: Mapped[str] = mapped_column(String, nullable=False)
+    kind: Mapped[str] = mapped_column(String, default="worktree", nullable=False)
+    dispatchable: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    leased_item_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("github_work_items.id", ondelete="SET NULL"), nullable=True
+    )
+    leased_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    released_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    provision_error: Mapped[str | None] = mapped_column(String, nullable=True)
+    enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("path", name="uix_workspace_path"),
+        UniqueConstraint("leased_item_id", name="uix_workspace_leased_item"),
     )
 
 

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -2162,6 +2162,11 @@ class TeamGithubScopeCreate(BaseModel):
     max_concurrent_dispatched: int = Field(default=3, ge=1)
     max_verification_retries: int = Field(default=2, ge=0)
     max_auto_merges_per_day: int = Field(default=5, ge=0)
+    base_ref: str = "origin/HEAD"
+    builds_out_of_tree: bool = False
+    build_dir_template: str = "build"
+    build_command_hint: Optional[str] = None
+    max_build_parallelism: int = Field(default=4, ge=1)
     enabled: bool = True
 
 
@@ -2176,6 +2181,11 @@ class TeamGithubScopeUpdate(BaseModel):
     max_concurrent_dispatched: Optional[int] = Field(default=None, ge=1)
     max_verification_retries: Optional[int] = Field(default=None, ge=0)
     max_auto_merges_per_day: Optional[int] = Field(default=None, ge=0)
+    base_ref: Optional[str] = None
+    builds_out_of_tree: Optional[bool] = None
+    build_dir_template: Optional[str] = None
+    build_command_hint: Optional[str] = None
+    max_build_parallelism: Optional[int] = Field(default=None, ge=1)
     enabled: Optional[bool] = None
 
 
@@ -2192,6 +2202,11 @@ class TeamGithubScopeResponse(BaseModel):
     max_concurrent_dispatched: int
     max_verification_retries: int
     max_auto_merges_per_day: int
+    base_ref: str
+    builds_out_of_tree: bool
+    build_dir_template: Optional[str] = None
+    build_command_hint: Optional[str] = None
+    max_build_parallelism: int
     enabled: bool
     last_polled_at: Optional[datetime] = None
     created_at: datetime
@@ -2204,6 +2219,37 @@ class TeamGithubScopeListResponse(BaseModel):
 
 class GithubWorkItemRetryRequest(BaseModel):
     reason: Optional[str] = None
+
+
+class GithubWorkItemAbandonRequest(BaseModel):
+    reason: Optional[str] = None
+
+
+class GithubWorkspaceCreate(BaseModel):
+    path: str
+    kind: str = "worktree"
+    dispatchable: Optional[bool] = None
+    enabled: bool = True
+
+
+class GithubWorkspaceResponse(BaseModel):
+    id: int
+    scope_id: int
+    path: str
+    kind: str
+    lease_state: str
+    dispatchable: bool
+    leased_item_id: Optional[int] = None
+    leased_at: Optional[datetime] = None
+    released_at: Optional[datetime] = None
+    provision_error: Optional[str] = None
+    enabled: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class GithubWorkspaceListResponse(BaseModel):
+    workspaces: List[GithubWorkspaceResponse] = Field(default_factory=list)
 
 
 class GithubWorkItemResponse(BaseModel):
@@ -2230,6 +2276,7 @@ class GithubWorkItemResponse(BaseModel):
     escalation_reason: Optional[str] = None
     status_note: Optional[str] = None
     auto_merged_at: Optional[datetime] = None
+    workspace_path: Optional[str] = None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/services/github_dispatch_service.py
+++ b/backend/app/services/github_dispatch_service.py
@@ -12,6 +12,7 @@ from app.models.database import (
     AgentTeamLaunchItem,
     AgentTeamSlot,
     GithubWorkItem,
+    GithubWorkspace,
     MailAgentSession,
     MailTeamMember,
     TeamGithubScope,
@@ -19,9 +20,16 @@ from app.models.database import (
 from app.models.schemas import AgentTeamLaunchRequest
 from app.services.agent_mail_service import agent_mail_service
 from app.services.agent_team_service import agent_team_service
+from app.services.github_workspace_service import github_workspace_service
 
 _BUSY_STATUSES = ("dispatched", "verifying")
 _SCOPE_CONCURRENCY_STATUSES = ("dispatched", "verifying")
+_LAUNCH_FAILED_STATUSES = {
+    "failed",
+    "blocked",
+    "blocked_provider_unavailable",
+    "blocked_agent_mail_not_configured",
+}
 
 logger = logging.getLogger(__name__)
 
@@ -160,6 +168,7 @@ class GithubDispatchService:
         issue_details_by_number = issue_details_by_number or {}
         slots_dispatched_this_batch: set[int] = set()
         scope_dispatched_this_batch = 0
+        await github_workspace_service.reclaim_stale(db, scope)
         scope_active = await self.scope_active_count(db, scope.id)
 
         pending = (
@@ -210,6 +219,14 @@ class GithubDispatchService:
                 item.updated_at = datetime.utcnow()
                 await db.commit()
                 continue
+            workspace = await github_workspace_service.acquire(db, scope, item)
+            if workspace is None:
+                item.owner_slot_id = owner_slot_id
+                item.routing_method = method
+                item.pending_reason = "queued_no_workspace"
+                item.updated_at = datetime.utcnow()
+                await db.commit()
+                continue
             try:
                 leader = self._leader_slot(preset_slots)
                 leader_member = (
@@ -218,6 +235,7 @@ class GithubDispatchService:
                 brief = self._dispatch_brief(
                     item,
                     scope,
+                    workspace,
                     owner_slot_id=owner_slot_id,
                     preset_slots=preset_slots,
                     leader_member=leader_member,
@@ -237,7 +255,7 @@ class GithubDispatchService:
                         slot_ids=[owner_slot_id],
                         reuse_existing=False,
                         skip_plan_confirmation=True,
-                        repo_path_override=scope.repo_path,
+                        repo_path_override=workspace.path,
                         slot_prompt_overrides={owner_slot_id: brief},
                     ),
                 )
@@ -248,18 +266,23 @@ class GithubDispatchService:
                 await self.escalate(db, item, "plan_blocked")
                 await db.commit()
                 continue
+            except Exception:
+                item.owner_slot_id = owner_slot_id
+                item.routing_method = method
+                item.pending_reason = None
+                await self.escalate(db, item, "launch_outcome_unknown")
+                await db.commit()
+                raise
             item.owner_slot_id = owner_slot_id
             item.routing_method = method
             item.launch_id = getattr(result, "launch_id", None)
             launch_item = next(iter(getattr(result, "items", []) or []), None)
             launch_status = getattr(launch_item, "status", None)
-            if launch_status in {
-                "failed",
-                "blocked",
-                "blocked_provider_unavailable",
-                "blocked_agent_mail_not_configured",
-            }:
+            tmux_target = getattr(launch_item, "tmux_target", None)
+            if launch_status in _LAUNCH_FAILED_STATUSES:
                 item.dispatch_status = "failed"
+                if tmux_target is None:
+                    await github_workspace_service.release(db, item.id)
             else:
                 item.dispatch_status = "dispatched"
                 item.dispatched_at = datetime.utcnow()
@@ -273,6 +296,7 @@ class GithubDispatchService:
         self,
         item: GithubWorkItem,
         scope: TeamGithubScope,
+        workspace: GithubWorkspace,
         *,
         owner_slot_id: int,
         preset_slots: list[AgentTeamSlot],
@@ -296,12 +320,33 @@ class GithubDispatchService:
             "",
             f"- Work item ID: {item.id}",
             f"- Repo: {scope.repo_owner}/{scope.repo_name}",
-            f"- Local checkout: {scope.repo_path}",
+            f"- Workspace: {workspace.path}",
+            "- This workspace is leased exclusively to this work item. No other "
+            "dispatched agent will be working in it.",
             f"- Issue: #{item.issue_number} — {item.issue_title}",
             f"- Issue URL: {item.issue_url}",
             f"- Pipeline: {item.issue_type}",
             f"- Owner slot: {owner.display_name if owner else owner_slot_id}",
         ]
+        if workspace.kind == "worktree":
+            lines.extend(
+                [
+                    f"- It is a git worktree on a detached HEAD at {scope.base_ref}. "
+                    "Create your own branch with `git switch -c <branch>` before committing.",
+                    "- Do NOT create, move or remove git worktrees yourself. Claude Deck "
+                    "provisions the workspace; you work inside the one you were given.",
+                    "- Do NOT work in any other checkout of this repository.",
+                ]
+            )
+        else:
+            lines.extend(
+                [
+                    "- This is a shared human checkout, not a Deck-managed worktree. Its "
+                    "current branch is not Deck's to change; confirm with the team leader "
+                    "before switching branches.",
+                    "- Do NOT work in any other checkout of this repository.",
+                ]
+            )
         if leader is not None:
             if leader_member is not None:
                 lines.append(
@@ -355,7 +400,54 @@ class GithubDispatchService:
                     "- After opening the draft PR, report `pr_opened` with the PR number and wait for CI verification.",
                 ]
             )
+            lines.extend(self._build_instructions(item, scope))
         return "\n".join(lines)
+
+    def _build_instructions(
+        self,
+        item: GithubWorkItem,
+        scope: TeamGithubScope,
+    ) -> list[str]:
+        instructions: list[str] = []
+        try:
+            if scope.build_command_hint:
+                if scope.builds_out_of_tree:
+                    build_dir = (scope.build_dir_template or "build").format(
+                        issue_number=item.issue_number
+                    )
+                    command = scope.build_command_hint.format(
+                        build_dir=build_dir,
+                        parallelism=scope.max_build_parallelism,
+                    )
+                    instructions.extend(
+                        [
+                            f"- Build directory: {build_dir}",
+                            f"- Build command: `{command}`",
+                        ]
+                    )
+                else:
+                    command = scope.build_command_hint.format(
+                        build_dir="",
+                        parallelism=scope.max_build_parallelism,
+                    )
+                    instructions.extend(
+                        [
+                            f"- Build command: `{command}`",
+                            "- Only one build may run in this workspace at a time; this "
+                            "project's build system does not support out-of-tree builds.",
+                        ]
+                    )
+        except (KeyError, IndexError, ValueError):
+            logger.exception(
+                "Invalid build template for GitHub scope %s; omitting build hints",
+                scope.id,
+            )
+        if scope.max_build_parallelism:
+            instructions.append(
+                f"- Cap build parallelism at -j{scope.max_build_parallelism}. "
+                "Higher values have OOM-killed this host."
+            )
+        return instructions
 
     def _leader_slot(self, preset_slots: list[AgentTeamSlot]) -> AgentTeamSlot | None:
         enabled = sorted(

--- a/backend/app/services/github_workspace_service.py
+++ b/backend/app/services/github_workspace_service.py
@@ -1,0 +1,305 @@
+"""Provision and lease isolated workspaces for GitHub dispatch."""
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.database import GithubWorkItem, GithubWorkspace, TeamGithubScope
+from app.services.agent_bridge.discovery import discover_agent_sessions
+
+GIT_TIMEOUT_SECONDS = 300
+
+_GIT_ENV = {
+    **os.environ,
+    "GIT_TERMINAL_PROMPT": "0",
+    "GIT_ASKPASS": "",
+    "SSH_ASKPASS": "",
+    "GIT_CONFIG_NOSYSTEM": "1",
+}
+
+_RECLAIMABLE_STATUSES = ("escalated", "failed", "merged", "completed")
+
+
+class GithubWorkspaceError(RuntimeError):
+    def __init__(self, message: str, block_code: str = "workspace_not_a_worktree"):
+        super().__init__(message)
+        self.block_code = block_code
+
+
+class GithubWorkspaceResetError(GithubWorkspaceError):
+    def __init__(self, message: str, *, transient: bool):
+        super().__init__(message, "workspace_reset_failed")
+        self.transient = transient
+
+
+class GithubWorkspaceService:
+    def __init__(self, runner=None):
+        self._runner = runner or self._run_git
+
+    async def _run_git(self, args: list[str]) -> tuple[int, str]:
+        process = await asyncio.create_subprocess_exec(
+            "git",
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            env=_GIT_ENV,
+        )
+        try:
+            stdout, _ = await asyncio.wait_for(
+                process.communicate(), timeout=GIT_TIMEOUT_SECONDS
+            )
+        except asyncio.TimeoutError:
+            process.kill()
+            await process.wait()
+            return 124, f"git {' '.join(args)} timed out after {GIT_TIMEOUT_SECONDS}s"
+        return process.returncode, stdout.decode("utf-8", "replace")
+
+    async def acquire(
+        self,
+        db: AsyncSession,
+        scope: TeamGithubScope,
+        item: GithubWorkItem,
+    ) -> GithubWorkspace | None:
+        held = (
+            await db.execute(
+                select(GithubWorkspace).where(GithubWorkspace.leased_item_id == item.id)
+            )
+        ).scalar_one_or_none()
+        if held is not None:
+            return held
+
+        workspace = (
+            await db.execute(
+                select(GithubWorkspace)
+                .where(
+                    GithubWorkspace.scope_id == scope.id,
+                    GithubWorkspace.enabled.is_(True),
+                    GithubWorkspace.dispatchable.is_(True),
+                    GithubWorkspace.leased_item_id.is_(None),
+                )
+                .order_by(GithubWorkspace.id)
+            )
+        ).scalars().first()
+        if workspace is None:
+            return None
+
+        now = datetime.utcnow()
+        workspace.leased_item_id = item.id
+        workspace.leased_at = now
+        workspace.released_at = None
+        workspace.updated_at = now
+        await db.commit()
+
+        if workspace.kind != "primary":
+            try:
+                await self.reset_workspace(db, scope, workspace)
+            except GithubWorkspaceResetError:
+                await self.release(db, item.id)
+                return None
+            workspace.updated_at = datetime.utcnow()
+            await db.commit()
+        return workspace
+
+    async def release(self, db: AsyncSession, item_id: int) -> None:
+        workspace = (
+            await db.execute(
+                select(GithubWorkspace).where(GithubWorkspace.leased_item_id == item_id)
+            )
+        ).scalar_one_or_none()
+        if workspace is None:
+            return
+        now = datetime.utcnow()
+        workspace.leased_item_id = None
+        workspace.released_at = now
+        workspace.updated_at = now
+        await db.commit()
+
+    async def reclaim_stale(self, db: AsyncSession, scope: TeamGithubScope) -> int:
+        from app.services.github_dispatch_service import github_dispatch_service
+
+        leased = (
+            await db.execute(
+                select(GithubWorkspace, GithubWorkItem)
+                .join(GithubWorkItem, GithubWorkspace.leased_item_id == GithubWorkItem.id)
+                .where(
+                    GithubWorkspace.scope_id == scope.id,
+                    GithubWorkItem.dispatch_status.in_(_RECLAIMABLE_STATUSES),
+                )
+                .order_by(GithubWorkspace.id)
+            )
+        ).all()
+        released = 0
+        for workspace, item in leased:
+            if (
+                item.owner_slot_id is not None
+                and await github_dispatch_service.slot_has_live_owner_session(
+                    db, item.owner_slot_id
+                )
+            ):
+                continue
+            await self.release(db, workspace.leased_item_id)
+            released += 1
+        return released
+
+    async def reset_workspace(
+        self,
+        db: AsyncSession,
+        scope: TeamGithubScope,
+        workspace: GithubWorkspace,
+    ) -> None:
+        if workspace.kind == "primary":
+            return
+
+        commands = [
+            ["-C", workspace.path, "fetch", "origin", "--prune"],
+            ["-C", workspace.path, "switch", "--detach", "--force", scope.base_ref],
+            ["-C", workspace.path, "reset", "--hard", scope.base_ref],
+            ["-C", workspace.path, "clean", "-fd"],
+        ]
+        for index, command in enumerate(commands):
+            return_code, output = await self._runner(command)
+            if return_code == 0:
+                continue
+            message = output.strip() or f"git {' '.join(command)} failed"
+            workspace.provision_error = message
+            workspace.updated_at = datetime.utcnow()
+            transient = index == 0
+            if not transient:
+                workspace.enabled = False
+            raise GithubWorkspaceResetError(message, transient=transient)
+        workspace.provision_error = None
+        workspace.updated_at = datetime.utcnow()
+
+    async def register_workspace(
+        self,
+        db: AsyncSession,
+        scope: TeamGithubScope,
+        path: str,
+        *,
+        kind: str = "worktree",
+        dispatchable: bool = True,
+        enabled: bool = True,
+    ) -> GithubWorkspace:
+        if kind not in {"primary", "worktree"}:
+            raise ValueError(f"Unsupported workspace kind: {kind}")
+
+        path = os.path.realpath(path)
+        repo_path = os.path.realpath(scope.repo_path)
+        path_exists = os.path.exists(path)
+        empty_directory = False
+        if path_exists and os.path.isdir(path):
+            with os.scandir(path) as entries:
+                empty_directory = next(entries, None) is None
+
+        if kind == "worktree" and path == repo_path:
+            raise GithubWorkspaceError(
+                "The scope primary checkout cannot be registered as a worktree",
+                "workspace_is_primary",
+            )
+
+        adopted = path_exists and not empty_directory
+        if kind == "primary" and not adopted:
+            raise GithubWorkspaceError(
+                "A primary workspace must be an existing repository checkout"
+            )
+
+        if adopted:
+            scope_identity = await self._probe_identity(repo_path)
+            candidate_identity = await self._probe_identity(path)
+            if scope_identity is None or candidate_identity is None:
+                raise GithubWorkspaceError(
+                    f"Workspace path is not a git worktree of {scope.repo_owner}/{scope.repo_name}"
+                )
+            git_dir, common_dir, top_level = candidate_identity
+            _, scope_common_dir, _ = scope_identity
+            if common_dir != scope_common_dir or top_level != path:
+                raise GithubWorkspaceError(
+                    f"Workspace path is not a worktree root of {scope.repo_owner}/{scope.repo_name}"
+                )
+            linked = git_dir != common_dir
+            if kind == "worktree" and not linked:
+                raise GithubWorkspaceError(
+                    "The requested worktree path resolves to a primary checkout",
+                    "workspace_is_primary",
+                )
+            if kind == "primary" and linked:
+                raise GithubWorkspaceError(
+                    "The requested primary path resolves to a linked worktree"
+                )
+            if dispatchable:
+                await self._validate_adoption_is_available(path)
+        else:
+            await self._provision_worktree(scope, path)
+
+        workspace = GithubWorkspace(
+            scope_id=scope.id,
+            path=path,
+            kind=kind,
+            dispatchable=dispatchable,
+            enabled=enabled,
+        )
+        db.add(workspace)
+        await db.commit()
+        await db.refresh(workspace)
+        return workspace
+
+    async def _probe_identity(self, path: str) -> tuple[str, str, str] | None:
+        return_code, output = await self._runner(
+            [
+                "-C",
+                path,
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-dir",
+                "--git-common-dir",
+                "--show-toplevel",
+            ]
+        )
+        if return_code != 0:
+            return None
+        lines = [line.strip() for line in output.splitlines() if line.strip()]
+        if len(lines) != 3:
+            return None
+        return tuple(os.path.realpath(line) for line in lines)
+
+    async def _validate_adoption_is_available(self, path: str) -> None:
+        return_code, output = await self._runner(["-C", path, "status", "--porcelain"])
+        if return_code != 0:
+            raise GithubWorkspaceError(
+                output.strip() or "Unable to inspect workspace status"
+            )
+        if output.strip():
+            raise GithubWorkspaceError(
+                f"Workspace has uncommitted or untracked changes:\n{output.strip()}",
+                "workspace_dirty",
+            )
+        for session in discover_agent_sessions():
+            cwd = session.get("cwd")
+            if cwd and os.path.realpath(cwd) == path:
+                raise GithubWorkspaceError(
+                    f"Workspace is occupied by live session {session.get('tmux_target', '')}".strip(),
+                    "workspace_occupied",
+                )
+
+    async def _provision_worktree(self, scope: TeamGithubScope, path: str) -> None:
+        command = [
+            "-C",
+            scope.repo_path,
+            "worktree",
+            "add",
+            "--detach",
+            path,
+            scope.base_ref,
+        ]
+        return_code, output = await self._runner(command)
+        if return_code != 0:
+            raise GithubWorkspaceError(
+                output.strip() or f"git {' '.join(command)} failed"
+            )
+
+
+github_workspace_service = GithubWorkspaceService()

--- a/backend/tests/agent_teams/test_agent_team_api.py
+++ b/backend/tests/agent_teams/test_agent_team_api.py
@@ -198,6 +198,11 @@ async def test_github_scope_crud_endpoints(client, monkeypatch, tmp_path):
             "max_concurrent_dispatched": 2,
             "max_verification_retries": 3,
             "max_auto_merges_per_day": 1,
+            "base_ref": "origin/main",
+            "builds_out_of_tree": True,
+            "build_dir_template": "build-{issue_number}",
+            "build_command_hint": "meson compile -C {build_dir} -j{parallelism}",
+            "max_build_parallelism": 3,
             "enabled": True,
         },
     )
@@ -206,6 +211,10 @@ async def test_github_scope_crud_endpoints(client, monkeypatch, tmp_path):
     assert scope["repo_owner"] == "adrirubio"
     assert scope["merge_policy"] == "auto"
     assert scope["max_verification_retries"] == 3
+    assert scope["base_ref"] == "origin/main"
+    assert scope["builds_out_of_tree"] is True
+    assert scope["build_dir_template"] == "build-{issue_number}"
+    assert scope["max_build_parallelism"] == 3
 
     list_response = await client.get(
         f"/api/v1/agent-teams/presets/{preset_id}/github-scopes"
@@ -215,10 +224,17 @@ async def test_github_scope_crud_endpoints(client, monkeypatch, tmp_path):
 
     update_response = await client.patch(
         f"/api/v1/agent-teams/github-scopes/{scope['id']}",
-        json={"merge_policy": "human", "enabled": False},
+        json={
+            "merge_policy": "human",
+            "build_dir_template": "build",
+            "max_build_parallelism": 4,
+            "enabled": False,
+        },
     )
     assert update_response.status_code == 200
     assert update_response.json()["merge_policy"] == "human"
+    assert update_response.json()["build_dir_template"] == "build"
+    assert update_response.json()["max_build_parallelism"] == 4
     assert update_response.json()["enabled"] is False
 
     delete_response = await client.delete(
@@ -226,6 +242,42 @@ async def test_github_scope_crud_endpoints(client, monkeypatch, tmp_path):
     )
     assert delete_response.status_code == 204
     assert sync_calls == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("build_dir_template", "build-{issue_number"),
+        ("build_dir_template", "build-{unknown}"),
+        ("build_command_hint", "make -C {unknown}"),
+    ],
+)
+async def test_github_scope_rejects_invalid_build_templates(
+    client, monkeypatch, tmp_path, field, value
+):
+    async def fake_sync(_db):
+        return None
+
+    monkeypatch.setattr("app.api.v1.agent_teams._sync_github_jobs", fake_sync)
+    repo = tmp_path / f"repo-{field}-{len(value)}"
+    repo.mkdir()
+    preset_response = await client.post(
+        "/api/v1/agent-teams/presets",
+        json={"name": f"Template team {field} {len(value)}", "slots": []},
+    )
+
+    response = await client.post(
+        f"/api/v1/agent-teams/presets/{preset_response.json()['id']}/github-scopes",
+        json={
+            "repo_owner": "owner",
+            "repo_name": repo.name,
+            "repo_path": str(repo),
+            field: value,
+        },
+    )
+
+    assert response.status_code == 400
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_teams/test_github_dispatch_service.py
+++ b/backend/tests/agent_teams/test_github_dispatch_service.py
@@ -4,7 +4,7 @@ from io import StringIO
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 import app.models.database  # noqa: F401
@@ -16,12 +16,14 @@ from app.models.database import (
     AgentTeamPreset,
     AgentTeamSlot,
     GithubWorkItem,
+    GithubWorkspace,
     MailAgentSession,
     MailMessage,
     MailTeamMember,
     TeamGithubScope,
 )
 from app.services.github_dispatch_service import GithubDispatchService, github_dispatch_service
+from app.services.github_workspace_service import github_workspace_service
 
 
 @pytest_asyncio.fixture
@@ -43,6 +45,11 @@ def host_has_enough_memory(monkeypatch):
         lambda: 999_999,
         raising=False,
     )
+
+    async def reset_succeeds(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(github_workspace_service, "reset_workspace", reset_succeeds)
 
 
 async def _team(db):
@@ -81,6 +88,13 @@ async def _team(db):
     await db.flush()
     scope = TeamGithubScope(preset_id=preset.id, repo_owner="o", repo_name="r", repo_path="/tmp/r")
     db.add(scope)
+    await db.flush()
+    db.add_all(
+        [
+            GithubWorkspace(scope_id=scope.id, path=f"/tmp/r-ws-{index}")
+            for index in range(1, 6)
+        ]
+    )
     await db.commit()
     return preset, [architect, backend], scope
 
@@ -357,6 +371,36 @@ def test_reset_for_retry_clears_ack_received_at():
     github_dispatch_service.reset_for_retry(item)
 
     assert item.ack_received_at is None
+
+
+@pytest.mark.asyncio
+async def test_reset_for_retry_does_not_release_workspace(db):
+    _, _, scope = await _team(db)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=909,
+        issue_title="retry",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="escalated",
+    )
+    db.add(item)
+    await db.flush()
+    workspace = (
+        await db.execute(
+            select(GithubWorkspace)
+            .where(GithubWorkspace.scope_id == scope.id)
+            .order_by(GithubWorkspace.id)
+        )
+    ).scalars().first()
+    workspace.leased_item_id = item.id
+    await db.commit()
+
+    github_dispatch_service.reset_for_retry(item)
+    await db.commit()
+
+    assert item.dispatch_status == "pending"
+    assert workspace.leased_item_id == item.id
 
 
 def test_ack_not_satisfied_by_ack_older_than_current_dispatch():
@@ -643,7 +687,7 @@ async def test_dispatch_pending_launches_and_marks_dispatched(db):
     assert item.routing_method == "label"
     assert item.launch_id == 99
     assert item.pending_reason is None
-    assert launched["override"] == scope.repo_path
+    assert launched["override"] == "/tmp/r-ws-1"
 
 
 @pytest.mark.asyncio
@@ -700,6 +744,9 @@ async def test_dispatch_pending_passes_issue_specific_owner_brief(db):
     assert f"to_member_id={architect.id}" not in prompt
     assert "wait for acknowledgment before starting implementation" in prompt
     assert "open a draft PR" in prompt
+    assert "Workspace: /tmp/r-ws-1" in prompt
+    assert "leased exclusively" in prompt
+    assert "Do NOT create, move or remove git worktrees" in prompt
 
     member = (
         await db.execute(select(MailTeamMember).where(MailTeamMember.team_slot_id == backend.id))
@@ -841,7 +888,7 @@ async def test_dispatch_pending_disables_reuse_for_repo_override(db):
     )
 
     assert launched["reuse_existing"] is False
-    assert launched["override"] == scope.repo_path
+    assert launched["override"] == "/tmp/r-ws-1"
 
 
 @pytest.mark.asyncio
@@ -2156,3 +2203,337 @@ async def test_monitor_leaves_item_when_leader_not_registered_yet(db):
     )
     await db.refresh(item)
     assert item.dispatch_status == "dispatched"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_pending_queues_when_no_workspace_is_available(db):
+    preset, slots, scope = await _team(db)
+    await db.execute(delete(GithubWorkspace).where(GithubWorkspace.scope_id == scope.id))
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=950,
+        issue_title="No workspace",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="pending",
+    )
+    db.add(item)
+    await db.commit()
+
+    async def fake_launcher(*_args, **_kwargs):
+        raise AssertionError("launcher must not run without a workspace")
+
+    await github_dispatch_service.dispatch_pending(
+        db,
+        scope,
+        slots,
+        launcher=fake_launcher,
+        issue_labels_by_number={950: ["area:backend"]},
+    )
+
+    assert item.dispatch_status == "pending"
+    assert item.pending_reason == "queued_no_workspace"
+    assert item.owner_slot_id == slots[1].id
+    assert item.routing_method == "label"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "launch_status",
+    [
+        "failed",
+        "blocked",
+        "blocked_provider_unavailable",
+        "blocked_agent_mail_not_configured",
+    ],
+)
+async def test_known_launch_failure_releases_workspace(db, launch_status):
+    _, slots, scope = await _team(db)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=951,
+        issue_title="Launch failure",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="pending",
+    )
+    db.add(item)
+    await db.commit()
+
+    class _LaunchItem:
+        status = launch_status
+        tmux_target = None
+
+    class _Result:
+        launch_id = 951
+        items = [_LaunchItem()]
+
+    async def fake_launcher(*_args, **_kwargs):
+        return _Result()
+
+    await github_dispatch_service.dispatch_pending(
+        db,
+        scope,
+        slots,
+        launcher=fake_launcher,
+        issue_labels_by_number={951: ["area:backend"]},
+    )
+
+    workspace = (
+        await db.execute(
+            select(GithubWorkspace).where(GithubWorkspace.scope_id == scope.id).order_by(GithubWorkspace.id)
+        )
+    ).scalars().first()
+    assert item.dispatch_status == "failed"
+    assert workspace.leased_item_id is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("launch_status", ["pending_registration", "reused", "spawned"])
+async def test_success_or_unknown_launch_status_retains_workspace(db, launch_status):
+    _, slots, scope = await _team(db)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=952,
+        issue_title="Launch",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="pending",
+    )
+    db.add(item)
+    await db.commit()
+
+    class _LaunchItem:
+        status = launch_status
+        tmux_target = "deck:0.0" if launch_status != "spawned" else None
+
+    class _Result:
+        launch_id = 952
+        items = [_LaunchItem()]
+
+    async def fake_launcher(*_args, **_kwargs):
+        return _Result()
+
+    await github_dispatch_service.dispatch_pending(
+        db,
+        scope,
+        slots,
+        launcher=fake_launcher,
+        issue_labels_by_number={952: ["area:backend"]},
+    )
+
+    workspace = (
+        await db.execute(
+            select(GithubWorkspace).where(GithubWorkspace.leased_item_id == item.id)
+        )
+    ).scalar_one()
+    assert workspace.path == "/tmp/r-ws-1"
+
+
+@pytest.mark.asyncio
+async def test_tmux_target_vetoes_release_for_failure_status(db):
+    _, slots, scope = await _team(db)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=953,
+        issue_title="Ambiguous launch",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="pending",
+    )
+    db.add(item)
+    await db.commit()
+
+    class _LaunchItem:
+        status = "failed"
+        tmux_target = "deck:0.0"
+
+    class _Result:
+        launch_id = 953
+        items = [_LaunchItem()]
+
+    async def fake_launcher(*_args, **_kwargs):
+        return _Result()
+
+    await github_dispatch_service.dispatch_pending(
+        db,
+        scope,
+        slots,
+        launcher=fake_launcher,
+        issue_labels_by_number={953: ["area:backend"]},
+    )
+
+    workspace = (
+        await db.execute(
+            select(GithubWorkspace).where(GithubWorkspace.leased_item_id == item.id)
+        )
+    ).scalar_one()
+    assert workspace.path == "/tmp/r-ws-1"
+
+
+@pytest.mark.asyncio
+async def test_value_error_retains_lease_until_reclaim_sweep(db):
+    _, slots, scope = await _team(db)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=954,
+        issue_title="Plan blocked",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="pending",
+    )
+    db.add(item)
+    await db.commit()
+
+    async def fake_launcher(*_args, **_kwargs):
+        raise ValueError("blocked plan")
+
+    await github_dispatch_service.dispatch_pending(
+        db,
+        scope,
+        slots,
+        launcher=fake_launcher,
+        issue_labels_by_number={954: ["area:backend"]},
+    )
+
+    workspace = (
+        await db.execute(
+            select(GithubWorkspace).where(GithubWorkspace.leased_item_id == item.id)
+        )
+    ).scalar_one()
+    assert item.dispatch_status == "escalated"
+    assert item.escalation_reason == "plan_blocked"
+    assert workspace.leased_item_id == item.id
+
+    assert await github_workspace_service.reclaim_stale(db, scope) == 1
+    assert workspace.leased_item_id is None
+
+
+@pytest.mark.asyncio
+async def test_unexpected_launch_exception_retains_lease_and_escalates(db):
+    _, slots, scope = await _team(db)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=955,
+        issue_title="Unknown launch",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="pending",
+    )
+    db.add(item)
+    await db.commit()
+
+    async def fake_launcher(*_args, **_kwargs):
+        raise RuntimeError("commit failed after spawn")
+
+    with pytest.raises(RuntimeError, match="commit failed after spawn"):
+        await github_dispatch_service.dispatch_pending(
+            db,
+            scope,
+            slots,
+            launcher=fake_launcher,
+            issue_labels_by_number={955: ["area:backend"]},
+        )
+
+    workspace = (
+        await db.execute(
+            select(GithubWorkspace).where(GithubWorkspace.leased_item_id == item.id)
+        )
+    ).scalar_one()
+    assert item.dispatch_status == "escalated"
+    assert item.escalation_reason == "launch_outcome_unknown"
+    assert workspace.leased_item_id == item.id
+
+
+@pytest.mark.asyncio
+async def test_dispatch_brief_renders_out_of_tree_build_hints(db):
+    _, slots, scope = await _team(db)
+    scope.builds_out_of_tree = True
+    scope.build_dir_template = "build-{issue_number}"
+    scope.build_command_hint = "meson compile -C {build_dir} -j{parallelism}"
+    scope.max_build_parallelism = 4
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=956,
+        issue_title="Build",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+    )
+    workspace = (
+        await db.execute(
+            select(GithubWorkspace).where(GithubWorkspace.scope_id == scope.id).order_by(GithubWorkspace.id)
+        )
+    ).scalars().first()
+
+    brief = github_dispatch_service._dispatch_brief(
+        item,
+        scope,
+        workspace,
+        owner_slot_id=slots[1].id,
+        preset_slots=slots,
+    )
+
+    assert "build-956" in brief
+    assert "meson compile -C build-956 -j4" in brief
+    assert "Cap build parallelism at -j4" in brief
+
+
+@pytest.mark.asyncio
+async def test_dispatch_brief_describes_in_tree_build_limit(db):
+    _, slots, scope = await _team(db)
+    scope.builds_out_of_tree = False
+    scope.build_command_hint = "make -C {build_dir} -j{parallelism}"
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=957,
+        issue_title="Build",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+    )
+    workspace = (
+        await db.execute(
+            select(GithubWorkspace).where(GithubWorkspace.scope_id == scope.id).order_by(GithubWorkspace.id)
+        )
+    ).scalars().first()
+
+    brief = github_dispatch_service._dispatch_brief(
+        item,
+        scope,
+        workspace,
+        owner_slot_id=slots[1].id,
+        preset_slots=slots,
+    )
+
+    assert "Only one build may run in this workspace at a time" in brief
+    assert "build-957" not in brief
+
+
+@pytest.mark.asyncio
+async def test_dispatch_brief_contains_malformed_build_template(db):
+    _, slots, scope = await _team(db)
+    scope.builds_out_of_tree = True
+    scope.build_dir_template = "build-{issue_number"
+    scope.build_command_hint = "make -C {build_dir} -j{parallelism}"
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=958,
+        issue_title="Build",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+    )
+    workspace = (
+        await db.execute(
+            select(GithubWorkspace).where(GithubWorkspace.scope_id == scope.id).order_by(GithubWorkspace.id)
+        )
+    ).scalars().first()
+
+    brief = github_dispatch_service._dispatch_brief(
+        item,
+        scope,
+        workspace,
+        owner_slot_id=slots[1].id,
+        preset_slots=slots,
+    )
+
+    assert "Issue: #958" in brief
+    assert "make -C" not in brief

--- a/backend/tests/agent_teams/test_github_scope_models.py
+++ b/backend/tests/agent_teams/test_github_scope_models.py
@@ -2,6 +2,7 @@
 import pytest
 import pytest_asyncio
 from sqlalchemy import select, text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 import app.models.database  # noqa: F401
@@ -11,6 +12,7 @@ from app.models.database import (
     AgentTeamSlot,
     TeamGithubScope,
     GithubWorkItem,
+    GithubWorkspace,
 )
 
 
@@ -46,7 +48,89 @@ async def test_team_github_scope_round_trips(db):
     assert scope.max_concurrent_dispatched == 3
     assert scope.max_verification_retries == 2
     assert scope.max_auto_merges_per_day == 5
+    assert scope.base_ref == "origin/HEAD"
+    assert scope.builds_out_of_tree is False
+    assert scope.build_dir_template == "build"
+    assert scope.build_command_hint is None
+    assert scope.max_build_parallelism == 4
     assert scope.enabled is True
+
+
+@pytest.mark.asyncio
+async def test_github_workspace_defaults(db):
+    preset = AgentTeamPreset(name="Workspace", description="", created_by="test")
+    db.add(preset)
+    await db.flush()
+    scope = TeamGithubScope(
+        preset_id=preset.id,
+        repo_owner="owner",
+        repo_name="repo",
+        repo_path="/tmp/repo",
+    )
+    db.add(scope)
+    await db.flush()
+    workspace = GithubWorkspace(scope_id=scope.id, path="/tmp/repo-ws1")
+    db.add(workspace)
+    await db.commit()
+    await db.refresh(workspace)
+    assert workspace.kind == "worktree"
+    assert workspace.enabled is True
+    assert workspace.dispatchable is True
+    assert workspace.leased_item_id is None
+
+
+@pytest.mark.asyncio
+async def test_github_workspace_leased_item_is_unique(db):
+    preset = AgentTeamPreset(name="Lease", description="", created_by="test")
+    db.add(preset)
+    await db.flush()
+    scope = TeamGithubScope(
+        preset_id=preset.id,
+        repo_owner="owner",
+        repo_name="repo",
+        repo_path="/tmp/repo",
+    )
+    db.add(scope)
+    await db.flush()
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=1,
+        issue_title="Issue",
+        issue_url="https://github.com/owner/repo/issues/1",
+        github_updated_at=__import__("datetime").datetime.utcnow(),
+    )
+    db.add(item)
+    await db.flush()
+    db.add_all([
+        GithubWorkspace(scope_id=scope.id, path="/tmp/repo-ws1", leased_item_id=item.id),
+        GithubWorkspace(scope_id=scope.id, path="/tmp/repo-ws2", leased_item_id=item.id),
+    ])
+    with pytest.raises(IntegrityError):
+        await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_github_workspace_path_is_globally_unique(db):
+    preset = AgentTeamPreset(name="Path", description="", created_by="test")
+    db.add(preset)
+    await db.flush()
+    scopes = [
+        TeamGithubScope(
+            preset_id=preset.id,
+            repo_owner="owner",
+            repo_name=repo_name,
+            repo_path=f"/tmp/{repo_name}",
+        )
+        for repo_name in ("repo-a", "repo-b")
+    ]
+    db.add_all(scopes)
+    await db.flush()
+    db.add_all([
+        GithubWorkspace(scope_id=scopes[0].id, path="/tmp/shared-ws"),
+        GithubWorkspace(scope_id=scopes[1].id, path="/tmp/shared-ws"),
+    ])
+    with pytest.raises(IntegrityError):
+        await db.commit()
 
 
 @pytest.mark.asyncio
@@ -137,4 +221,9 @@ async def test_compat_migration_adds_new_columns_to_legacy_db():
     assert "max_concurrent_dispatched" in scope_cols
     assert "max_verification_retries" in scope_cols
     assert "max_auto_merges_per_day" in scope_cols
+    assert "base_ref" in scope_cols
+    assert "builds_out_of_tree" in scope_cols
+    assert "build_dir_template" in scope_cols
+    assert "build_command_hint" in scope_cols
+    assert "max_build_parallelism" in scope_cols
     await engine.dispose()

--- a/backend/tests/agent_teams/test_github_verification_service.py
+++ b/backend/tests/agent_teams/test_github_verification_service.py
@@ -15,6 +15,7 @@ from app.models.database import (
     AgentTeamPreset,
     AgentTeamSlot,
     GithubWorkItem,
+    GithubWorkspace,
     MailMessage,
     MailTeamMember,
     TeamGithubScope,
@@ -95,6 +96,25 @@ async def _owner(db, scope):
     db.add(member)
     await db.flush()
     return slot, member
+
+
+@pytest.mark.asyncio
+async def test_mark_merged_does_not_release_workspace(db):
+    scope = await _scope(db)
+    item = await _item(db, scope)
+    workspace = GithubWorkspace(
+        scope_id=scope.id,
+        path="/tmp/r-ws-1",
+        leased_item_id=item.id,
+    )
+    db.add(workspace)
+    await db.commit()
+
+    github_verification_service._mark_merged(item)
+    await db.commit()
+
+    assert item.dispatch_status == "merged"
+    assert workspace.leased_item_id == item.id
 
 
 class _Client:

--- a/backend/tests/agent_teams/test_github_watcher_service.py
+++ b/backend/tests/agent_teams/test_github_watcher_service.py
@@ -13,6 +13,7 @@ from app.models.database import (
     AgentTeamPreset,
     AgentTeamSlot,
     GithubWorkItem,
+    GithubWorkspace,
     MailMessage,
     MailTeamMember,
     TeamGithubScope,
@@ -155,6 +156,33 @@ def _issue(number, labels, updated="2026-07-04T00:00:00Z"):
         "state": "open",
         "labels": [{"name": name} for name in labels],
     }
+
+
+@pytest.mark.asyncio
+async def test_complete_and_notify_does_not_release_workspace(db):
+    scope = await _make_scope(db)
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=99,
+        issue_title="closed",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="dispatched",
+    )
+    db.add(item)
+    await db.flush()
+    workspace = GithubWorkspace(
+        scope_id=scope.id,
+        path="/tmp/r-ws-1",
+        leased_item_id=item.id,
+    )
+    db.add(workspace)
+    await db.commit()
+
+    await github_watcher_service._complete_and_notify(db, scope, item)
+
+    assert item.dispatch_status == "completed"
+    assert workspace.leased_item_id == item.id
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_teams/test_github_workspace_api.py
+++ b/backend/tests/agent_teams/test_github_workspace_api.py
@@ -1,0 +1,479 @@
+"""HTTP contract tests for GitHub workspace operations."""
+from datetime import datetime
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.database import get_db
+from app.main import app
+from app.models.database import (
+    AgentTeamPreset,
+    GithubWorkItem,
+    GithubWorkspace,
+    TeamGithubScope,
+)
+from app.services.github_workspace_service import (
+    GithubWorkspaceError,
+    GithubWorkspaceResetError,
+    github_workspace_service,
+)
+
+
+@pytest_asyncio.fixture
+async def client(db):
+    async def _override():
+        yield db
+
+    app.dependency_overrides[get_db] = _override
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as http:
+        yield http
+    app.dependency_overrides.clear()
+
+
+async def _scope(db, repo_path: Path):
+    repo_path.mkdir(exist_ok=True)
+    (repo_path / "tracked").write_text("x")
+    preset = AgentTeamPreset(name=f"Workspace {repo_path.name}", description="", created_by="test")
+    db.add(preset)
+    await db.flush()
+    scope = TeamGithubScope(
+        preset_id=preset.id,
+        repo_owner="owner",
+        repo_name=repo_path.name,
+        repo_path=str(repo_path),
+    )
+    db.add(scope)
+    await db.commit()
+    return preset, scope
+
+
+class ApiGitRunner:
+    def __init__(self, repo_path: Path):
+        self.repo_path = repo_path
+        self.calls: list[list[str]] = []
+        self.status_output = ""
+        self.worktree_add_error: str | None = None
+
+    async def __call__(self, args: list[str]):
+        self.calls.append(args)
+        path = Path(args[1])
+        command = args[2]
+        common = self.repo_path / ".git"
+        if command == "rev-parse":
+            linked = path != self.repo_path
+            git_dir = common / "worktrees" / path.name if linked else common
+            return 0, f"{git_dir}\n{common}\n{path}\n"
+        if command == "status":
+            return 0, self.status_output
+        if command == "worktree" and self.worktree_add_error:
+            return 128, self.worktree_add_error
+        return 0, ""
+
+
+@pytest.fixture
+def no_live_sessions(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.github_workspace_service.discover_agent_sessions", lambda: []
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_workspaces_derives_all_lease_states(client, db, tmp_path):
+    _, scope = await _scope(db, tmp_path / "repo")
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=1,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+    )
+    db.add(item)
+    await db.flush()
+    db.add_all(
+        [
+            GithubWorkspace(scope_id=scope.id, path=str(tmp_path / "available")),
+            GithubWorkspace(
+                scope_id=scope.id,
+                path=str(tmp_path / "leased"),
+                leased_item_id=item.id,
+            ),
+            GithubWorkspace(
+                scope_id=scope.id,
+                path=str(tmp_path / "disabled"),
+                enabled=False,
+            ),
+            GithubWorkspace(
+                scope_id=scope.id,
+                path=str(tmp_path / "reserved"),
+                dispatchable=False,
+            ),
+        ]
+    )
+    await db.commit()
+
+    response = await client.get(
+        f"/api/v1/agent-teams/github-scopes/{scope.id}/workspaces"
+    )
+
+    assert response.status_code == 200
+    assert [row["lease_state"] for row in response.json()["workspaces"]] == [
+        "available",
+        "leased",
+        "disabled",
+        "disabled_for_dispatch",
+    ]
+    missing = await client.get("/api/v1/agent-teams/github-scopes/999999/workspaces")
+    assert missing.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_create_workspace_provisions_and_honors_explicit_flags(
+    client, db, tmp_path, monkeypatch, no_live_sessions
+):
+    repo_path = tmp_path / "repo"
+    _, scope = await _scope(db, repo_path)
+    runner = ApiGitRunner(repo_path)
+    monkeypatch.setattr(github_workspace_service, "_runner", runner)
+    workspace_path = tmp_path / "ws"
+
+    response = await client.post(
+        f"/api/v1/agent-teams/github-scopes/{scope.id}/workspaces",
+        json={
+            "path": str(workspace_path),
+            "kind": "worktree",
+            "dispatchable": False,
+            "enabled": False,
+        },
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["dispatchable"] is False
+    assert body["enabled"] is False
+    assert [
+        "-C", str(repo_path), "worktree", "add", "--detach",
+        str(workspace_path), "origin/HEAD",
+    ] in runner.calls
+
+
+@pytest.mark.asyncio
+async def test_create_primary_defaults_non_dispatchable_and_never_mutates_git(
+    client, db, tmp_path, monkeypatch, no_live_sessions
+):
+    repo_path = tmp_path / "repo"
+    _, scope = await _scope(db, repo_path)
+    runner = ApiGitRunner(repo_path)
+    monkeypatch.setattr(github_workspace_service, "_runner", runner)
+
+    response = await client.post(
+        f"/api/v1/agent-teams/github-scopes/{scope.id}/workspaces",
+        json={"path": str(repo_path), "kind": "primary"},
+    )
+
+    assert response.status_code == 201
+    assert response.json()["dispatchable"] is False
+    assert all(call[2] == "rev-parse" for call in runner.calls)
+
+
+@pytest.mark.asyncio
+async def test_create_workspace_rejects_duplicate_before_git_mutation(
+    client, db, tmp_path, monkeypatch
+):
+    repo_path = tmp_path / "repo"
+    _, scope = await _scope(db, repo_path)
+    missing_path = tmp_path / "missing-ws"
+    db.add(GithubWorkspace(scope_id=scope.id, path=str(missing_path)))
+    await db.commit()
+    runner = ApiGitRunner(repo_path)
+    monkeypatch.setattr(github_workspace_service, "_runner", runner)
+
+    response = await client.post(
+        f"/api/v1/agent-teams/github-scopes/{scope.id}/workspaces",
+        json={"path": str(missing_path), "kind": "worktree"},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["block_code"] == "workspace_path_registered"
+    assert runner.calls == []
+
+
+@pytest.mark.asyncio
+async def test_create_workspace_rejects_invalid_kind(client, db, tmp_path):
+    _, scope = await _scope(db, tmp_path / "repo")
+    response = await client.post(
+        f"/api/v1/agent-teams/github-scopes/{scope.id}/workspaces",
+        json={"path": str(tmp_path / "ws"), "kind": "Primary"},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_create_workspace_failure_persists_no_row(
+    client, db, tmp_path, monkeypatch
+):
+    repo_path = tmp_path / "repo"
+    _, scope = await _scope(db, repo_path)
+    runner = ApiGitRunner(repo_path)
+    runner.worktree_add_error = "stale worktree registration"
+    monkeypatch.setattr(github_workspace_service, "_runner", runner)
+
+    response = await client.post(
+        f"/api/v1/agent-teams/github-scopes/{scope.id}/workspaces",
+        json={"path": str(tmp_path / "ws"), "kind": "worktree"},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["block_code"] == "workspace_not_a_worktree"
+    rows = (await db.execute(select(GithubWorkspace))).scalars().all()
+    assert rows == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("block_code", "path_kind", "dispatchable"),
+    [
+        ("workspace_is_primary", "primary", True),
+        ("workspace_dirty", "linked", True),
+        ("workspace_occupied", "linked", True),
+    ],
+)
+async def test_create_workspace_conflicts_include_machine_code(
+    client,
+    db,
+    tmp_path,
+    monkeypatch,
+    block_code,
+    path_kind,
+    dispatchable,
+):
+    repo_path = tmp_path / "repo"
+    _, scope = await _scope(db, repo_path)
+    candidate = repo_path if path_kind == "primary" else tmp_path / "ws"
+    if candidate != repo_path:
+        candidate.mkdir()
+        (candidate / "tracked").write_text("x")
+    runner = ApiGitRunner(repo_path)
+    if block_code == "workspace_dirty":
+        runner.status_output = "?? untracked\n"
+    monkeypatch.setattr(github_workspace_service, "_runner", runner)
+    sessions = (
+        [{"cwd": str(candidate), "tmux_target": "deck:0.0"}]
+        if block_code == "workspace_occupied"
+        else []
+    )
+    monkeypatch.setattr(
+        "app.services.github_workspace_service.discover_agent_sessions",
+        lambda: sessions,
+    )
+
+    response = await client.post(
+        f"/api/v1/agent-teams/github-scopes/{scope.id}/workspaces",
+        json={
+            "path": str(candidate),
+            "kind": "worktree",
+            "dispatchable": dispatchable,
+        },
+    )
+
+    assert response.status_code == 409
+    detail = response.json()["detail"]
+    assert detail["block_code"] == block_code
+    assert isinstance(detail["message"], str)
+
+
+@pytest.mark.asyncio
+async def test_reprobe_reenables_only_after_success(client, db, tmp_path, monkeypatch):
+    _, scope = await _scope(db, tmp_path / "repo")
+    workspace = GithubWorkspace(
+        scope_id=scope.id,
+        path=str(tmp_path / "ws"),
+        enabled=False,
+        provision_error="old",
+    )
+    db.add(workspace)
+    await db.commit()
+
+    async def succeeds(*_args):
+        return None
+
+    monkeypatch.setattr(github_workspace_service, "reset_workspace", succeeds)
+    response = await client.post(
+        f"/api/v1/agent-teams/github-scopes/{scope.id}/workspaces/{workspace.id}/reprobe"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["enabled"] is True
+    assert response.json()["provision_error"] is None
+
+
+@pytest.mark.asyncio
+async def test_reprobe_failure_stays_disabled_with_block_code(
+    client, db, tmp_path, monkeypatch
+):
+    _, scope = await _scope(db, tmp_path / "repo")
+    workspace = GithubWorkspace(
+        scope_id=scope.id,
+        path=str(tmp_path / "ws"),
+        enabled=False,
+    )
+    db.add(workspace)
+    await db.commit()
+
+    async def fails(_db, _scope, target):
+        target.enabled = False
+        target.provision_error = "still broken"
+        raise GithubWorkspaceResetError("still broken", transient=False)
+
+    monkeypatch.setattr(github_workspace_service, "reset_workspace", fails)
+    response = await client.post(
+        f"/api/v1/agent-teams/github-scopes/{scope.id}/workspaces/{workspace.id}/reprobe"
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["block_code"] == "workspace_reset_failed"
+    assert workspace.enabled is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("guard", ["leased", "primary"])
+async def test_reprobe_guard_runs_before_reset(client, db, tmp_path, monkeypatch, guard):
+    _, scope = await _scope(db, tmp_path / "repo")
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=2,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+    )
+    db.add(item)
+    await db.flush()
+    workspace = GithubWorkspace(
+        scope_id=scope.id,
+        path=str(tmp_path / "ws"),
+        kind="primary" if guard == "primary" else "worktree",
+        leased_item_id=item.id if guard == "leased" else None,
+        enabled=False,
+    )
+    db.add(workspace)
+    await db.commit()
+    called = False
+
+    async def should_not_run(*_args):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(github_workspace_service, "reset_workspace", should_not_run)
+    response = await client.post(
+        f"/api/v1/agent-teams/github-scopes/{scope.id}/workspaces/{workspace.id}/reprobe"
+    )
+
+    assert response.status_code == 409
+    if guard == "leased":
+        assert response.json()["detail"]["block_code"] == "workspace_leased"
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_abandon_changes_status_but_retains_workspace(client, db, tmp_path, monkeypatch):
+    _, scope = await _scope(db, tmp_path / "repo")
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=3,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="ready_for_review",
+        pr_number=42,
+    )
+    db.add(item)
+    await db.flush()
+    workspace = GithubWorkspace(
+        scope_id=scope.id,
+        path=str(tmp_path / "ws"),
+        leased_item_id=item.id,
+    )
+    db.add(workspace)
+    await db.commit()
+    monkeypatch.setattr(
+        "app.services.github_dispatch_service.GithubDispatchService._send_escalation_broadcast",
+        lambda *_args, **_kwargs: _async_none(),
+    )
+
+    response = await client.post(
+        f"/api/v1/agent-teams/github-work-items/{item.id}/abandon",
+        json={"reason": "PR will not proceed"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["dispatch_status"] == "escalated"
+    assert response.json()["escalation_reason"] == "abandoned_by_operator"
+    assert workspace.leased_item_id == item.id
+
+
+async def _async_none():
+    return None
+
+
+@pytest.mark.asyncio
+async def test_abandon_terminal_item_returns_machine_code(client, db, tmp_path):
+    _, scope = await _scope(db, tmp_path / "repo")
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=4,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="merged",
+    )
+    db.add(item)
+    await db.commit()
+
+    response = await client.post(
+        f"/api/v1/agent-teams/github-work-items/{item.id}/abandon"
+    )
+
+    assert response.status_code == 409
+    detail = response.json()["detail"]
+    assert detail["block_code"] == "work_item_not_abandonable"
+    assert "message" in detail
+
+
+@pytest.mark.asyncio
+async def test_work_item_feed_outer_joins_workspace_path(client, db, tmp_path):
+    preset, scope = await _scope(db, tmp_path / "repo")
+    leased = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=5,
+        issue_title="leased",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+    )
+    unleased = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=6,
+        issue_title="unleased",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+    )
+    db.add_all([leased, unleased])
+    await db.flush()
+    workspace = GithubWorkspace(
+        scope_id=scope.id,
+        path=str(tmp_path / "ws"),
+        leased_item_id=leased.id,
+    )
+    db.add(workspace)
+    await db.commit()
+
+    response = await client.get(
+        f"/api/v1/agent-teams/presets/{preset.id}/github-work-items"
+    )
+
+    assert response.status_code == 200
+    rows = {row["issue_number"]: row for row in response.json()["items"]}
+    assert rows[5]["workspace_path"] == str(tmp_path / "ws")
+    assert rows[6]["workspace_path"] is None

--- a/backend/tests/agent_teams/test_github_workspace_service.py
+++ b/backend/tests/agent_teams/test_github_workspace_service.py
@@ -1,0 +1,604 @@
+"""Workspace lease, provisioning, adoption, and reset tests."""
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+import app.models.database  # noqa: F401
+from app.database import Base
+from app.models.database import (
+    AgentTeamPreset,
+    AgentTeamSlot,
+    GithubWorkItem,
+    GithubWorkspace,
+    TeamGithubScope,
+)
+from app.services.github_dispatch_service import github_dispatch_service
+from app.services.github_workspace_service import (
+    GIT_TIMEOUT_SECONDS,
+    GithubWorkspaceError,
+    GithubWorkspaceResetError,
+    GithubWorkspaceService,
+)
+
+
+@pytest_asyncio.fixture
+async def db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+class FakeGitRunner:
+    def __init__(self):
+        self.calls: list[list[str]] = []
+        self.identities: dict[str, tuple[str, str, str] | None] = {}
+        self.statuses: dict[str, str] = {}
+        self.failures: dict[str, str] = {}
+
+    async def __call__(self, args: list[str]) -> tuple[int, str]:
+        self.calls.append(args)
+        path = args[1] if len(args) > 1 and args[0] == "-C" else ""
+        command = args[2] if len(args) > 2 else ""
+        if command == "rev-parse":
+            identity = self.identities.get(path)
+            if identity is None:
+                return 128, "fatal: not a git repository"
+            return 0, "\n".join(identity) + "\n"
+        if command == "status":
+            return 0, self.statuses.get(path, "")
+        failure = self.failures.get(command)
+        if failure is not None:
+            return 1, failure
+        return 0, ""
+
+
+async def _context(db, repo_path: Path):
+    preset = AgentTeamPreset(name="Workspace Team", description="", created_by="test")
+    db.add(preset)
+    await db.flush()
+    slot = AgentTeamSlot(
+        preset_id=preset.id,
+        position=0,
+        display_name="Generalist",
+        provider="codex-cli",
+        repo_id="repo",
+        repo_path=str(repo_path),
+        repo_name="repo",
+        launch_mode="plain",
+        launch_options={},
+        enabled=True,
+    )
+    db.add(slot)
+    await db.flush()
+    scope = TeamGithubScope(
+        preset_id=preset.id,
+        repo_owner="owner",
+        repo_name="repo",
+        repo_path=str(repo_path),
+    )
+    db.add(scope)
+    await db.flush()
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=304,
+        issue_title="Provision workspaces",
+        issue_url="https://github.com/owner/repo/issues/304",
+        github_updated_at=datetime.utcnow(),
+        owner_slot_id=slot.id,
+    )
+    db.add(item)
+    await db.commit()
+    return scope, slot, item
+
+
+def _set_identity(runner: FakeGitRunner, path: Path, common_dir: Path, *, linked: bool):
+    git_dir = common_dir / "worktrees" / path.name if linked else common_dir
+    runner.identities[str(path)] = (str(git_dir), str(common_dir), str(path))
+
+
+@pytest.mark.asyncio
+async def test_acquire_leases_oldest_available_workspace(db, tmp_path):
+    repo_path = tmp_path / "repo"
+    scope, _, item = await _context(db, repo_path)
+    runner = FakeGitRunner()
+    service = GithubWorkspaceService(runner=runner)
+    first = GithubWorkspace(scope_id=scope.id, path=str(tmp_path / "ws1"))
+    second = GithubWorkspace(scope_id=scope.id, path=str(tmp_path / "ws2"))
+    db.add_all([first, second])
+    await db.commit()
+
+    acquired = await service.acquire(db, scope, item)
+
+    assert acquired.id == first.id
+    assert acquired.leased_item_id == item.id
+    assert acquired.leased_at is not None
+
+
+@pytest.mark.asyncio
+async def test_acquire_returns_none_when_every_workspace_is_leased(db, tmp_path):
+    scope, _, item = await _context(db, tmp_path / "repo")
+    other = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=305,
+        issue_title="Other",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+    )
+    db.add(other)
+    await db.flush()
+    db.add(GithubWorkspace(scope_id=scope.id, path=str(tmp_path / "ws"), leased_item_id=other.id))
+    await db.commit()
+
+    assert await GithubWorkspaceService(runner=FakeGitRunner()).acquire(db, scope, item) is None
+
+
+@pytest.mark.asyncio
+async def test_acquire_is_idempotent_for_existing_lease(db, tmp_path):
+    scope, _, item = await _context(db, tmp_path / "repo")
+    workspace = GithubWorkspace(
+        scope_id=scope.id,
+        path=str(tmp_path / "ws"),
+        leased_item_id=item.id,
+    )
+    db.add(workspace)
+    await db.commit()
+    runner = FakeGitRunner()
+
+    acquired = await GithubWorkspaceService(runner=runner).acquire(db, scope, item)
+
+    assert acquired.id == workspace.id
+    assert runner.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field", ["enabled", "dispatchable"])
+async def test_acquire_ignores_unavailable_workspace(db, tmp_path, field):
+    scope, _, item = await _context(db, tmp_path / "repo")
+    values = {"enabled": True, "dispatchable": True}
+    values[field] = False
+    db.add(GithubWorkspace(scope_id=scope.id, path=str(tmp_path / "ws"), **values))
+    await db.commit()
+
+    assert await GithubWorkspaceService(runner=FakeGitRunner()).acquire(db, scope, item) is None
+
+
+@pytest.mark.asyncio
+async def test_non_dispatchable_primary_never_wins_acquire(db, tmp_path):
+    scope, _, item = await _context(db, tmp_path / "repo")
+    primary = GithubWorkspace(
+        scope_id=scope.id,
+        path=scope.repo_path,
+        kind="primary",
+        dispatchable=False,
+    )
+    worktree = GithubWorkspace(scope_id=scope.id, path=str(tmp_path / "ws"))
+    db.add_all([primary, worktree])
+    await db.commit()
+
+    acquired = await GithubWorkspaceService(runner=FakeGitRunner()).acquire(db, scope, item)
+
+    assert acquired.id == worktree.id
+
+
+@pytest.mark.asyncio
+async def test_release_is_idempotent(db, tmp_path):
+    scope, _, item = await _context(db, tmp_path / "repo")
+    workspace = GithubWorkspace(
+        scope_id=scope.id,
+        path=str(tmp_path / "ws"),
+        leased_item_id=item.id,
+    )
+    db.add(workspace)
+    await db.commit()
+    service = GithubWorkspaceService(runner=FakeGitRunner())
+
+    await service.release(db, item.id)
+    await service.release(db, item.id)
+
+    assert workspace.leased_item_id is None
+    assert workspace.released_at is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["escalated", "failed", "merged", "completed"])
+async def test_reclaim_releases_non_working_item_without_live_owner(
+    db, tmp_path, monkeypatch, status
+):
+    scope, _, item = await _context(db, tmp_path / "repo")
+    item.dispatch_status = status
+    workspace = GithubWorkspace(
+        scope_id=scope.id,
+        path=str(tmp_path / "ws"),
+        leased_item_id=item.id,
+    )
+    db.add(workspace)
+    await db.commit()
+    monkeypatch.setattr(
+        github_dispatch_service,
+        "slot_has_live_owner_session",
+        lambda *_args, **_kwargs: _async_value(False),
+    )
+
+    count = await GithubWorkspaceService(runner=FakeGitRunner()).reclaim_stale(db, scope)
+
+    assert count == 1
+    assert workspace.leased_item_id is None
+
+
+@pytest.mark.asyncio
+async def test_reclaim_retains_non_working_item_with_live_owner(db, tmp_path, monkeypatch):
+    scope, _, item = await _context(db, tmp_path / "repo")
+    item.dispatch_status = "escalated"
+    workspace = GithubWorkspace(
+        scope_id=scope.id,
+        path=str(tmp_path / "ws"),
+        leased_item_id=item.id,
+    )
+    db.add(workspace)
+    await db.commit()
+    monkeypatch.setattr(
+        github_dispatch_service,
+        "slot_has_live_owner_session",
+        lambda *_args, **_kwargs: _async_value(True),
+    )
+
+    count = await GithubWorkspaceService(runner=FakeGitRunner()).reclaim_stale(db, scope)
+
+    assert count == 0
+    assert workspace.leased_item_id == item.id
+
+
+async def _async_value(value):
+    return value
+
+
+@pytest.mark.asyncio
+async def test_register_provisions_fresh_worktree(db, tmp_path):
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    scope, _, _ = await _context(db, repo_path)
+    runner = FakeGitRunner()
+    _set_identity(runner, repo_path, repo_path / ".git", linked=False)
+    workspace_path = tmp_path / "ws"
+
+    workspace = await GithubWorkspaceService(runner=runner).register_workspace(
+        db, scope, str(workspace_path), kind="worktree"
+    )
+
+    assert workspace.path == str(workspace_path)
+    assert [
+        "-C", str(repo_path), "worktree", "add", "--detach",
+        str(workspace_path), "origin/HEAD",
+    ] in runner.calls
+
+
+@pytest.mark.asyncio
+async def test_register_empty_directory_takes_provisioning_path(db, tmp_path):
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    workspace_path = tmp_path / "ws"
+    workspace_path.mkdir()
+    scope, _, _ = await _context(db, repo_path)
+    runner = FakeGitRunner()
+    _set_identity(runner, repo_path, repo_path / ".git", linked=False)
+
+    await GithubWorkspaceService(runner=runner).register_workspace(
+        db, scope, str(workspace_path), kind="worktree"
+    )
+
+    assert any(call[2:4] == ["worktree", "add"] for call in runner.calls)
+
+
+@pytest.mark.asyncio
+async def test_register_adopts_existing_linked_worktree(db, tmp_path):
+    repo_path = tmp_path / "repo"
+    workspace_path = tmp_path / "ws"
+    repo_path.mkdir()
+    workspace_path.mkdir()
+    (workspace_path / "tracked").write_text("clean")
+    scope, _, _ = await _context(db, repo_path)
+    runner = FakeGitRunner()
+    common_dir = repo_path / ".git"
+    _set_identity(runner, repo_path, common_dir, linked=False)
+    _set_identity(runner, workspace_path, common_dir, linked=True)
+
+    workspace = await GithubWorkspaceService(runner=runner).register_workspace(
+        db, scope, str(workspace_path), kind="worktree"
+    )
+
+    assert workspace.kind == "worktree"
+    assert not any(call[2:4] == ["worktree", "add"] for call in runner.calls)
+    assert all("--path-format=absolute" in call for call in runner.calls if "rev-parse" in call)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("candidate_kind", ["foreign", "nested", "plain"])
+async def test_register_rejects_invalid_existing_worktree(db, tmp_path, candidate_kind):
+    repo_path = tmp_path / "repo"
+    workspace_path = tmp_path / "ws"
+    repo_path.mkdir()
+    workspace_path.mkdir()
+    (workspace_path / "content").write_text("x")
+    scope, _, _ = await _context(db, repo_path)
+    runner = FakeGitRunner()
+    common_dir = repo_path / ".git"
+    _set_identity(runner, repo_path, common_dir, linked=False)
+    if candidate_kind == "foreign":
+        _set_identity(runner, workspace_path, tmp_path / "other" / ".git", linked=True)
+    elif candidate_kind == "nested":
+        runner.identities[str(workspace_path)] = (
+            str(common_dir / "worktrees" / "real"),
+            str(common_dir),
+            str(tmp_path / "real-root"),
+        )
+
+    with pytest.raises(GithubWorkspaceError) as exc_info:
+        await GithubWorkspaceService(runner=runner).register_workspace(
+            db, scope, str(workspace_path), kind="worktree"
+        )
+
+    assert exc_info.value.block_code == "workspace_not_a_worktree"
+
+
+@pytest.mark.asyncio
+async def test_register_rejects_primary_as_worktree(db, tmp_path):
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    (repo_path / "content").write_text("x")
+    scope, _, _ = await _context(db, repo_path)
+    runner = FakeGitRunner()
+    _set_identity(runner, repo_path, repo_path / ".git", linked=False)
+
+    with pytest.raises(GithubWorkspaceError) as exc_info:
+        await GithubWorkspaceService(runner=runner).register_workspace(
+            db, scope, str(repo_path), kind="worktree"
+        )
+
+    assert exc_info.value.block_code == "workspace_is_primary"
+
+
+@pytest.mark.asyncio
+async def test_register_rejects_linked_worktree_as_primary(db, tmp_path):
+    repo_path = tmp_path / "repo"
+    workspace_path = tmp_path / "ws"
+    repo_path.mkdir()
+    workspace_path.mkdir()
+    (workspace_path / "content").write_text("x")
+    scope, _, _ = await _context(db, repo_path)
+    runner = FakeGitRunner()
+    common_dir = repo_path / ".git"
+    _set_identity(runner, repo_path, common_dir, linked=False)
+    _set_identity(runner, workspace_path, common_dir, linked=True)
+
+    with pytest.raises(GithubWorkspaceError) as exc_info:
+        await GithubWorkspaceService(runner=runner).register_workspace(
+            db, scope, str(workspace_path), kind="primary"
+        )
+
+    assert exc_info.value.block_code == "workspace_not_a_worktree"
+
+
+@pytest.mark.asyncio
+async def test_register_primary_validates_repository_identity(db, tmp_path):
+    repo_path = tmp_path / "repo"
+    other_path = tmp_path / "other"
+    repo_path.mkdir()
+    other_path.mkdir()
+    (other_path / "content").write_text("x")
+    scope, _, _ = await _context(db, repo_path)
+    runner = FakeGitRunner()
+    _set_identity(runner, repo_path, repo_path / ".git", linked=False)
+    _set_identity(runner, other_path, other_path / ".git", linked=False)
+
+    with pytest.raises(GithubWorkspaceError) as exc_info:
+        await GithubWorkspaceService(runner=runner).register_workspace(
+            db, scope, str(other_path), kind="primary"
+        )
+
+    assert exc_info.value.block_code == "workspace_not_a_worktree"
+
+
+@pytest.mark.asyncio
+async def test_register_rejects_dirty_adopted_worktree(db, tmp_path):
+    repo_path = tmp_path / "repo"
+    workspace_path = tmp_path / "ws"
+    repo_path.mkdir()
+    workspace_path.mkdir()
+    (workspace_path / "content").write_text("x")
+    scope, _, _ = await _context(db, repo_path)
+    runner = FakeGitRunner()
+    common_dir = repo_path / ".git"
+    _set_identity(runner, repo_path, common_dir, linked=False)
+    _set_identity(runner, workspace_path, common_dir, linked=True)
+    runner.statuses[str(workspace_path)] = "?? untracked.txt\n"
+
+    with pytest.raises(GithubWorkspaceError) as exc_info:
+        await GithubWorkspaceService(runner=runner).register_workspace(
+            db, scope, str(workspace_path), kind="worktree"
+        )
+
+    assert exc_info.value.block_code == "workspace_dirty"
+    assert "untracked.txt" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_register_rejects_occupied_adopted_worktree(db, tmp_path, monkeypatch):
+    repo_path = tmp_path / "repo"
+    workspace_path = tmp_path / "ws"
+    repo_path.mkdir()
+    workspace_path.mkdir()
+    (workspace_path / "content").write_text("x")
+    scope, _, _ = await _context(db, repo_path)
+    runner = FakeGitRunner()
+    common_dir = repo_path / ".git"
+    _set_identity(runner, repo_path, common_dir, linked=False)
+    _set_identity(runner, workspace_path, common_dir, linked=True)
+    monkeypatch.setattr(
+        "app.services.github_workspace_service.discover_agent_sessions",
+        lambda: [{"cwd": str(workspace_path / ".." / "ws")}],
+    )
+
+    with pytest.raises(GithubWorkspaceError) as exc_info:
+        await GithubWorkspaceService(runner=runner).register_workspace(
+            db, scope, str(workspace_path), kind="worktree"
+        )
+
+    assert exc_info.value.block_code == "workspace_occupied"
+
+
+@pytest.mark.asyncio
+async def test_register_honors_explicit_workspace_flags(db, tmp_path):
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    scope, _, _ = await _context(db, repo_path)
+    runner = FakeGitRunner()
+    _set_identity(runner, repo_path, repo_path / ".git", linked=False)
+
+    workspace = await GithubWorkspaceService(runner=runner).register_workspace(
+        db,
+        scope,
+        str(tmp_path / "ws"),
+        kind="worktree",
+        dispatchable=False,
+        enabled=False,
+    )
+
+    assert workspace.dispatchable is False
+    assert workspace.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_reset_uses_safe_commands_and_preserves_ignored_files(db, tmp_path):
+    scope, _, _ = await _context(db, tmp_path / "repo")
+    workspace = GithubWorkspace(scope_id=scope.id, path=str(tmp_path / "ws"))
+    runner = FakeGitRunner()
+
+    await GithubWorkspaceService(runner=runner).reset_workspace(db, scope, workspace)
+
+    assert ["-C", workspace.path, "switch", "--detach", "--force", "origin/HEAD"] in runner.calls
+    assert ["-C", workspace.path, "reset", "--hard", "origin/HEAD"] in runner.calls
+    assert ["-C", workspace.path, "clean", "-fd"] in runner.calls
+    assert not any("-fdx" in call or "-x" in call for call in runner.calls)
+
+
+@pytest.mark.asyncio
+async def test_reset_primary_runs_no_git_commands(db, tmp_path):
+    scope, _, _ = await _context(db, tmp_path / "repo")
+    workspace = GithubWorkspace(
+        scope_id=scope.id,
+        path=scope.repo_path,
+        kind="primary",
+    )
+    runner = FakeGitRunner()
+
+    await GithubWorkspaceService(runner=runner).reset_workspace(db, scope, workspace)
+
+    assert runner.calls == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_failure_is_transient_and_releases_lease(db, tmp_path):
+    scope, _, item = await _context(db, tmp_path / "repo")
+    workspace = GithubWorkspace(scope_id=scope.id, path=str(tmp_path / "ws"))
+    db.add(workspace)
+    await db.commit()
+    runner = FakeGitRunner()
+    runner.failures["fetch"] = "network down"
+
+    acquired = await GithubWorkspaceService(runner=runner).acquire(db, scope, item)
+
+    assert acquired is None
+    assert workspace.enabled is True
+    assert workspace.provision_error == "network down"
+    assert workspace.leased_item_id is None
+
+
+@pytest.mark.asyncio
+async def test_local_reset_failure_disables_workspace(db, tmp_path):
+    scope, _, item = await _context(db, tmp_path / "repo")
+    workspace = GithubWorkspace(scope_id=scope.id, path=str(tmp_path / "ws"))
+    db.add(workspace)
+    await db.commit()
+    runner = FakeGitRunner()
+    runner.failures["switch"] = "broken tree"
+
+    acquired = await GithubWorkspaceService(runner=runner).acquire(db, scope, item)
+
+    assert acquired is None
+    assert workspace.enabled is False
+    assert workspace.provision_error == "broken tree"
+    assert workspace.leased_item_id is None
+
+
+@pytest.mark.asyncio
+async def test_successful_reset_clears_provision_error(db, tmp_path):
+    scope, _, _ = await _context(db, tmp_path / "repo")
+    workspace = GithubWorkspace(
+        scope_id=scope.id,
+        path=str(tmp_path / "ws"),
+        provision_error="old failure",
+    )
+
+    await GithubWorkspaceService(runner=FakeGitRunner()).reset_workspace(db, scope, workspace)
+
+    assert workspace.provision_error is None
+
+
+@pytest.mark.asyncio
+async def test_reset_error_reports_transient_classification(db, tmp_path):
+    scope, _, _ = await _context(db, tmp_path / "repo")
+    workspace = GithubWorkspace(scope_id=scope.id, path=str(tmp_path / "ws"))
+    runner = FakeGitRunner()
+    runner.failures["fetch"] = "offline"
+
+    with pytest.raises(GithubWorkspaceResetError) as exc_info:
+        await GithubWorkspaceService(runner=runner).reset_workspace(db, scope, workspace)
+
+    assert exc_info.value.transient is True
+
+
+@pytest.mark.asyncio
+async def test_git_runner_is_noninteractive_and_timed(monkeypatch):
+    captured = {}
+
+    class Process:
+        returncode = 0
+
+        async def communicate(self):
+            return b"ok", b""
+
+    async def create_process(*args, **kwargs):
+        captured["args"] = args
+        captured["env"] = kwargs["env"]
+        return Process()
+
+    real_wait_for = __import__("asyncio").wait_for
+
+    async def timed(awaitable, *, timeout):
+        captured["timeout"] = timeout
+        return await real_wait_for(awaitable, timeout=timeout)
+
+    monkeypatch.setattr(
+        "app.services.github_workspace_service.asyncio.create_subprocess_exec",
+        create_process,
+    )
+    monkeypatch.setattr(
+        "app.services.github_workspace_service.asyncio.wait_for",
+        timed,
+    )
+
+    result = await GithubWorkspaceService()._run_git(["status"])
+
+    assert result == (0, "ok")
+    assert captured["args"] == ("git", "status")
+    assert captured["timeout"] == GIT_TIMEOUT_SECONDS
+    assert captured["env"]["GIT_TERMINAL_PROMPT"] == "0"
+    assert captured["env"]["GIT_ASKPASS"] == ""
+    assert captured["env"]["SSH_ASKPASS"] == ""

--- a/frontend/src/features/agent-teams/AutonomyPanel.tsx
+++ b/frontend/src/features/agent-teams/AutonomyPanel.tsx
@@ -87,6 +87,11 @@ function pendingReasonLabel(item: GithubWorkItem, ownerName?: string) {
     return `queued · behind ${ownerName ?? 'assigned slot'}`
   }
   if (item.pending_reason === 'queued_repo_cap') return 'queued · repo cap reached'
+  if (item.pending_reason === 'queued_no_workspace') return 'queued · no free workspace'
+  if (item.pending_reason === 'queued_low_memory') return 'queued · low memory'
+  if (item.pending_reason === 'queued_owner_session_live') {
+    return `queued · ${ownerName ?? 'owner'} session still live`
+  }
   return null
 }
 
@@ -380,6 +385,10 @@ function WorkItemDialog({
                     <dt className="text-muted-foreground">Retries</dt>
                     <dd>{item.retry_count}</dd>
                   </div>
+                  <div className="grid grid-cols-[150px_1fr] border-b p-3">
+                    <dt className="text-muted-foreground">Workspace</dt>
+                    <dd className="truncate">{item.workspace_path ?? 'None leased'}</dd>
+                  </div>
                   <div className="grid grid-cols-[150px_1fr] p-3">
                     <dt className="text-muted-foreground">PR</dt>
                     <dd>{item.pr_number ? `#${item.pr_number}` : 'None yet'}</dd>
@@ -546,7 +555,7 @@ export function AutonomyPanel({
                     {!scope.enabled && <Badge variant="secondary">disabled</Badge>}
                   </div>
                   <p className="mt-2 truncate text-sm text-muted-foreground">
-                    Local checkout: {scope.repo_path}
+                    Worktree parent: {scope.repo_path}
                   </p>
                   <p className="mt-1 text-xs text-muted-foreground">
                     Approval rounds: {scope.max_approval_rounds} · Concurrent: {scope.max_concurrent_dispatched} · Verification retries: {scope.max_verification_retries} · Auto-merges/day: {scope.max_auto_merges_per_day} · Last polled {formatDateTime(scope.last_polled_at)}

--- a/frontend/src/types/agentTeams.ts
+++ b/frontend/src/types/agentTeams.ts
@@ -221,6 +221,7 @@ export interface GithubWorkItem {
   escalation_reason?: string | null
   status_note?: string | null
   auto_merged_at?: string | null
+  workspace_path?: string | null
   created_at: string
   updated_at: string
 }


### PR DESCRIPTION
Closes #304.

## Summary

- Adds a pooled `github_workspaces` resource with database-enforced one-item/one-workspace leasing. `leased_item_id` is unique, and `path` is globally unique because the protected resource is a physical directory, not a scope-local name.
- Adds `dispatchable` separately from `enabled`. Primary checkouts default non-dispatchable, preventing the first registered/lowest-ID primary from winning the first autonomous dispatch.
- Adds workspace gate 6 after routing, slot, liveness, memory, and repo-cap gates. Dispatch launches in `workspace.path`, and shortages remain pending with `queued_no_workspace`.
- Rewrites the dispatch brief as an explicit contract: exclusive leased path, detached base ref, create a branch, never create/remove worktrees, and never use another checkout. This closes the soak's phantom-contract ambiguity.
- Adds conservative per-scope build hints: `builds_out_of_tree=false`, `build_dir_template=build`, `max_build_parallelism=4`, optional command templates, and contained malformed-template rendering.

## Safety Model

- The only status-driven releaser is the reclaim sweep, and it releases `escalated`, `failed`, `merged`, or `completed` items only after the existing owner-slot liveness predicate reports no live session.
- Nothing releases on `merged` or `completed`: detached tmux sessions outlive logical completion and may still write. Prompt terminal release remains PR B after per-item liveness exists.
- Returned known no-process launch failures (`failed` and blocked variants) release immediately. `pending_registration`, `reused`, unknown statuses, and any result carrying `tmux_target` retain the lease.
- No exception releases, including `ValueError`. An exception cannot prove whether tmux already spawned; the item escalates as `launch_outcome_unknown`, and reclaim makes the later physically-grounded decision. The existing `plan_blocked` `ValueError` path likewise retains until the next sweep.
- `reset_for_retry`, escalation, verification failure, and operator abandon do not release.
- Reset uses `fetch origin --prune`, `switch --detach --force`, `reset --hard <base_ref>`, and `clean -fd`. It never uses `-fdx`, preserving ignored warm build directories.
- Fetch failure is transient: it records the error but leaves the workspace enabled. Local switch/reset/clean failure disables it.
- The primary checkout is never reset or cleaned.

## Registration And Operations

- `register_workspace` is the sole public registration entry point; private `_provision_worktree` has one call site and owns the only `git worktree add` command.
- Registration provisions a fresh path or adopts an existing linked worktree. Adoption checks absolute `--git-dir`, `--git-common-dir`, and `--show-toplevel`, validating kind in both directions so a primary cannot be registered as a dispatchable worktree.
- Dispatchable adoption additionally requires a clean `status --porcelain` and no discovered live session whose realpath cwd matches the candidate.
- The API canonical-path precheck happens before Git mutation, preventing a rejected duplicate request from leaving an unregistered worktree on disk; the global constraint remains for races.
- Adds exactly four endpoints: list/register workspaces, reprobe a disabled unleased worktree, and abandon a wedged work item. There is deliberately no DELETE, workspace PATCH, activation action, or force-release.
- `reprobe` re-enables only after a successful reset and refuses leased or primary rows.
- `abandon` changes the item to `escalated` with `abandoned_by_operator`, but neither releases the lease nor kills the session.
- All eight state conflicts return the existing `{message, block_code}` wire shape. This supports agent operators without adding MCP tools or deciding the external-supervisor trust boundary in this PR.

## UI

- Shows `queued_no_workspace`, low-memory, and live-owner queue reasons.
- Shows the leased workspace in work-item details.
- Renames the misleading scope label from `Local checkout` to `Worktree parent`.
- Adds only `workspace_path` to the frontend work-item type; scope-form fields and workspace management UI remain deferred.

## Staging Limitation

**Autonomy must remain off until PR B lands.** PR A intentionally has no prompt terminal release, so a size-1 dispatchable pool can remain occupied by a long-lived tmux session. This PR provides observation and supported recovery, but it is not ready for unattended soak dispatch. Deployment, restart, workspace registration, and DB changes are left to the orchestrator after review/merge.

3b, the host-wide build semaphore, is not included and remains a prerequisite for a second scope or second autonomy-enabled preset.

## Validation

- `pytest tests/agent_teams tests/agent_mail -q --disable-warnings`: **364 passed** (baseline 294, +70).
- `pytest tests/ -q --disable-warnings`: **530 passed, 1 known pre-existing failure** at `tests/test_multi_provider_smoke.py:54` (stale synchronous monkeypatch against async `list_sessions`).
- `npx tsc --noEmit`: passed.
- `npx eslint src/features/agent-teams/AutonomyPanel.tsx src/types/agentTeams.ts`: passed.
- Full `npm run lint`: blocked by 25 pre-existing errors outside the touched files; no reported error is in either changed frontend file.
- `git diff --check`: passed.

## Sanity Checks

All nineteen prescribed checks follow verbatim. Check 12's supplied pattern does not match the dashed literal `"--prune"`, so 12b explicitly proves the only prune usage is fetch's `--prune`.

```text

[1] forbidden clean flags (expected empty)

[2] dispatch repo_path_override
258:                        repo_path_override=workspace.path,

[3] dispatchable acquire filter
81:                    GithubWorkspace.dispatchable.is_(True),
184:        dispatchable: bool = True,
233:            if dispatchable:
242:            dispatchable=dispatchable,

[4] forced switch
159:            ["-C", workspace.path, "switch", "--detach", "--force", scope.base_ref],

[5] forbidden production diffs (expected empty)

[6] work-item outer join
627:            .outerjoin(GithubWorkspace, GithubWorkspace.leased_item_id == GithubWorkItem.id)

[7] delete routes (must not mention workspaces)
393:@router.delete("/presets/{preset_id}", status_code=204)
477:@router.delete("/github-scopes/{scope_id}", status_code=204)
754:@router.delete("/slots/{slot_id}", response_model=AgentTeamPresetResponse)

[8] forbidden release calls (expected empty)

[9] invented launch status (expected empty)

[10] absolute identity probe
256:                "--path-format=absolute",

[11] root identity probe
259:                "--show-toplevel",

[12] prune usage (only fetch --prune)

[13] primary/linked discriminator
257:                "--git-dir",

[14] primary-path guard
191:        repo_path = os.path.realpath(scope.repo_path)
198:        if kind == "worktree" and path == repo_path:
211:            scope_identity = await self._probe_identity(repo_path)
291:            scope.repo_path,

[15] adoption cleanliness gate
270:        return_code, output = await self._runner(["-C", path, "status", "--porcelain"])

[16] ValueError handler (contains no release)
262:            except ValueError:

[17] provisioning entry point (private only)
app/services/github_workspace_service.py:236:            await self._provision_worktree(scope, path)
app/services/github_workspace_service.py:288:    async def _provision_worktree(self, scope: TeamGithubScope, path: str) -> None:

[18] block_code occurrence count (must be >= 9)
13

[19] dirty/occupied machine codes
58:    "workspace_dirty",
59:    "workspace_occupied",

[12b] explicit fetch --prune proof (the prescribed grep does not match dashed flags)
158:            ["-C", workspace.path, "fetch", "origin", "--prune"],

```
