### PR TITLE
fix: prevent cross-slot session reuse

### DIFF
--- a/backend/app/services/agent_team_service.py
+++ b/backend/app/services/agent_team_service.py
@@ -420,16 +420,22 @@ class AgentTeamService:
     ) -> AgentTeamLaunchPlan:
         request = request or AgentTeamLaunchRequest()
         preset = await self._require_preset(db, preset_id)
-        slots = await self._selected_slots(
-            db,
-            preset_id,
+        preset_slots = await self._slots_for_preset(db, preset_id)
+        slots = self._select_slots(
+            preset_slots,
             request.slot_ids,
             include_disabled=request.include_disabled,
         )
         await agent_mail_service.sync_observed_sessions(db)
         discovered = self._discover_sessions()
         install_status = await agent_mail_install_service.get_install_status()
-        reuse_group_counts = self._reuse_group_counts(slots)
+        reuse_group_counts = self._reuse_group_counts(preset_slots)
+        attached_sessions = (
+            await db.execute(
+                select(MailAgentSession).where(MailAgentSession.team_slot_id.is_not(None))
+            )
+        ).scalars().all()
+        pane_bindings = (await db.execute(select(AgentPaneBinding))).scalars().all()
         unsafe_resume_last_slot_ids = self._unsafe_resume_last_slot_ids(slots)
 
         items: list[AgentTeamLaunchPlanItem] = []
@@ -442,6 +448,8 @@ class AgentTeamService:
                     discovered,
                     used_matching_sessions,
                     requires_disambiguation=reuse_group_counts.get((slot.provider, slot.repo_id), 0) > 1,
+                    attached_sessions=attached_sessions,
+                    pane_bindings=pane_bindings,
                 )
                 if request.reuse_existing and slot.enabled
                 else None
@@ -945,16 +953,28 @@ class AgentTeamService:
         used_matching_sessions: set[str],
         *,
         requires_disambiguation: bool,
+        attached_sessions: list[MailAgentSession],
+        pane_bindings: list[AgentPaneBinding],
     ) -> dict[str, Any] | None:
-        attached = await self._matching_attached_session(db, slot, discovered, used_matching_sessions)
+        eligible = [
+            session
+            for session in discovered
+            if not self._session_owned_by_other_slot(
+                session,
+                slot,
+                attached_sessions,
+                pane_bindings,
+            )
+        ]
+        attached = await self._matching_attached_session(db, slot, eligible, used_matching_sessions)
         if attached is not None:
             return attached
-        named = self._matching_named_session(slot, discovered, used_matching_sessions)
+        named = self._matching_named_session(slot, eligible, used_matching_sessions)
         if named is not None:
             return named
         if requires_disambiguation:
             return None
-        for session in discovered:
+        for session in eligible:
             match_key = self._matching_session_key(session)
             if match_key in used_matching_sessions:
                 continue
@@ -962,6 +982,33 @@ class AgentTeamService:
                 used_matching_sessions.add(match_key)
                 return self._matching_session_payload(session)
         return None
+
+    def _session_owned_by_other_slot(
+        self,
+        session: dict[str, Any],
+        slot: AgentTeamSlot,
+        attached_sessions: list[MailAgentSession],
+        pane_bindings: list[AgentPaneBinding],
+    ) -> bool:
+        for attached in attached_sessions:
+            if not self._discovered_session_matches_registered(session, attached):
+                continue
+            if attached.team_slot_id != slot.id or attached.team_preset_id != slot.preset_id:
+                return True
+
+        try:
+            pane_pid = int(str(session.get("pid")))
+        except (TypeError, ValueError):
+            return False
+        stat = read_proc_stat(pane_pid)
+        if stat is None:
+            return False
+        _parent_pid, proc_start = stat
+        for binding in pane_bindings:
+            if binding.pane_pid != pane_pid or binding.pane_proc_start != proc_start:
+                continue
+            return binding.slot_id != slot.id or binding.preset_id != slot.preset_id
+        return False
 
     async def _matching_attached_session(
         self,
@@ -1304,6 +1351,15 @@ class AgentTeamService:
         include_disabled: bool = False,
     ) -> list[AgentTeamSlot]:
         slots = await self._slots_for_preset(db, preset_id)
+        return self._select_slots(slots, slot_ids, include_disabled=include_disabled)
+
+    def _select_slots(
+        self,
+        slots: list[AgentTeamSlot],
+        slot_ids: list[int] | None,
+        *,
+        include_disabled: bool = False,
+    ) -> list[AgentTeamSlot]:
         if slot_ids is None:
             return slots if include_disabled else [slot for slot in slots if slot.enabled]
         requested = set(slot_ids)

--- a/backend/tests/agent_teams/test_agent_team_service.py
+++ b/backend/tests/agent_teams/test_agent_team_service.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 import pytest
 from sqlalchemy import select
 
