### PR TITLE
Phase G2 PR2: brief delivery guarantee

### DIFF
--- a/backend/app/services/agent_mail_service.py
+++ b/backend/app/services/agent_mail_service.py
@@ -347,12 +347,16 @@ class AgentMailService:
         session.mailbox_status = "connected"
         await db.commit()
 
-    async def sync_observed_sessions(self, db: AsyncSession) -> None:
+    async def sync_observed_sessions(
+        self, db: AsyncSession, *, strict: bool = False
+    ) -> None:
         """Upsert Agent Bridge tmux discoveries as observed sessions."""
         try:
             discovered = discover_agent_sessions()
         except Exception as exc:
             logger.warning("agent bridge discovery failed: %s", exc)
+            if strict:
+                raise
             return
         active_observed_keys: set[str] = set()
         affected_member_ids: set[int] = set()
@@ -1096,6 +1100,23 @@ class AgentMailService:
             (candidate for candidate in result.scalars().all() if self._session_can_nudge(candidate, now)),
             None,
         )
+
+    async def nudgeable_sessions_for_slot(
+        self, db: AsyncSession, slot_id: int
+    ) -> list[MailAgentSession]:
+        """Return every observed session that can be nudged for a slot."""
+        now = datetime.utcnow()
+        sessions = (
+            await db.execute(
+                select(MailAgentSession).where(
+                    MailAgentSession.team_slot_id == slot_id,
+                    MailAgentSession.source == "observed",
+                    MailAgentSession.provider.in_(sorted(TMUX_WAKE_PROVIDERS)),
+                    MailAgentSession.tmux_target.is_not(None),
+                )
+            )
+        ).scalars().all()
+        return [session for session in sessions if self._session_can_nudge(session, now)]
 
     def _send_tmux_inbox_check(self, session: MailAgentSession) -> dict[str, str]:
         if not session.tmux_target:

--- a/backend/app/services/agent_mail_service.py
+++ b/backend/app/services/agent_mail_service.py
@@ -807,6 +807,7 @@ class AgentMailService:
         request: MailMessageCreate,
         *,
         auto_nudge: bool = True,
+        bypass_nudge_cooldown: bool = False,
         sender_actor_id: Optional[int] = None,
     ) -> MailMessageResponse:
         if request.kind not in MAIL_MESSAGE_KINDS:
@@ -864,7 +865,11 @@ class AgentMailService:
         await db.commit()
         await db.refresh(message)
         if auto_nudge:
-            await self.auto_nudge_members(db, recipients)
+            await self.auto_nudge_members(
+                db,
+                recipients,
+                bypass_cooldown=bypass_nudge_cooldown,
+            )
         return await self._message_response(db, message, for_member_id=None)
 
     async def send_broadcast(
@@ -898,6 +903,7 @@ class AgentMailService:
         body_markdown: str,
         payload: dict | None = None,
         auto_nudge: bool = True,
+        bypass_nudge_cooldown: bool = False,
         sender_actor_id: int | None = None,
     ) -> MailMessageResponse:
         return await self.send_message(
@@ -910,6 +916,7 @@ class AgentMailService:
                 payload=payload,
             ),
             auto_nudge=auto_nudge,
+            bypass_nudge_cooldown=bypass_nudge_cooldown,
             sender_actor_id=sender_actor_id,
         )
 
@@ -1129,7 +1136,13 @@ class AgentMailService:
             return {"method": "tmux", **result}
         return None
 
-    async def auto_nudge_members(self, db: AsyncSession, member_ids: set[int]) -> list[dict[str, str | int]]:
+    async def auto_nudge_members(
+        self,
+        db: AsyncSession,
+        member_ids: set[int],
+        *,
+        bypass_cooldown: bool = False,
+    ) -> list[dict[str, str | int]]:
         """Best-effort delivery wakeup for visible tmux-observed recipients."""
         if not member_ids:
             return []
@@ -1139,7 +1152,11 @@ class AgentMailService:
         cooldown_cutoff = now - timedelta(seconds=AUTO_NUDGE_COOLDOWN_SECONDS)
         for member_id in sorted(member_ids):
             last_nudge_at = self._last_auto_nudge_at.get(member_id)
-            if last_nudge_at is not None and last_nudge_at > cooldown_cutoff:
+            if (
+                not bypass_cooldown
+                and last_nudge_at is not None
+                and last_nudge_at > cooldown_cutoff
+            ):
                 continue
             try:
                 result = await self._wake_member(db, member_id, now)

