### PR TITLE
fix(security): make workspace boundary explicit to CodeQL

### DIFF
--- a/backend/app/services/github_workspace_service.py
+++ b/backend/app/services/github_workspace_service.py
@@ -1047,14 +1047,18 @@ class GithubWorkspaceService:
         empty_directory = False
         if kind == "worktree":
             workspace_root = os.path.dirname(repo_path)
-            workspace_name = os.path.basename(path)
-            bounded_path = os.path.join(workspace_root, workspace_name)
-            if not workspace_name or path != bounded_path:
+            workspace_prefix = f"{workspace_root}{os.sep}"
+            if not path.startswith(workspace_prefix):
                 raise GithubWorkspaceError(
                     "A worktree path must be a direct sibling of the scope checkout",
                     "workspace_path_outside_root",
                 )
-            path = bounded_path
+            workspace_name = path[len(workspace_prefix) :]
+            if not workspace_name or os.sep in workspace_name:
+                raise GithubWorkspaceError(
+                    "A worktree path must be a direct sibling of the scope checkout",
+                    "workspace_path_outside_root",
+                )
             path_exists = os.path.exists(path)
             if path_exists and os.path.isdir(path):
                 with os.scandir(path) as entries:

--- a/backend/mcp_shim/git_credential_helper.py
+++ b/backend/mcp_shim/git_credential_helper.py
@@ -67,7 +67,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     print(f"username={username}")
     # Git's credential-helper protocol requires the password on stdout; this is not logging.
-    # lgtm[py/clear-text-logging-sensitive-data]
+    # codeql[py/clear-text-logging-sensitive-data]
     print(f"password={password}")
     print()
     return 0


### PR DESCRIPTION
## Summary
- express the canonical workspace boundary using GitHub CodeQL's documented `realpath` + trusted-root prefix guard
- retain the direct-sibling requirement with a second single-component check
- use the current `# codeql[...]` suppression form for the required Git credential protocol response

## Validation
- focused workspace API/service and credential-helper tests: 127 passed
- runtime behavior is unchanged from #317

This follow-up exists because CodeQL did not recognize the equivalent path reconstruction or legacy `lgtm` suppression in #317.
