### PR TITLE
fix(security): close final CodeQL findings

### DIFF
--- a/backend/app/api/v1/agent_teams.py
+++ b/backend/app/api/v1/agent_teams.py
@@ -90,6 +90,7 @@ logger = logging.getLogger(__name__)
 
 _WORKSPACE_CONFLICT_CODES = {
     "workspace_path_registered",
+    "workspace_path_outside_root",
     "workspace_not_a_worktree",
     "workspace_is_primary",
     "workspace_dirty",

--- a/backend/app/services/github_workspace_service.py
+++ b/backend/app/services/github_workspace_service.py
@@ -1044,11 +1044,23 @@ class GithubWorkspaceService:
 
         path = os.path.realpath(path)
         repo_path = os.path.realpath(scope.repo_path)
-        path_exists = os.path.exists(path)
         empty_directory = False
-        if path_exists and os.path.isdir(path):
-            with os.scandir(path) as entries:
-                empty_directory = next(entries, None) is None
+        if kind == "worktree":
+            workspace_root = os.path.dirname(repo_path)
+            workspace_name = os.path.basename(path)
+            bounded_path = os.path.join(workspace_root, workspace_name)
+            if not workspace_name or path != bounded_path:
+                raise GithubWorkspaceError(
+                    "A worktree path must be a direct sibling of the scope checkout",
+                    "workspace_path_outside_root",
+                )
+            path = bounded_path
+            path_exists = os.path.exists(path)
+            if path_exists and os.path.isdir(path):
+                with os.scandir(path) as entries:
+                    empty_directory = next(entries, None) is None
+        else:
+            path_exists = True
 
         if kind == "worktree" and path == repo_path:
             raise GithubWorkspaceError(

--- a/backend/mcp_shim/git_credential_helper.py
+++ b/backend/mcp_shim/git_credential_helper.py
@@ -66,6 +66,8 @@ def main(argv: list[str] | None = None) -> int:
         print("Claude Deck could not provide a GitHub credential", file=sys.stderr)
         return 1
     print(f"username={username}")
+    # Git's credential-helper protocol requires the password on stdout; this is not logging.
+    # lgtm[py/clear-text-logging-sensitive-data]
     print(f"password={password}")
     print()
     return 0

--- a/backend/tests/agent_teams/test_github_workspace_api.py
+++ b/backend/tests/agent_teams/test_github_workspace_api.py
@@ -1187,6 +1187,26 @@ async def test_create_workspace_rejects_invalid_kind(client, db, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_create_workspace_rejects_path_outside_scope_checkout_parent(
+    client, db, tmp_path, monkeypatch
+):
+    repo_path = tmp_path / "pool" / "repo"
+    repo_path.parent.mkdir()
+    _, scope = await _scope(db, repo_path)
+    runner = ApiGitRunner(repo_path)
+    monkeypatch.setattr(github_workspace_service, "_runner", runner)
+
+    response = await client.post(
+        f"/api/v1/agent-teams/github-scopes/{scope.id}/workspaces",
+        json={"path": str(tmp_path / "outside"), "kind": "worktree"},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["block_code"] == "workspace_path_outside_root"
+    assert runner.calls == []
+
+
+@pytest.mark.asyncio
 async def test_create_workspace_failure_persists_no_row(
     client, db, tmp_path, monkeypatch
 ):

--- a/backend/tests/agent_teams/test_github_workspace_service.py
+++ b/backend/tests/agent_teams/test_github_workspace_service.py
@@ -1477,6 +1477,27 @@ async def test_register_empty_directory_takes_provisioning_path(db, tmp_path):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("relative_candidate", ["../outside", "nested/ws"])
+async def test_register_rejects_worktree_outside_direct_sibling_root(
+    db, tmp_path, relative_candidate
+):
+    workspace_root = tmp_path / "pool"
+    repo_path = workspace_root / "repo"
+    repo_path.mkdir(parents=True)
+    scope, _, _ = await _context(db, repo_path)
+    runner = FakeGitRunner()
+    candidate = os.path.realpath(workspace_root / relative_candidate)
+
+    with pytest.raises(GithubWorkspaceError) as exc_info:
+        await GithubWorkspaceService(runner=runner).register_workspace(
+            db, scope, candidate, kind="worktree"
+        )
+
+    assert exc_info.value.block_code == "workspace_path_outside_root"
+    assert runner.calls == []
+
+
+@pytest.mark.asyncio
 async def test_register_adopts_existing_linked_worktree(db, tmp_path):
     repo_path = tmp_path / "repo"
     workspace_path = tmp_path / "ws"


### PR DESCRIPTION
## Summary
- restrict worktree registration and provisioning to canonical direct siblings of the scope checkout
- reject traversal, nested paths, symlink escapes, and arbitrary filesystem probes before Git or filesystem access
- preserve read-only primary identity probes without treating arbitrary primary paths as provision targets
- mark the required Git credential-helper password response as protocol output, not logging

## Findings addressed
- 3 `py/path-injection` alerts in workspace registration
- 1 `py/clear-text-logging-sensitive-data` false positive in the Git credential protocol

## Validation
- focused workspace API/service and credential-helper tests: 127 passed
- `git diff --check`: passed

This PR targets the integration branch so final delivery PR #316 can rerun CodeQL on the corrected tree.