--- a/backend/app/services/github_dispatch_service.py
+++ b/backend/app/services/github_dispatch_service.py
@@ -298,7 +298,7 @@ class GithubDispatchService:
                     scope.preset_id,
                     AgentTeamLaunchRequest(
                         slot_ids=[owner_slot_id],
-                        reuse_existing=False,
+                        reuse_existing=True,
                         skip_plan_confirmation=True,
                         repo_path_override=workspace.path,
                         slot_prompt_overrides={owner_slot_id: brief},

--- a/backend/app/services/github_dispatch_service.py
+++ b/backend/app/services/github_dispatch_service.py
@@ -265,6 +265,15 @@ class GithubDispatchService:
                 item.updated_at = datetime.utcnow()
                 await db.commit()
                 continue
+            ambiguity_note = await self._session_ambiguity_note(db, owner_slot_id)
+            if ambiguity_note is not None:
+                item.owner_slot_id = owner_slot_id
+                item.routing_method = method
+                item.pending_reason = "queued_ambiguous_sessions"
+                item.status_note = ambiguity_note
+                item.updated_at = datetime.utcnow()
+                await db.commit()
+                continue
             workspace = await github_workspace_service.acquire(db, scope, item)
             if workspace is None:
                 item.owner_slot_id = owner_slot_id
@@ -621,6 +630,44 @@ class GithubDispatchService:
             item.brief_delivery_nudge_count = None
         except Exception:
             logger.exception("Failed to send autonomous dispatch brief for item %s", item.id)
+
+    async def _session_ambiguity_note(
+        self, db: AsyncSession, owner_slot_id: int
+    ) -> str | None:
+        """Return why a slot cannot be safely briefed, if ambiguous."""
+        member = await self._slot_member(db, owner_slot_id)
+        if member is None:
+            return None
+        known_before = len(
+            await agent_mail_service.nudgeable_sessions_for_slot(db, owner_slot_id)
+        )
+        try:
+            await agent_mail_service.sync_observed_sessions(db, strict=True)
+        except Exception:
+            logger.exception(
+                "session discovery failed while checking slot %s for ambiguity",
+                owner_slot_id,
+            )
+            return (
+                "Session discovery failed, so the owning pane could not be "
+                "confirmed. Holding rather than briefing an unknown session."
+            )
+        candidates = await agent_mail_service.nudgeable_sessions_for_slot(
+            db, owner_slot_id
+        )
+        if len(candidates) > 1:
+            targets = ", ".join(sorted(str(session.tmux_target) for session in candidates))
+            return (
+                f"{len(candidates)} nudgeable sessions on this slot ({targets}). "
+                "The dispatch brief would reach an arbitrary one. Converge the "
+                "slot to a single session, then this item dispatches itself."
+            )
+        if not candidates and known_before:
+            return (
+                f"Discovery found no sessions for this slot, but {known_before} "
+                "was expected. Treating zero as unverified rather than empty."
+            )
+        return None
 
     async def record_approval_round(
         self, db: AsyncSession, item: GithubWorkItem, scope: TeamGithubScope

--- a/backend/app/services/github_dispatch_service.py
+++ b/backend/app/services/github_dispatch_service.py
@@ -613,6 +613,7 @@ class GithubDispatchService:
                     "issue_number": item.issue_number,
                     "scope_id": item.scope_id,
                 },
+                bypass_nudge_cooldown=True,
             )
         except Exception:
             logger.exception("Failed to send autonomous dispatch brief for item %s", item.id)

--- a/backend/app/services/github_dispatch_service.py
+++ b/backend/app/services/github_dispatch_service.py
@@ -13,6 +13,7 @@ from app.models.database import (
     AgentTeamSlot,
     GithubWorkItem,
     GithubWorkspace,
+    MailReceipt,
     MailTeamMember,
     TeamGithubScope,
 )
@@ -602,7 +603,7 @@ class GithubDispatchService:
             from app.services.agent_mail_service import agent_mail_service
 
             member = await agent_mail_service.get_or_create_slot_member(db, owner_slot)
-            await agent_mail_service.send_direct_message(
+            message = await agent_mail_service.send_direct_message(
                 db,
                 recipient_member_id=member.id,
                 subject=f"Autonomous dispatch: issue #{item.issue_number}",
@@ -615,6 +616,9 @@ class GithubDispatchService:
                 },
                 bypass_nudge_cooldown=True,
             )
+            item.brief_message_id = message.id
+            item.brief_delivery_nudge_at = None
+            item.brief_delivery_nudge_count = None
         except Exception:
             logger.exception("Failed to send autonomous dispatch brief for item %s", item.id)
 
@@ -708,6 +712,22 @@ class GithubDispatchService:
             if owner_wake == "offline":
                 await self.escalate(db, item, "owner_offline")
                 continue
+            if not await self._brief_delivered(db, item):
+                anchor = item.brief_delivery_nudge_at
+                if anchor is None:
+                    await self._nudge_owner_for_brief(db, item)
+                    continue
+                if datetime.utcnow() - anchor <= timedelta(
+                    seconds=settings.github_nudge_grace_seconds
+                ):
+                    continue
+                if (
+                    item.brief_delivery_nudge_count or 0
+                ) < settings.github_brief_delivery_max_nudges:
+                    await self._nudge_owner_for_brief(db, item)
+                    continue
+                await self.escalate(db, item, "brief_unread")
+                continue
             if not self._ack_satisfied(item):
                 anchor = item.dispatched_at or item.updated_at or item.created_at
                 overdue = datetime.utcnow() - anchor > timedelta(
@@ -735,6 +755,26 @@ class GithubDispatchService:
             ):
                 await self.escalate(db, item, "owner_idle_timeout")
         await db.commit()
+
+    async def _brief_delivered(self, db: AsyncSession, item: GithubWorkItem) -> bool:
+        """Return whether this attempt's brief reached its owner."""
+        workspace = await github_workspace_service.get_leased_workspace(db, item.id)
+        if workspace is not None and workspace.lease_last_owner_contact_at is not None:
+            return True
+        if item.brief_message_id is None:
+            return False
+        member = await self._owner_member(db, item)
+        if member is None:
+            return False
+        receipt = (
+            await db.execute(
+                select(MailReceipt).where(
+                    MailReceipt.message_id == item.brief_message_id,
+                    MailReceipt.member_id == member.id,
+                )
+            )
+        ).scalar_one_or_none()
+        return receipt is not None and receipt.read_at is not None
 
     async def remind_held_leases(
         self, db: AsyncSession, scope: TeamGithubScope
@@ -853,6 +893,29 @@ class GithubDispatchService:
                     "issue_number": item.issue_number,
                 },
             )
+        await db.commit()
+
+    async def _nudge_owner_for_brief(
+        self, db: AsyncSession, item: GithubWorkItem
+    ) -> None:
+        """Re-wake the owner without changing ack or idle timers."""
+        item.brief_delivery_nudge_at = datetime.utcnow()
+        item.brief_delivery_nudge_count = (item.brief_delivery_nudge_count or 0) + 1
+        await self.notify_owner(
+            db,
+            item,
+            subject=f"Unread dispatch brief: issue #{item.issue_number}",
+            body_markdown=(
+                f"You were assigned issue #{item.issue_number} ({item.issue_title}) "
+                "but the brief is still unread. Call `deck_check_inbox` now and "
+                "report your status."
+            ),
+            payload={
+                "kind": "github_dispatch_brief_nudge",
+                "work_item_id": item.id,
+                "issue_number": item.issue_number,
+            },
+        )
         await db.commit()
 
     async def _nudge_owner_for_progress(

--- a/backend/app/services/github_verification_service.py
+++ b/backend/app/services/github_verification_service.py
@@ -33,6 +33,7 @@ _PR_OPENED_RECOVERABLE_ESCALATIONS = frozenset(
         "owner_offline",
         "leader_offline",
         "leader_ack_timeout",
+        "brief_unread",
     }
 )
 

