### PR TITLE
fix(g3): observed session durability — Finding 20

### DIFF
--- a/backend/app/services/agent_mail_service.py
+++ b/backend/app/services/agent_mail_service.py
@@ -542,6 +542,9 @@ class AgentMailService:
         for session in result.scalars().all():
             if session.session_key in active_observed_keys:
                 continue
+            # Absence from one discovery pass is not evidence of death.
+            if self._pid_is_running(session.pid):
+                continue
             affected_member_ids.add(session.member_id)
             await db.delete(session)
 

--- a/backend/app/services/agent_mail_service.py
+++ b/backend/app/services/agent_mail_service.py
@@ -373,6 +373,8 @@ class AgentMailService:
             session = result.scalar_one_or_none()
             member = await self._member_for_existing_observed_session(db, session, info)
             if member is None:
+                member = await self._member_for_advertised_slot(db, info)
+            if member is None:
                 member = await self._member_for_observed_session(db, info)
             if session is None:
                 session = MailAgentSession(
@@ -400,6 +402,31 @@ class AgentMailService:
         for member_id in affected_member_ids:
             await self._remove_empty_observed_member(db, member_id)
         await db.commit()
+
+    async def _member_for_advertised_slot(
+        self,
+        db: AsyncSession,
+        info: dict,
+    ) -> MailTeamMember | None:
+        """Bind a pane to the slot its own tmux environment advertises."""
+        slot_id = info.get("team_slot_id")
+        if not isinstance(slot_id, int):
+            return None
+        slot = await db.get(AgentTeamSlot, slot_id)
+        if slot is None or slot.provider != str(info.get("provider") or "unknown"):
+            return None
+        preset_id = info.get("team_preset_id")
+        if isinstance(preset_id, int) and preset_id != slot.preset_id:
+            return None
+        cwd = str(info.get("cwd") or "")
+        if not cwd:
+            return None
+        try:
+            if derive_repo_identity(cwd)["repo_id"] != slot.repo_id:
+                return None
+        except Exception:
+            return None
+        return await self.get_or_create_slot_member(db, slot)
 
     async def _member_for_observed_session(
         self,

--- a/backend/app/services/providers/base.py
+++ b/backend/app/services/providers/base.py
@@ -58,9 +58,10 @@ class ProviderLaunchError(ValueError):
 
 def argv0_name(command: str) -> str:
     """Return the executable basename from a command or argv0 string."""
-    if not command:
+    parts = command.split() if command else []
+    if not parts:
         return ""
-    return Path(command.strip().split()[0]).name.lower()
+    return Path(parts[0]).name.lower()
 
 
 def has_binary_descendant(

--- a/backend/tests/agent_mail/test_registry.py
+++ b/backend/tests/agent_mail/test_registry.py
@@ -370,6 +370,109 @@ async def test_sync_observed_creates_observed_sessions(db, svc, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_sync_observed_keeps_row_whose_pid_is_alive(db, svc, tmp_path):
+    """A single failed discovery pass must not delete a live pane's row.
+
+    discover_agent_sessions() returns [] for tmux-missing, non-zero exit, and
+    timeout, so [] cannot be read as "no panes exist".
+    """
+    cwd = tmp_path / "obs"
+    cwd.mkdir()
+    preset, slot = await _slot(db, str(cwd), "Owner")
+    member = await svc.get_or_create_slot_member(db, slot)
+    db.add(
+        MailAgentSession(
+            member_id=member.id,
+            team_preset_id=slot.preset_id,
+            team_slot_id=slot.id,
+            source="observed",
+            provider="codex-cli",
+            session_key="tmux:%1",
+            pane_id="%1",
+            tmux_target="obs:0.0",
+            cwd=str(cwd),
+            pid=os.getpid(),
+            mailbox_status="observed",
+            last_seen_at=datetime.utcnow(),
+        )
+    )
+    await db.commit()
+
+    assert len(await svc.nudgeable_sessions_for_slot(db, slot.id)) == 1
+
+    with patch("app.services.agent_mail_service.discover_agent_sessions", return_value=[]):
+        await svc.sync_observed_sessions(db)
+
+    kept = await svc.nudgeable_sessions_for_slot(db, slot.id)
+    assert len(kept) == 1
+    assert kept[0].team_slot_id == slot.id
+
+
+@pytest.mark.asyncio
+async def test_sync_observed_still_deletes_row_whose_pid_is_dead(db, svc, tmp_path):
+    """Retention becomes pid-aware, not pid-only. A dead pane still goes."""
+    cwd = tmp_path / "obs"
+    cwd.mkdir()
+    preset, slot = await _slot(db, str(cwd), "Owner")
+    member = await svc.get_or_create_slot_member(db, slot)
+    db.add(
+        MailAgentSession(
+            member_id=member.id,
+            team_preset_id=slot.preset_id,
+            team_slot_id=slot.id,
+            source="observed",
+            provider="codex-cli",
+            session_key="tmux:%2",
+            pane_id="%2",
+            tmux_target="obs:0.1",
+            cwd=str(cwd),
+            pid=None,
+            mailbox_status="observed",
+            last_seen_at=datetime.utcnow(),
+        )
+    )
+    await db.commit()
+
+    with patch("app.services.agent_mail_service.discover_agent_sessions", return_value=[]):
+        await svc.sync_observed_sessions(db)
+
+    assert await svc.nudgeable_sessions_for_slot(db, slot.id) == []
+
+
+@pytest.mark.asyncio
+async def test_sync_observed_deletes_row_whose_pid_is_gone(db, svc, tmp_path):
+    """A non-null pid that is not running must still be deleted."""
+    cwd = tmp_path / "obs"
+    cwd.mkdir()
+    preset, slot = await _slot(db, str(cwd), "Owner")
+    member = await svc.get_or_create_slot_member(db, slot)
+    db.add(
+        MailAgentSession(
+            member_id=member.id,
+            team_preset_id=slot.preset_id,
+            team_slot_id=slot.id,
+            source="observed",
+            provider="codex-cli",
+            session_key="tmux:%3",
+            pane_id="%3",
+            tmux_target="obs:0.2",
+            cwd=str(cwd),
+            pid=999999,
+            mailbox_status="observed",
+            last_seen_at=datetime.utcnow(),
+        )
+    )
+    await db.commit()
+
+    with patch(
+        "app.services.agent_mail_service.discover_agent_sessions", return_value=[]
+    ), patch.object(type(svc), "_pid_is_running", return_value=False):
+        await svc.sync_observed_sessions(db)
+
+    assert await svc.nudgeable_sessions_for_slot(db, slot.id) == []
+
+
+@pytest.mark.asyncio
 async def test_observed_session_attaches_to_matching_team_slot_participant(db, svc, tmp_path):
     cwd = tmp_path / "obs"
     cwd.mkdir()

--- a/backend/tests/agent_mail/test_registry.py
+++ b/backend/tests/agent_mail/test_registry.py
@@ -473,6 +473,173 @@ async def test_sync_observed_deletes_row_whose_pid_is_gone(db, svc, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_sync_observed_binds_slot_from_tmux_environment(db, svc, tmp_path):
+    """A rebuilt row recovers its slot from the pane's own tmux env."""
+    cwd = tmp_path / "obs"
+    cwd.mkdir()
+    preset, slot = await _slot(db, str(cwd), "Owner")
+    fake = [
+        {
+            "provider": "codex-cli",
+            "provider_display_name": "Codex",
+            "tmux_target": "obs:0.0",
+            "session_name": "obs",
+            "window_name": "main",
+            "pane_id": "%1",
+            "cwd": str(cwd),
+            "pid": "4242",
+            "status": "active",
+            "team_preset_id": preset.id,
+            "team_slot_id": slot.id,
+        }
+    ]
+    with patch("app.services.agent_mail_service.discover_agent_sessions", return_value=fake):
+        await svc.sync_observed_sessions(db)
+
+    session = (
+        await db.execute(
+            select(MailAgentSession).where(MailAgentSession.session_key == "tmux:%1")
+        )
+    ).scalar_one()
+    assert session.team_slot_id == slot.id
+    assert session.team_preset_id == preset.id
+    member = await db.get(MailTeamMember, session.member_id)
+    assert member.participant_kind == "team_slot"
+
+
+@pytest.mark.asyncio
+async def test_sync_observed_ignores_env_slot_from_another_repo(db, svc, tmp_path):
+    """An advertised slot whose repo does not match the pane's cwd is rejected."""
+    slot_cwd = tmp_path / "slotrepo"
+    slot_cwd.mkdir()
+    pane_cwd = tmp_path / "elsewhere"
+    pane_cwd.mkdir()
+    preset, slot = await _slot(db, str(slot_cwd), "Owner")
+    fake = [
+        {
+            "provider": "codex-cli",
+            "provider_display_name": "Codex",
+            "tmux_target": "obs:0.0",
+            "session_name": "obs",
+            "window_name": "main",
+            "pane_id": "%1",
+            "cwd": str(pane_cwd),
+            "pid": "4242",
+            "status": "active",
+            "team_preset_id": preset.id,
+            "team_slot_id": slot.id,
+        }
+    ]
+    with patch("app.services.agent_mail_service.discover_agent_sessions", return_value=fake):
+        await svc.sync_observed_sessions(db)
+
+    session = (
+        await db.execute(
+            select(MailAgentSession).where(MailAgentSession.session_key == "tmux:%1")
+        )
+    ).scalar_one()
+    assert session.team_slot_id is None
+    member = await db.get(MailTeamMember, session.member_id)
+    assert member.participant_kind == "repo"
+
+
+@pytest.mark.asyncio
+async def test_sync_observed_ignores_env_slot_that_no_longer_exists(db, svc, tmp_path):
+    """A stale tmux env naming a deleted slot falls back, it does not crash."""
+    cwd = tmp_path / "obs"
+    cwd.mkdir()
+    fake = [
+        {
+            "provider": "codex-cli",
+            "provider_display_name": "Codex",
+            "tmux_target": "obs:0.0",
+            "session_name": "obs",
+            "window_name": "main",
+            "pane_id": "%1",
+            "cwd": str(cwd),
+            "pid": "4242",
+            "status": "active",
+            "team_preset_id": 999,
+            "team_slot_id": 999,
+        }
+    ]
+    with patch("app.services.agent_mail_service.discover_agent_sessions", return_value=fake):
+        await svc.sync_observed_sessions(db)
+
+    session = (
+        await db.execute(
+            select(MailAgentSession).where(MailAgentSession.session_key == "tmux:%1")
+        )
+    ).scalar_one()
+    assert session.team_slot_id is None
+
+
+@pytest.mark.asyncio
+async def test_sync_observed_ignores_env_slot_with_a_different_provider(db, svc, tmp_path):
+    """A pane advertising a slot whose provider disagrees is rejected."""
+    cwd = tmp_path / "obs"
+    cwd.mkdir()
+    preset, slot = await _slot(db, str(cwd), "Owner")
+    assert slot.provider == "codex-cli"
+    fake = [
+        {
+            "provider": "claude-code",
+            "provider_display_name": "Claude Code",
+            "tmux_target": "obs:0.0",
+            "session_name": "obs",
+            "window_name": "main",
+            "pane_id": "%1",
+            "cwd": str(cwd),
+            "pid": "4242",
+            "status": "active",
+            "team_preset_id": preset.id,
+            "team_slot_id": slot.id,
+        }
+    ]
+    with patch("app.services.agent_mail_service.discover_agent_sessions", return_value=fake):
+        await svc.sync_observed_sessions(db)
+
+    session = (
+        await db.execute(
+            select(MailAgentSession).where(MailAgentSession.session_key == "tmux:%1")
+        )
+    ).scalar_one()
+    assert session.team_slot_id is None
+
+
+@pytest.mark.asyncio
+async def test_sync_observed_ignores_env_slot_whose_preset_disagrees(db, svc, tmp_path):
+    """A reused slot id with a contradictory preset id must not bind."""
+    cwd = tmp_path / "obs"
+    cwd.mkdir()
+    preset, slot = await _slot(db, str(cwd), "Owner")
+    fake = [
+        {
+            "provider": "codex-cli",
+            "provider_display_name": "Codex",
+            "tmux_target": "obs:0.0",
+            "session_name": "obs",
+            "window_name": "main",
+            "pane_id": "%1",
+            "cwd": str(cwd),
+            "pid": "4242",
+            "status": "active",
+            "team_preset_id": preset.id + 500,
+            "team_slot_id": slot.id,
+        }
+    ]
+    with patch("app.services.agent_mail_service.discover_agent_sessions", return_value=fake):
+        await svc.sync_observed_sessions(db)
+
+    session = (
+        await db.execute(
+            select(MailAgentSession).where(MailAgentSession.session_key == "tmux:%1")
+        )
+    ).scalar_one()
+    assert session.team_slot_id is None
+
+
+@pytest.mark.asyncio
 async def test_observed_session_attaches_to_matching_team_slot_participant(db, svc, tmp_path):
     cwd = tmp_path / "obs"
     cwd.mkdir()

--- a/backend/tests/agent_teams/test_github_dispatch_service.py
+++ b/backend/tests/agent_teams/test_github_dispatch_service.py
@@ -1,4 +1,5 @@
 """Dispatch routing + concurrency tests."""
+import os
 from datetime import datetime, timedelta
 from io import StringIO
 
@@ -1954,6 +1955,42 @@ async def test_ambiguous_check_holds_when_discovery_loses_known_session(db, monk
         )
     ).scalars().all()
     assert leased == []
+
+
+@pytest.mark.asyncio
+async def test_ambiguity_gate_is_stable_when_discovery_blips(db, monkeypatch):
+    """Two consecutive failed discoveries must not become permission to dispatch."""
+    preset, slots, scope = await _team(db)
+    slot = slots[0]
+    member = await agent_mail_service.get_or_create_slot_member(db, slot)
+    db.add(
+        MailAgentSession(
+            member_id=member.id,
+            team_preset_id=slot.preset_id,
+            team_slot_id=slot.id,
+            source="observed",
+            provider=slot.provider,
+            session_key="tmux:%1",
+            pane_id="%1",
+            tmux_target="live:0.0",
+            cwd=slot.repo_path,
+            pid=os.getpid(),
+            mailbox_status="observed",
+            last_seen_at=datetime.utcnow(),
+        )
+    )
+    await db.commit()
+
+    monkeypatch.setattr(
+        "app.services.agent_mail_service.discover_agent_sessions", lambda: []
+    )
+
+    first = await github_dispatch_service._session_ambiguity_note(db, slot.id)
+    second = await github_dispatch_service._session_ambiguity_note(db, slot.id)
+
+    assert len(await agent_mail_service.nudgeable_sessions_for_slot(db, slot.id)) == 1
+    assert first is None
+    assert second == first
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_teams/test_github_dispatch_service.py
+++ b/backend/tests/agent_teams/test_github_dispatch_service.py
@@ -1994,6 +1994,44 @@ async def test_ambiguity_gate_is_stable_when_discovery_blips(db, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_ambiguous_check_holds_when_discovery_raises(db, monkeypatch):
+    """strict=True converts a discovery exception into a hold, not a dispatch."""
+    preset, slots, scope = await _team(db)
+    owner = next(slot for slot in slots if slot.display_name == "Backend SME")
+    await _seed_observed_panes(db, preset, owner, [("%1", "w:0.1")])
+
+    def raises_like_a_failed_fork():
+        raise OSError(12, "Cannot allocate memory")
+
+    monkeypatch.setattr(
+        "app.services.agent_mail_service.discover_agent_sessions",
+        raises_like_a_failed_fork,
+    )
+    item = GithubWorkItem(
+        scope_id=scope.id,
+        issue_number=954,
+        issue_title="discovery exploded",
+        issue_url="u",
+        github_updated_at=datetime.utcnow(),
+        dispatch_status="pending",
+    )
+    db.add(item)
+    await db.commit()
+
+    await github_dispatch_service.dispatch_pending(
+        db,
+        scope,
+        slots,
+        launcher=_launcher_that_must_not_run,
+        issue_labels_by_number={954: ["area:backend"]},
+    )
+
+    await db.refresh(item)
+    assert item.pending_reason == "queued_ambiguous_sessions"
+    assert len(await agent_mail_service.nudgeable_sessions_for_slot(db, owner.id)) == 1
+
+
+@pytest.mark.asyncio
 async def test_ambiguous_check_allows_one_nudgeable_pane(db, monkeypatch):
     preset, slots, scope = await _team(db)
     owner = next(slot for slot in slots if slot.display_name == "Backend SME")

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -126,6 +126,38 @@ def test_opencode_process_detection_matches_binary_and_wrappers():
         assert provider.is_process_match("bun", "123") is True
 
 
+def test_argv0_name_tolerates_blank_commands():
+    from app.services.providers.base import argv0_name
+
+    assert argv0_name(" ") == ""
+    assert argv0_name("\t") == ""
+    assert argv0_name("") == ""
+    assert argv0_name("  codex  ") == "codex"
+
+
+def test_discovery_survives_a_blank_pane_command():
+    from app.services.agent_bridge.discovery import discover_agent_sessions
+
+    tmux_output = "\n".join(
+        [
+            "blank:0.0|blank|main|%1|/repo/a|111| ",
+            "codexproj:0.0|codexproj|main|%2|/repo/b|222|codex",
+        ]
+    )
+
+    def fake_run(args, **_kwargs):
+        if args[:2] == ["tmux", "list-panes"]:
+            return SimpleNamespace(returncode=0, stdout=tmux_output, stderr="")
+        return SimpleNamespace(returncode=1, stdout="", stderr="")
+
+    with patch(
+        "app.services.agent_bridge.discovery.subprocess.run", side_effect=fake_run
+    ):
+        sessions = discover_agent_sessions()
+
+    assert [session["pane_id"] for session in sessions] == ["%2"]
+
+
 def test_opencode_home_respects_xdg_config_home(monkeypatch, tmp_path):
     from app.services.providers.opencode_cli import get_opencode_home
 


### PR DESCRIPTION
## Summary

- Retain observed session rows when their recorded pane PID is still alive, while continuing to delete rows with absent or proven-dead PIDs.
- Recover rebuilt observed-session slot bindings from the pane's existing tmux environment, validating slot existence, provider, repository, and any advertised preset.
- Make blank pane commands non-fatal during provider matching while retaining the dispatch gate's `strict=True` fail-closed behavior.

Relates to #306 and fixes Finding 20 from the Phase G2 review.

## Validation

- Mandatory baseline: **147 passed**.
- Scoped dispatch/registry/discovery suite: **157 passed**.
- Provider suite: **11 passed**.
- Agent-team and Agent Mail suites: **454 passed**.
- Full backend suite: **622 passed, 1 known pre-existing failure**.
- Added **12 regression tests**.
- Mutation-checked the strict-path test: it fails when strict handling is temporarily removed and passes after exact restoration.

The only full-suite failure is the documented pre-existing `tests/test_multi_provider_smoke.py::test_agent_bridge_session_filter_smoke` stale-monkeypatch failure. It was not changed in this PR. All in-scope suites are green.

## Contracts

- `strict=True` is retained because provider initialization/process matching can raise outside discovery's internal `try`; swallowing that at cold start would dispatch on unknown state.
- `discover_agent_sessions` keeps its existing signature and returned dictionary shape.
- No new `dispatch_status` value was added.
- No frontend, schema, migration, live database, backend process, or tmux-session changes were made.

## Adaptations

- Reused `tests/test_providers.py`'s module-level `SimpleNamespace` and `patch` imports instead of re-importing them inside the new discovery test.
- Kept explanatory comments and docstrings shorter than the plan examples; behavior, assertions, and measured checkpoints are unchanged.
- Could not produce a zero-failure full-suite run because of the explicitly accepted pre-existing smoke-test failure above; no additional failures occurred.

## Deferred findings

- Same-preset SQLite slot-id reuse remains indistinguishable without an `AUTOINCREMENT` or spawn-time UUID schema change.
- Discovery still mixes `[]` failure results with propagated exceptions; changing that six-caller contract remains out of scope.
