### PR TITLE
fix(mail): reject stale session capability tokens

### DIFF
--- a/backend/app/api/v1/agent_mail.py
+++ b/backend/app/api/v1/agent_mail.py
@@ -1,4 +1,5 @@
 """Agent Mail endpoints: team roster, messages, agent registration, hooks, install."""
+import hmac
 import logging
 import os
 from datetime import datetime
@@ -220,15 +221,39 @@ async def queue_inbox_check(member_id: int, db: AsyncSession = Depends(get_db)):
 async def register_agent(
     http_request: Request,
     request: MailAgentRegisterRequest,
+    x_deck_session_token: Optional[str] = Header(default=None),
     db: AsyncSession = Depends(get_db),
 ):
     existing = await agent_mail_service.peek_session_by_key(db, request.session_key)
     hashless_rebind = existing is not None and existing.capability_token_hash is None
     if hashless_rebind and settings.mail_capability_tokens_required:
         raise HTTPException(status_code=409, detail="token_required_for_rebind")
+    if (
+        existing is not None
+        and existing.capability_token_hash is not None
+        and settings.mail_capability_tokens_required
+    ):
+        if not x_deck_session_token:
+            raise HTTPException(status_code=409, detail="token_required_for_rebind")
+        presented_hash = agent_mail_service.hash_capability_token(x_deck_session_token)
+        if not hmac.compare_digest(existing.capability_token_hash, presented_hash):
+            raise HTTPException(status_code=401, detail="session_token_invalid")
 
     claims_team_context = request.team_preset_id is not None or request.team_slot_id is not None
     pane = resolve_request_pane(http_request)
+    if (
+        existing is not None
+        and existing.team_slot_id is not None
+        and settings.mail_capability_tokens_required
+        and (
+            pane is None
+            or existing.bound_pane_pid is None
+            or existing.bound_pane_proc_start is None
+            or pane.pane_pid != existing.bound_pane_pid
+            or pane.pane_proc_start != existing.bound_pane_proc_start
+        )
+    ):
+        raise HTTPException(status_code=401, detail="session_token_stale")
 
     binding = None
     if pane is None:

--- a/backend/app/api/v1/deps.py
+++ b/backend/app/api/v1/deps.py
@@ -40,6 +40,27 @@ def resolve_request_pane(
     """Compatibility projection used by Agent Mail registration."""
     return resolve_request_pane_detailed(http_request).pane
 
+
+def require_current_mail_session(session: MailAgentSession) -> None:
+    """Reject ended sessions and role-bearing sessions whose pane is stale."""
+    if not settings.mail_capability_tokens_required:
+        return
+    if session.mailbox_status == "offline":
+        raise HTTPException(status_code=401, detail="session_token_stale")
+    if session.team_slot_id is None:
+        return
+    if session.bound_pane_pid is None or session.bound_pane_proc_start is None:
+        raise HTTPException(status_code=401, detail="session_token_stale")
+    if (
+        peer_process.pane_is_alive(
+            session.bound_pane_pid,
+            session.bound_pane_proc_start,
+        )
+        is not True
+    ):
+        raise HTTPException(status_code=401, detail="session_token_stale")
+
+
 async def mail_session(
     x_deck_session_token: Optional[str] = Header(default=None),
     db: AsyncSession = Depends(get_db),
@@ -56,6 +77,7 @@ async def mail_session(
     )
     for session in result.scalars().all():
         if hmac.compare_digest(session.capability_token_hash, hashed):
+            require_current_mail_session(session)
             return session
     raise HTTPException(status_code=401, detail="session_token_invalid")
 

--- a/backend/tests/agent_mail/test_api.py
+++ b/backend/tests/agent_mail/test_api.py
@@ -19,6 +19,7 @@ from app.models.database import (
     TeamGithubScope,
 )
 from app.services.agent_mail_service import agent_mail_service
+from app.utils import peer_process
 
 
 @pytest_asyncio.fixture
@@ -31,6 +32,11 @@ async def client(db):
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
         yield c
     app.dependency_overrides.clear()
+
+
+@pytest.fixture(autouse=True)
+def live_slot_session_bindings(monkeypatch):
+    monkeypatch.setattr(peer_process, "pane_is_alive", lambda _pid, _start: True)
 
 
 async def _member(db, repo_id, name):
@@ -112,6 +118,8 @@ async def _dispatch_approval_fixture(db):
             mailbox_status="connected",
             last_seen_at=datetime.utcnow(),
             capability_token_hash=agent_mail_service.hash_capability_token(token),
+            bound_pane_pid=1000 + position,
+            bound_pane_proc_start=f"start-{position}",
         )
         db.add(session)
         slots.append(slot)
@@ -272,6 +280,46 @@ async def test_decision_route_requires_a_session_token(client, db, monkeypatch):
     )
 
     assert response.status_code == 401