-from app.models.database import AgentTeamSlot, MailAgentSession, MailTeamMember
+from app.models.database import AgentPaneBinding, AgentTeamSlot, MailAgentSession, MailTeamMember
 from app.models.schemas import (
     AgentTeamCreateFromMailRequest,
     AgentTeamCreateFromBridgeRequest,
@@ -814,6 +814,175 @@ async def test_plan_launch_does_not_reuse_ambiguous_same_repo_sessions(db, tmp_p
     plan = await agent_team_service.plan_launch(db, preset.id)
 
     assert [item.action for item in plan.items] == ["spawn", "spawn"]
+
+
+@pytest.mark.asyncio
+async def test_partial_plan_does_not_reuse_a_same_repo_sibling_session(db, tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    preset = await agent_team_service.create_preset(
+        db,
+        AgentTeamPresetCreate(
+            name="Dispatch team",
+            slots=[
+                AgentTeamSlotCreate(
+                    display_name="Generalist",
+                    provider="codex-cli",
+                    repo_path=str(repo),
+                ),
+                AgentTeamSlotCreate(
+                    display_name="Specialist",
+                    provider="codex-cli",
+                    repo_path=str(repo),
+                ),
+            ],
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.agent_team_service.discover_agent_sessions",
+        lambda: [
+            {
+                "provider": "codex-cli",
+                "session_name": "generalist",
+                "tmux_target": "generalist:0.0",
+                "pane_id": "%1",
+                "cwd": str(repo),
+            }
+        ],
+    )
+
+    plan = await agent_team_service.plan_launch(
+        db,
+        preset.id,
+        AgentTeamLaunchRequest(slot_ids=[preset.slots[1].id]),
+    )
+
+    assert [item.slot_name for item in plan.items] == ["Specialist"]
+    assert plan.items[0].action == "spawn"
+
+
+@pytest.mark.asyncio
+async def test_partial_plan_reuses_the_selected_slots_attached_session(db, tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    preset = await agent_team_service.create_preset(
+        db,
+        AgentTeamPresetCreate(
+            name="Dispatch team",
+            slots=[
+                AgentTeamSlotCreate(
+                    display_name="Generalist",
+                    provider="codex-cli",
+                    repo_path=str(repo),
+                ),
+                AgentTeamSlotCreate(
+                    display_name="Specialist",
+                    provider="codex-cli",
+                    repo_path=str(repo),
+                ),
+            ],
+        ),
+    )
+    generalist_slot = await db.get(AgentTeamSlot, preset.slots[0].id)
+    generalist_member = await agent_mail_service.get_or_create_slot_member(db, generalist_slot)
+    db.add(
+        MailAgentSession(
+            member_id=generalist_member.id,
+            source="observed",
+            provider="codex-cli",
+            session_key="tmux:%1",
+            tmux_target="generalist:0.0",
+            pane_id="%1",
+            cwd=str(repo),
+            team_preset_id=preset.id,
+            team_slot_id=generalist_slot.id,
+            mailbox_status="observed",
+        )
+    )
+    await db.commit()
+    monkeypatch.setattr(
+        "app.services.agent_team_service.discover_agent_sessions",
+        lambda: [
+            {
+                "provider": "codex-cli",
+                "session_name": "generalist",
+                "tmux_target": "generalist:0.0",
+                "pane_id": "%1",
+                "cwd": str(repo),
+            }
+        ],
+    )
+
+    plan = await agent_team_service.plan_launch(
+        db,
+        preset.id,
+        AgentTeamLaunchRequest(slot_ids=[preset.slots[0].id]),
+    )
+
+    assert plan.items[0].action == "reuse"
+    assert plan.items[0].matching_session["tmux_target"] == "generalist:0.0"
+
+
+@pytest.mark.asyncio
+async def test_plan_does_not_reuse_a_pane_bound_to_another_preset(db, tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = await agent_team_service.create_preset(
+        db,
+        AgentTeamPresetCreate(
+            name="Target team",
+            slots=[
+                AgentTeamSlotCreate(
+                    display_name="Target",
+                    provider="codex-cli",
+                    repo_path=str(repo),
+                )
+            ],
+        ),
+    )
+    owner = await agent_team_service.create_preset(
+        db,
+        AgentTeamPresetCreate(
+            name="Owner team",
+            slots=[
+                AgentTeamSlotCreate(
+                    display_name="Owner",
+                    provider="codex-cli",
+                    repo_path=str(repo),
+                )
+            ],
+        ),
+    )
+    db.add(
+        AgentPaneBinding(
+            pane_pid=4242,
+            pane_proc_start="120913170",
+            slot_id=owner.slots[0].id,
+            preset_id=owner.id,
+            tmux_target="repo:0.0",
+        )
+    )
+    await db.commit()
+    monkeypatch.setattr(
+        "app.services.agent_team_service.discover_agent_sessions",
+        lambda: [
+            {
+                "provider": "codex-cli",
+                "session_name": "repo",
+                "tmux_target": "repo:0.0",
+                "pid": "4242",
+                "cwd": str(repo),
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        "app.services.agent_team_service.read_proc_stat",
+        lambda pid: (1, "120913170"),
+    )
+
+    plan = await agent_team_service.plan_launch(db, target.id)
+
+    assert plan.items[0].action == "spawn"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- compute reuse ambiguity from every enabled slot in the preset, even when a launch selects one slot
- exclude discovered sessions durably attached or pane-bound to another slot or preset
- preserve exact same-slot attachment reuse and generic reuse for true single-slot teams

## Soak blocker
G3 selected only the empty Specialist slot, but the launch plan proposed reusing the live Generalist pane. Autonomous dispatch uses this same one-slot plan shape, so proceeding could have stolen the Generalist session.

## Validation
- `venv/bin/pytest -q tests/agent_teams/test_agent_team_service.py` — 47 passed
- `mail_capability_tokens_required=false venv/bin/pytest -q tests/agent_teams tests/agent_mail` — 792 passed

The first broad run inherited the live soak setting from `backend/.env` and produced five expected grace-mode failures; the test-baseline override above passed without changing the running backend.