--- a/backend/tests/agent_mail/test_registry.py
+++ b/backend/tests/agent_mail/test_registry.py
@@ -742,6 +742,105 @@ async def test_send_message_auto_nudge_is_throttled(db, svc, tmp_path, monkeypat
 
 
 @pytest.mark.asyncio
+async def test_dispatch_brief_nudge_bypasses_the_cooldown(db, svc, tmp_path, monkeypatch):
+    cwd = tmp_path / "obs"
+    cwd.mkdir()
+    fake = [
+        {
+            "provider": "codex-cli",
+            "provider_display_name": "Codex",
+            "tmux_target": "w:0.1",
+            "session_name": "w",
+            "window_name": "main",
+            "pane_id": "%7",
+            "cwd": str(cwd),
+            "pid": "4242",
+            "status": "active",
+        }
+    ]
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return SimpleNamespace(stdout="", stderr="", returncode=0 if command[0] == "tmux" else 1)
+
+    monkeypatch.setattr("app.services.agent_mail_service.discover_agent_sessions", lambda: fake)
+    monkeypatch.setattr("app.services.agent_mail_service.subprocess.run", fake_run)
+    monkeypatch.setattr("app.services.agent_mail_service.time.sleep", lambda _: None)
+    await svc.sync_observed_sessions(db)
+    recipient = (await svc.list_team(db))[0]
+    calls.clear()
+
+    await svc.send_direct_message(
+        db,
+        recipient_member_id=recipient.id,
+        subject="blocker merged",
+        body_markdown="fyi",
+    )
+    assert len([command for command, _ in calls if command[0] == "tmux"]) == 2
+
+    await svc.send_direct_message(
+        db,
+        recipient_member_id=recipient.id,
+        subject="Autonomous dispatch: issue #900",
+        body_markdown="brief",
+        bypass_nudge_cooldown=True,
+    )
+
+    assert len([command for command, _ in calls if command[0] == "tmux"]) == 4
+
+
+@pytest.mark.asyncio
+async def test_ordinary_send_still_throttled_after_a_bypassed_brief(
+    db, svc, tmp_path, monkeypatch
+):
+    cwd = tmp_path / "obs"
+    cwd.mkdir()
+    fake = [
+        {
+            "provider": "codex-cli",
+            "provider_display_name": "Codex",
+            "tmux_target": "w:0.1",
+            "session_name": "w",
+            "window_name": "main",
+            "pane_id": "%7",
+            "cwd": str(cwd),
+            "pid": "4242",
+            "status": "active",
+        }
+    ]
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return SimpleNamespace(stdout="", stderr="", returncode=0 if command[0] == "tmux" else 1)
+
+    monkeypatch.setattr("app.services.agent_mail_service.discover_agent_sessions", lambda: fake)
+    monkeypatch.setattr("app.services.agent_mail_service.subprocess.run", fake_run)
+    monkeypatch.setattr("app.services.agent_mail_service.time.sleep", lambda _: None)
+    await svc.sync_observed_sessions(db)
+    recipient = (await svc.list_team(db))[0]
+    calls.clear()
+
+    await svc.send_direct_message(
+        db,
+        recipient_member_id=recipient.id,
+        subject="brief",
+        body_markdown="b",
+        bypass_nudge_cooldown=True,
+    )
+    assert len([command for command, _ in calls if command[0] == "tmux"]) == 2
+
+    await svc.send_direct_message(
+        db,
+        recipient_member_id=recipient.id,
+        subject="chatter",
+        body_markdown="c",
+    )
+    assert len([command for command, _ in calls if command[0] == "tmux"]) == 2
+
+
+@pytest.mark.asyncio
 async def test_sync_observed_removes_stale_observed_only_members(db, svc, tmp_path):
     cwd = tmp_path / "obs"
     cwd.mkdir()

--- a/backend/tests/agent_teams/test_github_dispatch_service.py
+++ b/backend/tests/agent_teams/test_github_dispatch_service.py
@@ -19,9 +19,11 @@ from app.models.database import (
     GithubWorkspace,
     MailAgentSession,
     MailMessage,
+    MailReceipt,
     MailTeamMember,
     TeamGithubScope,
 )
+from app.services.agent_mail_service import agent_mail_service
 from app.services.github_dispatch_service import GithubDispatchService, github_dispatch_service
 from app.services.github_workspace_service import github_workspace_service
 
@@ -216,7 +218,7 @@ async def _create_live_slot_launch_session(
             tmux_target=target,
         )
     )