+    assert (
+        await db.execute(select(MailMessage).where(MailMessage.decision.is_not(None)))
+    ).scalars().all() == []
+
+
+@pytest.mark.asyncio
+async def test_stale_leader_token_cannot_record_a_decision(client, db, monkeypatch):
+    monkeypatch.setattr(settings, "mail_capability_tokens_required", True)
+    item, members, tokens = await _dispatch_approval_fixture(db)
+    leader, owner = members
+    request = await client.post(
+        "/api/v1/agent-mail/messages",
+        headers={"X-Deck-Session-Token": tokens[1]},
+        json={
+            "kind": "context_request",
+            "sender_member_id": owner.id,
+            "recipient_member_id": leader.id,
+            "body_markdown": "plan",
+            "payload": {
+                "work_item_id": item.id,
+                "dispatch_nonce": item.dispatch_nonce,
+            },
+        },
+    )
+    assert request.status_code == 200
+    monkeypatch.setattr(peer_process, "pane_is_alive", lambda _pid, _start: False)
+
+    response = await client.post(
+        "/api/v1/agent-mail/decisions",
+        headers={"X-Deck-Session-Token": tokens[0]},
+        json={
+            "work_item_id": item.id,
+            "dispatch_nonce": item.dispatch_nonce,
+            "decision": "approved",
+            "reason": "stale approval",
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "session_token_stale"
     assert (
         await db.execute(select(MailMessage).where(MailMessage.decision.is_not(None)))
     ).scalars().all() == []

--- a/backend/tests/agent_mail/test_capability_tokens.py
+++ b/backend/tests/agent_mail/test_capability_tokens.py
@@ -23,6 +23,7 @@ from app.models.database import (
 )
 from app.models.schemas import MailAgentRegisterRequest
 from app.services.agent_mail_service import agent_mail_service
+from app.utils import peer_process
 from app.utils.peer_process import PeerPane
 from app.utils.repo_utils import derive_repo_identity
 
@@ -126,6 +127,38 @@ async def _member(db, repo_id, name):
     await db.commit()
     await db.refresh(member)
     return member
+
+
+async def _slot_session(db, slot, token, *, pane_pid=3000, pane_start="111"):
+    member = MailTeamMember(
+        identity_key=f"slot:liveness:{slot.id}:{token}",
+        repo_id=slot.repo_id,
+        repo_path=slot.repo_path,
+        repo_name=slot.repo_name,
+        display_name=slot.display_name,
+        participant_kind="team_slot",
+        team_preset_id=slot.preset_id,
+        team_slot_id=slot.id,
+    )
+    db.add(member)
+    await db.flush()
+    session = MailAgentSession(
+        member_id=member.id,
+        provider=slot.provider,
+        source="mcp",
+        session_key=f"mcp:liveness:{token}",
+        cwd=slot.repo_path,
+        team_preset_id=slot.preset_id,
+        team_slot_id=slot.id,
+        mailbox_status="connected",
+        last_seen_at=datetime.utcnow(),
+        capability_token_hash=agent_mail_service.hash_capability_token(token),
+        bound_pane_pid=pane_pid,
+        bound_pane_proc_start=pane_start,
+    )
+    db.add(session)
+    await db.commit()
+    return session
 
 
 def test_capability_token_settings_default_to_grace_mode():
@@ -276,7 +309,8 @@ async def test_two_sessions_get_different_tokens(db, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_register_route_returns_the_token_once(client, tmp_path):
+async def test_register_route_returns_the_token_once(client, tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "mail_capability_tokens_required", True)
     body = {
         "source": "mcp",
         "provider": "claude",
@@ -288,9 +322,94 @@ async def test_register_route_returns_the_token_once(client, tmp_path):
     token = first.json()["capability_token"]
     assert token
 
-    second = await client.post("/api/v1/agent-mail/agent/register", json=body)
+    second = await client.post(
+        "/api/v1/agent-mail/agent/register",
+        json=body,
+        headers={"X-Deck-Session-Token": token},
+    )
     assert second.status_code == 200
     assert second.json()["capability_token"] is None
+
+
+@pytest.mark.asyncio
+async def test_hashed_rebind_requires_the_existing_token_under_enforcement(
+    client, db, tmp_path, monkeypatch
+):
+    body = {
+        "source": "mcp",
+        "provider": "claude",
+        "cwd": str(tmp_path),
+        "session_key": "mcp:authenticated-rebind",
+    }
+    first = await client.post("/api/v1/agent-mail/agent/register", json=body)
+    assert first.status_code == 200
+    token = first.json()["capability_token"]
+    session_id = first.json()["session"]["id"]
+    before = await db.get(MailAgentSession, session_id)
+    before_values = (before.member_id, before.cwd, before.pid, before.capability_token_hash)
+    monkeypatch.setattr(settings, "mail_capability_tokens_required", True)
+
+    missing = await client.post("/api/v1/agent-mail/agent/register", json=body)
+    invalid = await client.post(
+        "/api/v1/agent-mail/agent/register",
+        json=body,
+        headers={"X-Deck-Session-Token": "wrong-token"},
+    )
+
+    assert missing.status_code == 409
+    assert missing.json()["detail"] == "token_required_for_rebind"
+    assert invalid.status_code == 401
+    assert invalid.json()["detail"] == "session_token_invalid"
+    db.expire_all()
+    after = await db.get(MailAgentSession, session_id)
+    assert (after.member_id, after.cwd, after.pid, after.capability_token_hash) == before_values
+    assert agent_mail_service.hash_capability_token(token) == after.capability_token_hash
+
+
+@pytest.mark.asyncio
+async def test_stale_slot_token_cannot_rebind_the_row_to_another_pane(
+    client, db, tmp_path, pane_resolver, slot, monkeypatch
+):
+    monkeypatch.setattr(settings, "mail_capability_tokens_required", True)
+    db.add(
+        AgentPaneBinding(
+            pane_pid=3000,
+            pane_proc_start="111",
+            slot_id=slot.id,
+            preset_id=slot.preset_id,
+        )
+    )
+    await db.commit()
+    pane_resolver(_pane())
+    body = _body(
+        slot.repo_path,
+        session_key="mcp:slot-rebind",
+        provider=slot.provider,
+        team_slot_id=slot.id,
+        team_preset_id=slot.preset_id,
+    )
+    first = await client.post("/api/v1/agent-mail/agent/register", json=body)
+    assert first.status_code == 200
+    token = first.json()["capability_token"]
+    session_id = first.json()["session"]["id"]
+    slot_id = slot.id
+
+    pane_resolver(_pane(pid=4000, start="222", target="other:0.1"))
+    replay = await client.post(
+        "/api/v1/agent-mail/agent/register",
+        json=body,
+        headers={"X-Deck-Session-Token": token},
+    )
+
+    assert replay.status_code == 401, replay.text
+    assert replay.json()["detail"] == "session_token_stale"
+    db.expire_all()
+    session = await db.get(MailAgentSession, session_id)
+    assert (session.team_slot_id, session.bound_pane_pid, session.bound_pane_proc_start) == (
+        slot_id,
+        3000,
+        "111",
+    )
 
 
 @pytest.mark.asyncio
@@ -574,6 +693,181 @@ async def test_no_pane_ancestor_mints_unbound(client, tmp_path, pane_resolver):
     response = await client.post("/api/v1/agent-mail/agent/register", json=_body(tmp_path))
     assert response.status_code == 200
     assert response.json()["capability_token"]
+
+
+@pytest.mark.asyncio
+async def test_live_slot_session_token_authenticates_under_enforcement(
+    client, db, slot, monkeypatch
+):
+    monkeypatch.setattr(settings, "mail_capability_tokens_required", True)
+    await _slot_session(db, slot, "live-slot-token")
+    observed = []
+    monkeypatch.setattr(
+        peer_process,
+        "pane_is_alive",
+        lambda pane_pid, pane_start: observed.append((pane_pid, pane_start)) or True,
+    )
+
+    response = await client.get(
+        "/api/v1/agent-mail/agent/inbox",
+        headers={"X-Deck-Session-Token": "live-slot-token"},
+    )
+
+    assert response.status_code == 200
+    assert observed == [(3000, "111")]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("proc_stat", "token"),
+    [
+        (None, "dead-slot-token"),
+        ((1, "NEW"), "reused-pid-token"),
+    ],
+)
+async def test_dead_or_reused_slot_session_token_is_stale(
+    client, db, slot, monkeypatch, proc_stat, token
+):
+    monkeypatch.setattr(settings, "mail_capability_tokens_required", True)
+    await _slot_session(db, slot, token)
+    monkeypatch.setattr(peer_process, "read_proc_stat", lambda _pid: proc_stat)
+
+    response = await client.get(
+        "/api/v1/agent-mail/agent/inbox",
+        headers={"X-Deck-Session-Token": token},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "session_token_stale"
+
+
+@pytest.mark.asyncio
+async def test_unobservable_slot_session_fails_closed(client, db, slot, monkeypatch):
+    monkeypatch.setattr(settings, "mail_capability_tokens_required", True)
+    await _slot_session(db, slot, "unobservable-slot-token")
+    monkeypatch.setattr(peer_process, "pane_is_alive", lambda _pid, _start: None)
+
+    response = await client.get(
+        "/api/v1/agent-mail/agent/inbox",
+        headers={"X-Deck-Session-Token": "unobservable-slot-token"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "session_token_stale"
+
+
+@pytest.mark.asyncio
+async def test_slot_session_without_a_complete_binding_is_stale(
+    client, db, slot, monkeypatch
+):
+    monkeypatch.setattr(settings, "mail_capability_tokens_required", True)
+    await _slot_session(
+        db,
+        slot,
+        "missing-binding-token",
+        pane_pid=None,
+        pane_start=None,
+    )
+    monkeypatch.setattr(
+        peer_process,
+        "pane_is_alive",
+        lambda *_args: pytest.fail("an incomplete binding must not reach /proc"),
+    )
+
+    response = await client.get(
+        "/api/v1/agent-mail/agent/inbox",
+        headers={"X-Deck-Session-Token": "missing-binding-token"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "session_token_stale"
+
+
+@pytest.mark.asyncio
+async def test_unbound_manual_session_remains_valid_under_enforcement(
+    client, db, monkeypatch
+):
+    monkeypatch.setattr(settings, "mail_capability_tokens_required", True)
+    member = await _member(db, "manual", "manual")
+    token = "manual-session-token"
+    db.add(
+        MailAgentSession(
+            member_id=member.id,
+            provider="codex-cli",
+            source="mcp",
+            session_key="mcp:manual",
+            cwd=member.repo_path,
+            mailbox_status="connected",
+            last_seen_at=datetime.utcnow(),
+            capability_token_hash=agent_mail_service.hash_capability_token(token),
+        )
+    )
+    await db.commit()
+    monkeypatch.setattr(
+        peer_process,
+        "pane_is_alive",
+        lambda *_args: pytest.fail("manual sessions have no role binding to validate"),
+    )
+
+    response = await client.get(
+        "/api/v1/agent-mail/agent/inbox",
+        headers={"X-Deck-Session-Token": token},
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_explicitly_offline_session_token_is_stale(client, db, monkeypatch):
+    monkeypatch.setattr(settings, "mail_capability_tokens_required", True)
+    member = await _member(db, "offline", "offline")
+    token = "offline-session-token"
+    db.add(
+        MailAgentSession(
+            member_id=member.id,
+            provider="codex-cli",
+            source="mcp",
+            session_key="mcp:offline",
+            cwd=member.repo_path,
+            mailbox_status="offline",
+            last_seen_at=datetime.utcnow(),
+            capability_token_hash=agent_mail_service.hash_capability_token(token),
+        )
+    )
+    await db.commit()
+    monkeypatch.setattr(
+        peer_process,
+        "pane_is_alive",
+        lambda *_args: pytest.fail("offline state must refuse before pane liveness"),
+    )
+
+    response = await client.get(
+        "/api/v1/agent-mail/agent/inbox",
+        headers={"X-Deck-Session-Token": token},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "session_token_stale"
+
+
+@pytest.mark.asyncio
+async def test_grace_mode_does_not_apply_slot_liveness_gate(
+    client, db, slot, monkeypatch
+):
+    monkeypatch.setattr(settings, "mail_capability_tokens_required", False)
+    await _slot_session(db, slot, "grace-slot-token")
+    monkeypatch.setattr(
+        peer_process,
+        "pane_is_alive",
+        lambda *_args: pytest.fail("grace mode must retain compatibility"),
+    )
+
+    response = await client.get(
+        "/api/v1/agent-mail/agent/inbox",
+        headers={"X-Deck-Session-Token": "grace-slot-token"},
+    )
+
+    assert response.status_code == 200
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_mail/test_dispatch_status_tool.py
+++ b/backend/tests/agent_mail/test_dispatch_status_tool.py
@@ -35,6 +35,7 @@ from app.services.github_workspace_service import (
     GithubWorkspaceCredentialRevokeError,
     github_workspace_service,
 )
+from app.utils import peer_process
 
 DEFAULT_TOKEN = "default-owner-token"
 
@@ -42,6 +43,11 @@ DEFAULT_TOKEN = "default-owner-token"
 @pytest.fixture(autouse=True)
 def require_capabilities(monkeypatch):
     monkeypatch.setattr(settings, "mail_capability_tokens_required", True)
+
+
+@pytest.fixture(autouse=True)
+def live_slot_session_bindings(monkeypatch):
+    monkeypatch.setattr(peer_process, "pane_is_alive", lambda _pid, _start: True)
 
 
 @pytest.fixture(autouse=True)
@@ -410,6 +416,27 @@ async def test_triaging_does_not_increment_approval_rounds(client_and_db):
         assert item.dispatch_status == "dispatched"
         assert item.approval_round_count == 1
         assert item.escalation_reason is None
+
+
+@pytest.mark.asyncio
+async def test_stale_owner_token_cannot_update_dispatch_status(
+    client_and_db, monkeypatch
+):
+    ac, maker = client_and_db
+    item_id = await _seed_item(maker, status_note="original")
+    monkeypatch.setattr(peer_process, "pane_is_alive", lambda _pid, _start: False)
+
+    response = await ac.post(
+        "/api/v1/agent-teams/dispatch-status",
+        json={"work_item_id": item_id, "status": "triaging", "note": "stale write"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "session_token_stale"
+    async with maker() as db:
+        item = await db.get(GithubWorkItem, item_id)
+        assert item.dispatch_status == "dispatched"
+        assert item.status_note == "original"
 
 
 @pytest.mark.asyncio

--- a/docs/deploy/pr0-capability-tokens-rollout.md
+++ b/docs/deploy/pr0-capability-tokens-rollout.md
@@ -103,6 +103,11 @@ Restart the backend again. From this point:
 - A mail write with no credential is `401 session_token_required`.
 - A write with a token matching no session is `401 session_token_invalid` — an
   invalid token is never treated as an absent one.
+- A token for an explicitly offline session, or for a slot-bound session whose
+  recorded pane is gone, reused, or unobservable, is `401 session_token_stale`.
+  Start a fresh agent session; do not copy the old bearer token into a new pane.
+- Re-registering an existing hashed session row requires that row's current
+  token. A slot-bound row can only re-register from its original live pane.
 - Agent registration on a host where the pane cannot be derived from the kernel
   refuses with `bind_unverifiable`. On Linux this means the peer process is
   gone; on macOS it means always, which is why the README lists Linux as a

--- a/docs/superpowers/specs/2026-07-06-tizonia-roadmap-v1-soak-run-log.md
+++ b/docs/superpowers/specs/2026-07-06-tizonia-roadmap-v1-soak-run-log.md
@@ -990,4 +990,5 @@ tests/agent_mail + tests/agent_teams                              789 passed
 
 This entry records implementation evidence only. The live backend still runs the pre-fix
 code, enforcement is still off, and G1 step 4 remains blocked until the fix PR is merged,
-the backend is restarted, and a real stale-token probe returns `401 session_token_stale`.
+the flag is enabled, and the restarted backend returns `401 session_token_stale` for a
+real stale-token probe as its first post-restart gate.

--- a/docs/superpowers/specs/2026-07-06-tizonia-roadmap-v1-soak-run-log.md
+++ b/docs/superpowers/specs/2026-07-06-tizonia-roadmap-v1-soak-run-log.md
@@ -958,3 +958,36 @@ liveness revocation.
 `mail_capability_tokens_required` is absent from `.env`, so enforcement remains at its
 default `false`. Stop for operator disposition of the retained-token behavior before
 flipping enforcement.
+
+### 2026-08-16 — focused retained-token remediation implemented, not deployed
+
+The retained-token behavior is confirmed as a blocker for enforcement. The focused fix
+keeps the existing bearer-token design and adds validity checks at the shared
+`mail_session` dependency:
+
+- an explicitly `offline` session is `401 session_token_stale`;
+- a slot-bound session must still have a complete `(bound_pane_pid,
+  bound_pane_proc_start)` pair and that exact process must be alive;
+- a connected, unbound manual session remains valid, preserving the non-team workflow;
+- grace mode remains unchanged.
+
+Registration is also part of the boundary. Under enforcement, re-registering an existing
+hashed row now requires its current capability token. A slot-bound row can only re-register
+from the same live pane identity; a copied token cannot move the durable row to another
+pane. Fresh shim processes continue to use fresh random session keys and mint their own
+tokens.
+
+Regression coverage includes dead panes, PID reuse, unobservable and incomplete bindings,
+explicitly offline sessions, authenticated re-registration, stale-pane rebind attempts,
+and no-write assertions on both leader decisions and `/dispatch-status`. Validation on the
+fix branch:
+
+```text
+tests/agent_mail/test_capability_tokens.py                         43 passed
+tests/agent_mail/test_api.py + test_dispatch_status_tool.py       85 passed
+tests/agent_mail + tests/agent_teams                              789 passed
+```
+
+This entry records implementation evidence only. The live backend still runs the pre-fix
+code, enforcement is still off, and G1 step 4 remains blocked until the fix PR is merged,
+the backend is restarted, and a real stale-token probe returns `401 session_token_stale`.


### PR DESCRIPTION
## Summary
- reject capability tokens for explicitly offline sessions
- require slot-bound tokens to retain a live PID/start-time pane binding
- authenticate and pane-bind re-registration of existing session rows
- preserve grace mode and connected unbound manual sessions

## Security coverage
- dead pane and PID-reuse rejection
- fail-closed unobservable/incomplete bindings
- stale token cannot move a slot session to another pane
- stale leader/owner tokens cannot write approvals or dispatch state

## Validation
- `43 passed` — `tests/agent_mail/test_capability_tokens.py`
- `85 passed` — `tests/agent_mail/test_api.py tests/agent_mail/test_dispatch_status_tool.py`
- `789 passed` — `tests/agent_mail tests/agent_teams`

## Soak status
G1 step 4 remains blocked. The live backend still runs pre-fix code with capability-token enforcement off. After merge, enable enforcement and restart the backend; the first post-restart gate is verifying that a real stale token receives `401 session_token_stale`.