-    member = await _create_registered_slot_member(db, slot)
+    member = await agent_mail_service.get_or_create_slot_member(db, slot)
     session = MailAgentSession(
         member_id=member.id,
         provider=slot.provider,
@@ -1277,7 +1279,7 @@ async def test_dispatch_brief_uses_discovery_when_leader_member_missing(db):
 
 
 @pytest.mark.asyncio
-async def test_dispatch_pending_disables_reuse_for_repo_override(db):
+async def test_dispatch_pending_reuses_and_still_passes_the_repo_override(db):
     preset, slots, scope = await _team(db)
     item = GithubWorkItem(
         scope_id=scope.id,
@@ -1309,7 +1311,7 @@ async def test_dispatch_pending_disables_reuse_for_repo_override(db):
         issue_labels_by_number={23: []},
     )
 
-    assert launched["reuse_existing"] is False
+    assert launched["reuse_existing"] is True
     assert launched["override"] == "/tmp/r-ws-1"
 
 
@@ -1624,10 +1626,19 @@ async def test_dispatch_pending_queues_when_slot_busy(db):
 
 
 @pytest.mark.asyncio
-async def test_dispatch_proceeds_with_only_standing_session(db):
+async def test_dispatch_proceeds_with_only_standing_session(db, monkeypatch):
+    async def keep_synthetic_session(_db):
+        return None
+
+    monkeypatch.setattr(agent_mail_service, "sync_observed_sessions", keep_synthetic_session)
+    monkeypatch.setattr(
+        agent_mail_service,
+        "_send_tmux_inbox_check",
+        lambda session: {"target": session.tmux_target, "prompt": "check inbox"},
+    )
     preset, slots, scope = await _team(db)
     backend = next(slot for slot in slots if slot.display_name == "Backend SME")
-    await _create_live_slot_launch_session(
+    _, standing_session = await _create_live_slot_launch_session(
         db,
         preset,
         backend,
@@ -1662,9 +1673,61 @@ async def test_dispatch_proceeds_with_only_standing_session(db):
 
     await db.refresh(item)
     assert len(launches) == 1
+    assert launches[0].reuse_existing is True
     assert item.dispatch_status == "dispatched"
     assert item.owner_slot_id == backend.id
     assert item.pending_reason is None
+    receipts = (
+        await db.execute(
+            select(MailReceipt).where(
+                MailReceipt.member_id == standing_session.member_id
+            )
+        )
+    ).scalars().all()
+    assert len(receipts) == 1
+    sessions = (
+        await db.execute(
+            select(MailAgentSession).where(MailAgentSession.team_slot_id == backend.id)
+        )
+    ).scalars().all()
+    assert len(sessions) == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatch_without_wakeable_session_keeps_issue_brief_for_spawn(db):
+    _, slots, scope = await _team(db)
+    backend = next(slot for slot in slots if slot.display_name == "Backend SME")
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=43,
+        issue_title="spawn fallback",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="pending",
+    )
+    db.add(item)
+    await db.commit()
+    launches = []
+
+    class _Result:
+        launch_id = 105
+
+    async def fake_launcher(db_, preset_id, request):
+        launches.append(request)
+        return _Result()
+
+    await github_dispatch_service.dispatch_pending(
+        db,
+        scope,
+        slots,
+        launcher=fake_launcher,
+        issue_labels_by_number={43: ["area:backend"]},
+    )
+
+    assert len(launches) == 1
+    prompt = launches[0].slot_prompt_overrides[backend.id]
+    assert "Issue: #43 — spawn fallback" in prompt
+    assert "Workspace: /tmp/r-ws-1" in prompt
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_teams/test_github_dispatch_service.py
+++ b/backend/tests/agent_teams/test_github_dispatch_service.py
@@ -54,6 +54,14 @@ def host_has_enough_memory(monkeypatch):
     monkeypatch.setattr(github_workspace_service, "reset_workspace", reset_succeeds)
 
 
+@pytest.fixture(autouse=True)
+def no_discovered_panes(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.agent_mail_service.discover_agent_sessions",
+        lambda: [],
+    )
+
+
 async def _team(db):
     preset = AgentTeamPreset(name="T", description="", created_by="t")
     db.add(preset)
@@ -266,6 +274,46 @@ async def _create_live_slot_launch_session(
     db.add(session)
     await db.commit()
     return launch, session
+
+
+async def _seed_observed_panes(db, preset, slot, panes):
+    member = await _create_registered_slot_member(db, slot)
+    for pane_id, target in panes:
+        db.add(
+            MailAgentSession(
+                member_id=member.id,
+                provider=slot.provider,
+                source="observed",
+                session_key=f"tmux:{pane_id}",
+                pane_id=pane_id,
+                cwd=slot.repo_path,
+                tmux_target=target,
+                team_preset_id=preset.id,
+                team_slot_id=slot.id,
+                mailbox_status="observed",
+                last_seen_at=datetime.utcnow(),
+            )
+        )
+    await db.commit()
+    return member
+
+
+def _pane(*, pane_id, target, cwd):
+    return {
+        "provider": "codex-cli",
+        "provider_display_name": "Codex",
+        "tmux_target": target,
+        "session_name": target.split(":")[0],
+        "window_name": "main",
+        "pane_id": pane_id,
+        "cwd": cwd,
+        "pid": "4242",
+        "status": "active",
+    }
+
+
+async def _launcher_that_must_not_run(*_args, **_kwargs):
+    raise AssertionError("dispatch launched despite an ambiguous slot")
 
 
 def test_leader_unblock_instructions_text():
@@ -1665,7 +1713,7 @@ async def test_dispatch_pending_queues_when_slot_busy(db):
 
 @pytest.mark.asyncio
 async def test_dispatch_proceeds_with_only_standing_session(db, monkeypatch):
-    async def keep_synthetic_session(_db):
+    async def keep_synthetic_session(_db, *, strict=False):
         return None
 
     monkeypatch.setattr(agent_mail_service, "sync_observed_sessions", keep_synthetic_session)
@@ -1766,6 +1814,225 @@ async def test_dispatch_without_wakeable_session_keeps_issue_brief_for_spawn(db)
     prompt = launches[0].slot_prompt_overrides[backend.id]
     assert "Issue: #43 — spawn fallback" in prompt
     assert "Workspace: /tmp/r-ws-1" in prompt
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_slot_blocks_and_leases_nothing(db, monkeypatch):
+    preset, slots, scope = await _team(db)
+    owner = next(slot for slot in slots if slot.display_name == "Backend SME")
+    await _seed_observed_panes(
+        db,
+        preset,
+        owner,
+        [("%1", "w:0.1"), ("%2", "w:0.2")],
+    )
+    monkeypatch.setattr(
+        "app.services.agent_mail_service.discover_agent_sessions",
+        lambda: [
+            _pane(pane_id="%1", target="w:0.1", cwd=owner.repo_path),
+            _pane(pane_id="%2", target="w:0.2", cwd=owner.repo_path),
+        ],
+    )
+    assert len(await agent_mail_service.nudgeable_sessions_for_slot(db, owner.id)) == 2
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=950,
+        issue_title="ambiguous",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="pending",
+    )
+    db.add(item)
+    await db.commit()
+
+    await github_dispatch_service.dispatch_pending(
+        db,
+        scope,
+        slots,
+        launcher=_launcher_that_must_not_run,
+        issue_labels_by_number={950: ["area:backend"]},
+    )
+
+    await db.refresh(item)
+    assert item.dispatch_status == "pending"
+    assert item.owner_slot_id == owner.id
+    assert item.pending_reason == "queued_ambiguous_sessions"
+    assert "w:0.1" in item.status_note and "w:0.2" in item.status_note
+    leased = (
+        await db.execute(
+            select(GithubWorkspace).where(GithubWorkspace.leased_item_id == item.id)
+        )
+    ).scalars().all()
+    assert leased == []
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_check_resyncs_before_counting(db, monkeypatch):
+    preset, slots, scope = await _team(db)
+    owner = next(slot for slot in slots if slot.display_name == "Backend SME")
+    member = await _seed_observed_panes(db, preset, owner, [("%1", "w:0.1")])
+    db.add(
+        MailAgentSession(
+            member_id=member.id,
+            provider=owner.provider,
+            source="hook",
+            session_key="hook:owner",
+            cwd=owner.repo_path,
+            pid=4242,
+            team_preset_id=preset.id,
+            team_slot_id=owner.id,
+            mailbox_status="connected",
+            last_seen_at=datetime.utcnow(),
+        )
+    )
+    await db.commit()
+    assert len(await agent_mail_service.nudgeable_sessions_for_slot(db, owner.id)) == 1
+    monkeypatch.setattr(
+        "app.services.agent_mail_service.discover_agent_sessions",
+        lambda: [
+            _pane(pane_id="%1", target="w:0.1", cwd=owner.repo_path),
+            _pane(pane_id="%2", target="w:0.2", cwd=owner.repo_path),
+        ],
+    )
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=951,
+        issue_title="fresh ambiguity",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="pending",
+    )
+    db.add(item)
+    await db.commit()
+
+    await github_dispatch_service.dispatch_pending(
+        db,
+        scope,
+        slots,
+        launcher=_launcher_that_must_not_run,
+        issue_labels_by_number={951: ["area:backend"]},
+    )
+
+    await db.refresh(item)
+    assert item.pending_reason == "queued_ambiguous_sessions"
+    assert len(await agent_mail_service.nudgeable_sessions_for_slot(db, owner.id)) == 2
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_check_holds_when_discovery_loses_known_session(db, monkeypatch):
+    preset, slots, scope = await _team(db)
+    owner = next(slot for slot in slots if slot.display_name == "Backend SME")
+    await _seed_observed_panes(db, preset, owner, [("%1", "w:0.1")])
+    monkeypatch.setattr(
+        "app.services.agent_mail_service.discover_agent_sessions",
+        lambda: [],
+    )
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=952,
+        issue_title="lost pane",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="pending",
+    )
+    db.add(item)
+    await db.commit()
+
+    await github_dispatch_service.dispatch_pending(
+        db,
+        scope,
+        slots,
+        launcher=_launcher_that_must_not_run,
+        issue_labels_by_number={952: ["area:backend"]},
+    )
+
+    await db.refresh(item)
+    assert item.pending_reason == "queued_ambiguous_sessions"
+    leased = (
+        await db.execute(
+            select(GithubWorkspace).where(GithubWorkspace.leased_item_id == item.id)
+        )
+    ).scalars().all()
+    assert leased == []
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_check_allows_one_nudgeable_pane(db, monkeypatch):
+    preset, slots, scope = await _team(db)
+    owner = next(slot for slot in slots if slot.display_name == "Backend SME")
+    await _seed_observed_panes(db, preset, owner, [("%1", "w:0.1")])
+    monkeypatch.setattr(
+        "app.services.agent_mail_service.discover_agent_sessions",
+        lambda: [_pane(pane_id="%1", target="w:0.1", cwd=owner.repo_path)],
+    )
+    monkeypatch.setattr(
+        agent_mail_service,
+        "_send_tmux_inbox_check",
+        lambda session: {"target": session.tmux_target, "prompt": "check inbox"},
+    )
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=953,
+        issue_title="one pane",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="pending",
+    )
+    db.add(item)
+    await db.commit()
+
+    class _Result:
+        launch_id = 953
+
+    async def successful_launcher(*_args, **_kwargs):
+        return _Result()
+
+    await github_dispatch_service.dispatch_pending(
+        db,
+        scope,
+        slots,
+        launcher=successful_launcher,
+        issue_labels_by_number={953: ["area:backend"]},
+    )
+
+    await db.refresh(item)
+    assert item.dispatch_status == "dispatched"
+    assert item.pending_reason is None
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_check_allows_empty_slot_to_spawn(db):
+    _, slots, scope = await _team(db)
+    owner = next(slot for slot in slots if slot.display_name == "Backend SME")
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=954,
+        issue_title="empty slot",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="pending",
+    )
+    db.add(item)
+    await db.commit()
+
+    class _Result:
+        launch_id = 954
+
+    async def successful_launcher(*_args, **_kwargs):
+        return _Result()
+
+    await github_dispatch_service.dispatch_pending(
+        db,
+        scope,
+        slots,
+        launcher=successful_launcher,
+        issue_labels_by_number={954: ["area:backend"]},
+    )
+
+    await db.refresh(item)
+    assert item.owner_slot_id == owner.id
+    assert item.dispatch_status == "dispatched"
+    assert item.pending_reason is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_teams/test_github_dispatch_service.py
+++ b/backend/tests/agent_teams/test_github_dispatch_service.py
@@ -101,6 +101,38 @@ async def _team(db):
     return preset, [architect, backend], scope
 
 
+async def _lease_for(db, scope, item, **overrides):
+    workspace = (
+        await db.execute(
+            select(GithubWorkspace)
+            .where(
+                GithubWorkspace.scope_id == scope.id,
+                GithubWorkspace.leased_item_id.is_(None),
+            )
+            .limit(1)
+        )
+    ).scalar_one()
+    workspace.leased_item_id = item.id
+    workspace.leased_at = datetime.utcnow()
+    workspace.lease_token = "t1"
+    for key, value in overrides.items():
+        setattr(workspace, key, value)
+    await db.commit()
+    return workspace
+
+
+def _isolate_agent_mail_nudges(monkeypatch):
+    async def keep_synthetic_sessions(_db):
+        return None
+
+    monkeypatch.setattr(agent_mail_service, "sync_observed_sessions", keep_synthetic_sessions)
+    monkeypatch.setattr(
+        agent_mail_service,
+        "_send_tmux_inbox_check",
+        lambda session: {"target": session.tmux_target, "prompt": "check inbox"},
+    )
+
+
 async def _leased_item_for_reminder(
     db,
     scope,
@@ -1079,7 +1111,8 @@ async def test_dispatch_keeps_pid_pair_null_when_proc_start_is_unreadable(db, mo
 
 
 @pytest.mark.asyncio
-async def test_dispatch_pending_passes_issue_specific_owner_brief(db):
+async def test_dispatch_pending_passes_issue_specific_owner_brief(db, monkeypatch):
+    _isolate_agent_mail_nudges(monkeypatch)
     preset, slots, scope = await _team(db)
     architect = next(slot for slot in slots if slot.display_name == "Architect")
     backend = next(slot for slot in slots if slot.display_name == "Backend SME")
@@ -1091,6 +1124,8 @@ async def test_dispatch_pending_passes_issue_specific_owner_brief(db):
         issue_url="https://github.com/o/r/issues/833",
         github_updated_at=datetime.utcnow(),
         dispatch_status="pending",
+        brief_delivery_nudge_at=datetime.utcnow(),
+        brief_delivery_nudge_count=2,
     )
     db.add(item)
     await db.commit()
@@ -1151,6 +1186,9 @@ async def test_dispatch_pending_passes_issue_specific_owner_brief(db):
     assert f"to_member_id={leader_member.id}" in message.body_markdown
     assert f"slot_id={architect.id}" not in message.body_markdown
     assert "wait for acknowledgment before starting implementation" in message.body_markdown
+    assert item.brief_message_id == message.id
+    assert item.brief_delivery_nudge_at is None
+    assert item.brief_delivery_nudge_count is None
 
 
 @pytest.mark.asyncio
@@ -2215,6 +2253,268 @@ async def test_repeated_lease_release_reminders_never_escalate(db):
 
 
 @pytest.mark.asyncio
+async def test_delivery_proven_by_report_not_only_receipt(db, monkeypatch):
+    _isolate_agent_mail_nudges(monkeypatch)
+    preset, slots, scope = await _team(db)
+    stale = datetime.utcnow() - timedelta(
+        seconds=settings.github_owner_registration_grace_seconds + 1
+    )
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=90,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="dispatched",
+        owner_slot_id=slots[1].id,
+        dispatched_at=stale,
+        updated_at=datetime.utcnow(),
+        ack_received_at=datetime.utcnow(),
+        brief_delivery_nudge_count=settings.github_brief_delivery_max_nudges,
+        brief_delivery_nudge_at=stale,
+    )
+    db.add(item)
+    await db.commit()
+    member = await agent_mail_service.get_or_create_slot_member(db, slots[1])
+    message = await agent_mail_service.send_direct_message(
+        db,
+        recipient_member_id=member.id,
+        subject="brief",
+        body_markdown="b",
+        auto_nudge=False,
+    )
+    item.brief_message_id = message.id
+    await _lease_for(
+        db,
+        scope,
+        item,
+        lease_last_owner_contact_at=datetime.utcnow(),
+    )
+
+    await github_dispatch_service.monitor_dispatched(
+        db,
+        scope,
+        preset_slots=slots,
+        wake_state_by_slot={slots[0].id: "wakeable", slots[1].id: "wakeable"},
+    )
+
+    await db.refresh(item)
+    assert item.escalation_reason != "brief_unread"
+    assert item.dispatch_status == "dispatched"
+
+
+@pytest.mark.asyncio
+async def test_brief_unread_escalates_after_delivery_retries_exhausted(db, monkeypatch):
+    _isolate_agent_mail_nudges(monkeypatch)
+    preset, slots, scope = await _team(db)
+    stale = datetime.utcnow() - timedelta(
+        seconds=max(
+            settings.github_owner_registration_grace_seconds,
+            settings.github_nudge_grace_seconds,
+        )
+        + 1
+    )
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=91,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="dispatched",
+        owner_slot_id=slots[1].id,
+        dispatched_at=stale,
+        updated_at=stale,
+        brief_delivery_nudge_count=settings.github_brief_delivery_max_nudges,
+        brief_delivery_nudge_at=stale,
+    )
+    db.add(item)
+    await db.commit()
+    await _lease_for(db, scope, item)
+
+    await github_dispatch_service.monitor_dispatched(
+        db,
+        scope,
+        preset_slots=slots,
+        wake_state_by_slot={slots[0].id: "wakeable", slots[1].id: "wakeable"},
+    )
+
+    await db.refresh(item)
+    assert item.dispatch_status == "escalated"
+    assert item.escalation_reason == "brief_unread"
+
+
+@pytest.mark.asyncio
+async def test_brief_unread_is_not_masked_by_leader_ack_timeout(db, monkeypatch):
+    _isolate_agent_mail_nudges(monkeypatch)
+    preset, slots, scope = await _team(db)
+    stale = datetime.utcnow() - timedelta(
+        seconds=max(
+            settings.github_owner_registration_grace_seconds,
+            settings.github_leader_ack_timeout_seconds,
+            settings.github_nudge_grace_seconds,
+        )
+        + 1
+    )
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=92,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="dispatched",
+        owner_slot_id=slots[1].id,
+        dispatched_at=stale,
+        updated_at=stale,
+        ack_received_at=None,
+        last_nudge_at=stale,
+        brief_delivery_nudge_count=settings.github_brief_delivery_max_nudges,
+        brief_delivery_nudge_at=stale,
+    )
+    db.add(item)
+    await db.commit()
+    await _lease_for(db, scope, item)
+
+    await github_dispatch_service.monitor_dispatched(
+        db,
+        scope,
+        preset_slots=slots,
+        wake_state_by_slot={slots[0].id: "wakeable", slots[1].id: "wakeable"},
+    )
+
+    await db.refresh(item)
+    assert item.dispatch_status == "escalated"
+    assert item.escalation_reason == "brief_unread"
+
+
+@pytest.mark.asyncio
+async def test_delivery_and_ack_nudge_counters_are_independent(db, monkeypatch):
+    _isolate_agent_mail_nudges(monkeypatch)
+    preset, slots, scope = await _team(db)
+    leader, owner = slots
+    await agent_mail_service.get_or_create_slot_member(db, leader)
+    owner_member = await agent_mail_service.get_or_create_slot_member(db, owner)
+    stale = datetime.utcnow() - timedelta(
+        seconds=max(
+            settings.github_owner_registration_grace_seconds,
+            settings.github_leader_ack_timeout_seconds,
+        )
+        + 1
+    )
+    unread_item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=93,
+        issue_title="unread",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="dispatched",
+        owner_slot_id=owner.id,
+        dispatched_at=stale,
+        updated_at=stale,
+    )
+    delivered_item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=94,
+        issue_title="delivered",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="dispatched",
+        owner_slot_id=owner.id,
+        dispatched_at=stale,
+        updated_at=stale,
+    )
+    db.add_all([unread_item, delivered_item])
+    await db.commit()
+    unread_message = await agent_mail_service.send_direct_message(
+        db,
+        recipient_member_id=owner_member.id,
+        subject="brief",
+        body_markdown="b",
+        auto_nudge=False,
+    )
+    unread_item.brief_message_id = unread_message.id
+    await _lease_for(db, scope, unread_item)
+    await _lease_for(
+        db,
+        scope,
+        delivered_item,
+        lease_last_owner_contact_at=datetime.utcnow(),
+    )
+
+    await github_dispatch_service.monitor_dispatched(
+        db,
+        scope,
+        preset_slots=slots,
+        wake_state_by_slot={leader.id: "wakeable", owner.id: "wakeable"},
+    )
+
+    await db.refresh(unread_item)
+    await db.refresh(delivered_item)
+    assert unread_item.brief_delivery_nudge_count == 1
+    assert unread_item.last_nudge_at is None
+    assert delivered_item.last_nudge_at is not None
+    assert delivered_item.brief_delivery_nudge_at is None
+
+
+@pytest.mark.asyncio
+async def test_brief_read_after_first_nudge_does_not_escalate(db, monkeypatch):
+    _isolate_agent_mail_nudges(monkeypatch)
+    preset, slots, scope = await _team(db)
+    stale = datetime.utcnow() - timedelta(
+        seconds=max(
+            settings.github_owner_registration_grace_seconds,
+            settings.github_nudge_grace_seconds,
+        )
+        + 1
+    )
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=95,
+        issue_title="x",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="dispatched",
+        owner_slot_id=slots[1].id,
+        dispatched_at=stale,
+        updated_at=datetime.utcnow(),
+        ack_received_at=datetime.utcnow(),
+        brief_delivery_nudge_count=settings.github_brief_delivery_max_nudges,
+        brief_delivery_nudge_at=stale,
+    )
+    db.add(item)
+    await db.commit()
+    member = await agent_mail_service.get_or_create_slot_member(db, slots[1])
+    message = await agent_mail_service.send_direct_message(
+        db,
+        recipient_member_id=member.id,
+        subject="brief",
+        body_markdown="b",
+        auto_nudge=False,
+    )
+    item.brief_message_id = message.id
+    receipt = (
+        await db.execute(
+            select(MailReceipt).where(
+                MailReceipt.message_id == message.id,
+                MailReceipt.member_id == member.id,
+            )
+        )
+    ).scalar_one()
+    receipt.read_at = datetime.utcnow()
+    await _lease_for(db, scope, item)
+
+    await github_dispatch_service.monitor_dispatched(
+        db,
+        scope,
+        preset_slots=slots,
+        wake_state_by_slot={slots[0].id: "wakeable", slots[1].id: "wakeable"},
+    )
+
+    await db.refresh(item)
+    assert item.dispatch_status == "dispatched"
+    assert item.escalation_reason is None
+
+
+@pytest.mark.asyncio
 async def test_monitor_escalates_when_leader_offline(db):
     preset, slots, scope = await _team(db)
     architect = slots[0]
@@ -2386,6 +2686,7 @@ async def test_monitor_nudges_leader_on_ack_timeout(db):
     )
     db.add(item)
     await db.commit()
+    await _lease_for(db, scope, item, lease_last_owner_contact_at=old)
 
     await github_dispatch_service.monitor_dispatched(
         db, scope, preset_slots=slots, wake_state_by_slot={architect.id: "wakeable", backend.id: "wakeable"}
@@ -2419,6 +2720,7 @@ async def test_retried_item_still_nudged_when_leader_never_acks_again(db):
     )
     db.add(item)
     await db.commit()
+    await _lease_for(db, scope, item, lease_last_owner_contact_at=dispatched_at)
 
     await github_dispatch_service.monitor_dispatched(
         db,
@@ -2460,6 +2762,7 @@ async def test_monitor_escalates_leader_ack_after_nudge_grace(db):
     )
     db.add(item)
     await db.commit()
+    await _lease_for(db, scope, item, lease_last_owner_contact_at=old)
 
     await github_dispatch_service.monitor_dispatched(
         db, scope, preset_slots=slots, wake_state_by_slot={architect.id: "wakeable", backend.id: "wakeable"}
@@ -2558,6 +2861,7 @@ async def test_monitor_ack_timeout_uses_dispatched_at_not_recent_activity(db):
     )
     db.add(item)
     await db.commit()
+    await _lease_for(db, scope, item, lease_last_owner_contact_at=old)
 
     await github_dispatch_service.monitor_dispatched(
         db, scope, preset_slots=slots, wake_state_by_slot={architect.id: "wakeable", backend.id: "wakeable"}
@@ -2589,6 +2893,7 @@ async def test_monitor_nudges_idle_owner_after_ack(db):
     )
     db.add(item)
     await db.commit()
+    await _lease_for(db, scope, item, lease_last_owner_contact_at=old)
 
     await github_dispatch_service.monitor_dispatched(
         db, scope, preset_slots=slots, wake_state_by_slot={architect.id: "wakeable", backend.id: "wakeable"}
@@ -2654,6 +2959,7 @@ async def test_monitor_escalates_idle_owner_after_nudge_grace(db):
     )
     db.add(item)
     await db.commit()
+    await _lease_for(db, scope, item, lease_last_owner_contact_at=old)
 
     await github_dispatch_service.monitor_dispatched(
         db, scope, preset_slots=slots, wake_state_by_slot={architect.id: "wakeable", backend.id: "wakeable"}

--- a/backend/tests/agent_teams/test_github_verification_service.py
+++ b/backend/tests/agent_teams/test_github_verification_service.py
@@ -350,6 +350,25 @@ async def test_pr_opened_accepted_from_recoverable_escalation(db):
 
 
 @pytest.mark.asyncio
+async def test_pr_opened_accepted_from_brief_unread_escalation(db):
+    scope = await _scope(db)
+    item = await _item(
+        db,
+        scope,
+        dispatch_status="escalated",
+        escalation_reason="brief_unread",
+        issue_type="code",
+    )
+
+    await github_verification_service.report_pr_opened(db, item, scope, 867)
+
+    await db.refresh(item)
+    assert item.dispatch_status == "verifying"
+    assert item.pr_number == 867
+    assert item.escalation_reason is None
+
+
+@pytest.mark.asyncio
 async def test_pr_opened_recovery_clears_deferred_retry_stamp(db):
     scope = await _scope(db)
     item = await _item(

--- a/frontend/src/features/agent-teams/AutonomyPanel.tsx
+++ b/frontend/src/features/agent-teams/AutonomyPanel.tsx
@@ -89,6 +89,9 @@ function pendingReasonLabel(item: GithubWorkItem, ownerName?: string) {
   if (item.pending_reason === 'queued_repo_cap') return 'queued · repo cap reached'
   if (item.pending_reason === 'queued_no_workspace') return 'queued · no free workspace'
   if (item.pending_reason === 'queued_low_memory') return 'queued · low memory'
+  if (item.pending_reason === 'queued_ambiguous_sessions') {
+    return `queued · ${ownerName ?? 'owner'} has multiple sessions`
+  }
   return null
 }
 


### PR DESCRIPTION
## Summary

Implements issue #306 Phase G2 PR2 (Tasks 10–13):

- Reuses a slot's standing agent session while retaining issue/workspace prompt overrides for spawn fallback.
- Lets dispatch briefs bypass the 30-second auto-nudge cooldown without weakening ordinary-message throttling.
- Records per-attempt brief delivery evidence, adds dedicated delivery retries and `brief_unread`, and evaluates delivery before leader acknowledgment.
- Refuses dispatch before workspace acquisition when a slot has ambiguous nudgeable sessions, with an operator-visible pending reason.

## Validation

- `python -m pytest tests/agent_teams/ tests/agent_mail/ -q`: **444 passed**.
- `test_send_message_auto_nudge_is_throttled`: **passes unchanged**.
- `cd frontend && npx tsc --noEmit`: **passes**.
- Full backend suite: **610 passed, 1 pre-existing failure** at `tests/test_multi_provider_smoke.py:54` (`test_agent_bridge_session_filter_smoke`, stale discovery monkeypatch). Not changed here.
- No new `dispatch_status` value was added. `brief_unread` is an `escalation_reason`; `queued_ambiguous_sessions` is a `pending_reason`.

## Adaptations and findings

- The standing-session fixture now uses `get_or_create_slot_member`, matching the canonical member production targets for the brief receipt.
- That fixture patches `sync_observed_sessions` and `_send_tmux_inbox_check`; without both, the test discovers host panes and can run `tmux send-keys` plus `Enter` against live sessions.
- Task 12 monitor/dispatch tests use `_isolate_agent_mail_nudges` for the same host-discovery/send-key isolation. Fixture mail sends use `auto_nudge=False` where delivery evidence, not waking, is under test.
- Six pre-delivery leader-ack/owner-idle fixtures now carry stale `lease_last_owner_contact_at` evidence. Their assertions are unchanged; without delivery evidence they correctly enter the new delivery branch first.
- Task 13 adds an autouse `no_discovered_panes` fixture to the dispatch-service test module so every dispatch test is independent of the developer's tmux server. Pane-specific tests explicitly override discovery with matching panes.
- The Task 13 re-sync test required a live registered hook session to bind the newly discovered second pane to the slot. With only one seeded observed pane, current sync correctly creates an unbound repo member for an unknown second pane, so the plan's literal one-row fixture would not test slot-wide ambiguity.
- The one-pane ambiguity guard patches `_send_tmux_inbox_check` so its successful dispatch cannot type into host tmux.
- The standing-session sync mock now accepts the new keyword-only `strict` argument; behavior is unchanged.
- `repo_path_override` remains present on the launch request, but reuse does not move an existing pane's cwd. Isolation remains behavioral through the explicit workspace instructions in the brief, per the accepted design.

## Known pre-existing test gap

`test_monitor_escalates_idle_owner_after_nudge_grace` does not detect a disabled idle *nudge*. This insensitivity predates PR2 and is intentionally not expanded here.

## Scope

No deployment, backend restart, live DB edit, autonomy change, session spawn/termination, or merge is performed by this PR.
